### PR TITLE
Working ESP32 pin config

### DIFF
--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -331,23 +331,6 @@
 //                                  ////////
 ////////////////////////////////////////////
 
-// Stepper drivers
-#if (RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
-  #if defined(ESP32)
-    #define RA_SERIAL_PORT Serial2    // Can be shared with DEC_SERIAL_PORT
-  #elif defined(__AVR_ATmega2560__)
-    // Uses SoftwareSerial
-  #endif
-#endif
-
-#if (DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
-  #if defined(ESP32)
-    #define DEC_SERIAL_PORT Serial2   // Can be shared with RA_SERIAL_PORT
-  #elif defined(__AVR_ATmega2560__)
-    // Uses SoftwareSerial
-  #endif
-#endif
-
 // GPS
 #if USE_GPS == 1
   #if defined(ESP32)

--- a/Configuration_local_CI.hpp
+++ b/Configuration_local_CI.hpp
@@ -78,7 +78,7 @@
         #define RA_SERIAL_PORT_TX (-1)  
         #define RA_SERIAL_PORT_RX  (-1)  
     #elif defined(ESP32)
-        #define RA_SERIAL_PORT (-1)
+        #define RA_SERIAL_PORT (Serial2)
     #endif
     // Additional configuration
     #define RA_DRIVER_ADDRESS (0)
@@ -113,7 +113,7 @@
         #define DEC_SERIAL_PORT_TX (-1)  
         #define DEC_SERIAL_PORT_RX  (-1)  
     #elif defined(ESP32)
-        #define DEC_SERIAL_PORT (-1)
+        #define DEC_SERIAL_PORT (Serial2)
     #endif
     // Additional configuration
     #define DEC_DRIVER_ADDRESS (0)

--- a/Configuration_local_CI.hpp
+++ b/Configuration_local_CI.hpp
@@ -77,6 +77,8 @@
         // Additional SoftSerial pins required
         #define RA_SERIAL_PORT_TX (-1)  
         #define RA_SERIAL_PORT_RX  (-1)  
+    #elif defined(ESP32)
+        #define RA_SERIAL_PORT (-1)
     #endif
     // Additional configuration
     #define RA_DRIVER_ADDRESS (0)
@@ -110,6 +112,8 @@
         // Additional SoftSerial pins required
         #define DEC_SERIAL_PORT_TX (-1)  
         #define DEC_SERIAL_PORT_RX  (-1)  
+    #elif defined(ESP32)
+        #define DEC_SERIAL_PORT (-1)
     #endif
     // Additional configuration
     #define DEC_DRIVER_ADDRESS (0)

--- a/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
+++ b/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
@@ -53,22 +53,18 @@
 #ifndef RA_MS2_PIN
   #define RA_MS2_PIN  2
 #endif    
-// DRIVER_TYPE_TMC2209_UART requires 2 additional digital pins for SoftwareSerial, can be shared across all drivers
-#ifndef RA_SERIAL_PORT_TX
-  #define RA_SERIAL_PORT_TX 27 // SoftwareSerial TX port
-#endif
-#ifndef RA_SERIAL_PORT_RX
-  #define RA_SERIAL_PORT_RX 25 // SoftwareSerial RX port
+#ifndef RA_SERIAL_PORT
+  #define RA_SERIAL_PORT Serial2  // only TX2 required
 #endif
 #ifndef RA_DRIVER_ADDRESS
   #define RA_DRIVER_ADDRESS 0b00  // Set by MS1/MS2. LOW/LOW in this case
 #endif
 // DRIVER_TYPE_TMC2209_UART requires 4 digital pins in Arduino pin numbering
 #ifndef DEC_STEP_PIN
-  #define DEC_STEP_PIN 16  // STEP
+  #define DEC_STEP_PIN 26  // STEP
 #endif
 #ifndef DEC_DIR_PIN
-  #define DEC_DIR_PIN  17  // DIR
+  #define DEC_DIR_PIN  27  // DIR
 #endif
 #ifndef DEC_EN_PIN
   #define DEC_EN_PIN   5  // Enable
@@ -85,12 +81,8 @@
 #ifndef DEC_MS2_PIN
   #define DEC_MS2_PIN  7
 #endif
-// DRIVER_TYPE_TMC2209_UART requires 2 additional digital pins for SoftwareSerial, can be shared across all drivers
-#ifndef DEC_SERIAL_PORT_TX
-  #define DEC_SERIAL_PORT_TX 27 // SoftwareSerial TX port
-#endif
-#ifndef DEC_SERIAL_PORT_RX
-  #define DEC_SERIAL_PORT_RX 25 // SoftwareSerial RX port
+#ifndef DEC_SERIAL_PORT
+  #define DEC_SERIAL_PORT Serial2 // only TX2 required
 #endif
 #ifndef DEC_DRIVER_ADDRESS
   #define DEC_DRIVER_ADDRESS 0b01  // Set by MS1/MS2 (MS1 HIGH, MS2 LOW)

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -107,7 +107,7 @@ void WifiControl::loop()
             _udp = new WiFiUDP();
             _udp->begin(4031);
 
-            LOGV4(DEBUG_WIFI,F("Wifi: Connecting to SSID %s at %s:%d"), INFRA_SSID, WiFi.localIP().toString().c_str(), WIFI_PORT);
+            LOGV4(DEBUG_WIFI,F("Wifi: Connecting to SSID %s at %s:%d"), WIFI_INFRASTRUCTURE_MODE_SSID, WiFi.localIP().toString().c_str(), WIFI_PORT);
         }
     }
 


### PR DESCRIPTION
Preliminary working config for ESP32. Serial2 by default is 16/17 so I moved DEC S/D to 26/27. 

I cannot seem to get SoftwareSerial to compile on ESP32. It doesn't seem like it affects anything because the behaviour of ESP32 serial and Arduino SoftwareSerial is the same anyway once it's opened? The ESP32 pins don't get loaded for Mega so there's no need for the extra ifdefs in Config_adv. Apparently with HardwareSerial you can use any pin for serial TX/RX anyway so shouldn't be too hard to add GPS on Serial1.