### PR TITLE
Minor fixes for esp32 configurations

### DIFF
--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -47,9 +47,10 @@
  * Use default values for any parameters the user didn't provide.
  */
 
-// If board is not defined in local configuration, assume Arduino Mega2560
+// If board is not defined in local configuration, assume BOARD_UNKNOWN
+// Configuration checks below will capture any missing pin assignments.
 #ifndef BOARD
-  #define BOARD BOARD_AVR_MEGA2560
+  #define BOARD BOARD_UNKNOWN
 #endif
 
 // Set to 1 for the northern hemisphere, 0 otherwise
@@ -252,7 +253,9 @@
 #include "Configuration_adv.hpp"
 
 // Append board specific pins data.
-#if (BOARD == BOARD_AVR_MEGA2560)
+#if (BOARD == BOARD_UNKNOWN)
+  // Assume custom user board - no predefined pin mapping
+#elif (BOARD == BOARD_AVR_MEGA2560)
   #include "boards/AVR_MEGA2560/pins_MEGA2560.hpp"
 #elif (BOARD == BOARD_ESP32_ESP32DEV)
   #include "boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp"

--- a/Constants.hpp
+++ b/Constants.hpp
@@ -8,7 +8,11 @@
 
 /**
  * Supported boards. The name consists of the platform and the board name (model).
+ * Applies predefined pin mappings for common boards.
+ * If BOARD_UNKNOWN is used then user is responsible for specifying complete mapping in Configuration_local.hpp
  **/
+#define BOARD_UNKNOWN            0000
+
 // AVR based boards
 #define BOARD_AVR_MEGA2560       0001
 #define BOARD_AVR_MKS_GEN_L_V21  0002
@@ -54,9 +58,6 @@
 // USB serial port speed according to external controller
 #define SERIAL_BAUDRATE_STELLARIUM_DIRECT   9600
 #define SERIAL_BAUDRATE_ASCOM               57600
-
-#define DISABLED 0
-#define ENABLED  1
 
 // Wifi operating modes (ESP32 only)
 #define WIFI_MODE_INFRASTRUCTURE                        0   // Infrastructure Only - OAT connects to an existing Router

--- a/boards/AVR_MEGA2560/pins_MEGA2560.hpp
+++ b/boards/AVR_MEGA2560/pins_MEGA2560.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Constants.hpp"
-
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  22

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Constants.hpp"
-
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  63

--- a/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
+++ b/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Constants.hpp"
-
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  13  


### PR DESCRIPTION
Minor fixes against the esp32 build:

- Removed #define DISABLED & ENABLED in Constants.hpp due to clash with existing symbols in esp32 IDF. DISABLED & ENABLED don't appear anywhere else in the OAT codebase.
- Removed unnecessary #include "Constants.hpp" in .\boards\* . Constants is already included in the parent Configuration.hpp.
- In Configuration.hpp default BOARD to new BOARD_UNKNOWN value and extend conditional tree at line 253. This is to prevent potential misconfigured hardware in case BOARD_TYPE is undefined: for an esp32 build, if BOARD_TYPE is undefined then Configuration.hpp would apply pin assignments for BOARD_AVR_MEGA2560. Mismatches were possible with other configurations also. With this change no pin assignments are made, however the configuration checks later in Configuration.hpp will provide a suitable message. @CTetford - you may want to review this.