### PR TITLE
Enforce stricter warnings to build, fix warnings

### DIFF
--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -119,10 +119,10 @@
 
 // Set these factors to correct Alt/Az arcsecond/step values
 #ifndef AZ_CORRECTION_FACTOR
-#define AZ_CORRECTION_FACTOR    1.0000
+#define AZ_CORRECTION_FACTOR    1.0000f
 #endif
 #ifndef ALT_CORRECTION_FACTOR
-#define ALT_CORRECTION_FACTOR    1.0000
+#define ALT_CORRECTION_FACTOR    1.0000f
 #endif
 
 /**

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -131,19 +131,19 @@
 // 
 
 // the pitch of the GT2 timing belt
-#define GT2_BELT_PITCH  2.0 // mm
+#define GT2_BELT_PITCH  2.0f // mm
 
 // the Circumference of the RA wheel.  V1 = 1057.1  |  V2 = 1131.0
 #if RA_WHEEL_VERSION == 1
-  #define RA_WHEEL_CIRCUMFERENCE 1057.1
+  #define RA_WHEEL_CIRCUMFERENCE 1057.1f
 #elif RA_WHEEL_VERSION >= 2
-  #define RA_WHEEL_CIRCUMFERENCE 1132.73
+  #define RA_WHEEL_CIRCUMFERENCE 1132.73f
 #else
   #error Unsupported RA wheel version, please recheck RA_WHEEL_VERSION
 #endif
 
 // the Circumference of the DEC wheel.
-#define DEC_WHEEL_CIRCUMFERENCE 565.5
+#define DEC_WHEEL_CIRCUMFERENCE 565.5f
 
 // RA movement:
 // The radius of the surface that the belt runs on (in V1 of the ring) was 168.24mm.
@@ -155,7 +155,7 @@
 // Theoretically correct RA tracking speed is 1.246586 (300 x 14.95903 / 3600) (V2 : 1.333800 (322 x 14.95903 / 3600) steps/sec (this is for 20T)
 // Include microstepping ratio here such that steps/sec is updates/sec to stepper driver
 #ifndef RA_STEPS_PER_DEGREE
-  #define RA_STEPS_PER_DEGREE   (RA_WHEEL_CIRCUMFERENCE / (RA_PULLEY_TEETH * GT2_BELT_PITCH) * RA_STEPPER_SPR * RA_SLEW_MICROSTEPPING / 360.0)
+  #define RA_STEPS_PER_DEGREE   (RA_WHEEL_CIRCUMFERENCE / (RA_PULLEY_TEETH * GT2_BELT_PITCH) * RA_STEPPER_SPR * RA_SLEW_MICROSTEPPING / 360.0f)
 #endif
 
 // DEC movement:
@@ -166,7 +166,7 @@
 // So there are 160.85 steps/degree (57907/360) (this is for 20T)
 // Include microstepping ratio here such that steps/sec is updates/sec to stepper driver
 #ifndef DEC_STEPS_PER_DEGREE
-  #define DEC_STEPS_PER_DEGREE  (DEC_WHEEL_CIRCUMFERENCE / (DEC_PULLEY_TEETH * GT2_BELT_PITCH) * DEC_STEPPER_SPR * DEC_SLEW_MICROSTEPPING / 360.0)
+  #define DEC_STEPS_PER_DEGREE  (DEC_WHEEL_CIRCUMFERENCE / (DEC_PULLEY_TEETH * GT2_BELT_PITCH) * DEC_STEPPER_SPR * DEC_SLEW_MICROSTEPPING / 360.0f)
 #endif
 
 ////////////////////////////
@@ -176,17 +176,17 @@
 // Note that the North & South (DEC) tracking speed is calculated as the +multiplier & -multiplier
 // Note that the West & East (RA) tracking speed is calculated as the (multiplier+1.0) & (multiplier-1.0)
 #if RA_STEPPER_TYPE == STEPPER_TYPE_28BYJ48
-  #define RA_PULSE_MULTIPLIER 1.0
+  #define RA_PULSE_MULTIPLIER 1.0f
 #elif RA_STEPPER_TYPE == STEPPER_TYPE_NEMA17
-  #define RA_PULSE_MULTIPLIER 1.5
+  #define RA_PULSE_MULTIPLIER 1.5f
 #else
   #error New RA Stepper type? Add it here...
 #endif
 
 #if DEC_STEPPER_TYPE == STEPPER_TYPE_28BYJ48
-  #define DEC_PULSE_MULTIPLIER 1.0
+  #define DEC_PULSE_MULTIPLIER 1.0f
 #elif DEC_STEPPER_TYPE == STEPPER_TYPE_NEMA17
-  #define DEC_PULSE_MULTIPLIER 1.0
+  #define DEC_PULSE_MULTIPLIER 1.0f
 #else
   #error New DEC Stepper type? Add it here...
 #endif
@@ -273,11 +273,11 @@
 
 
   // the Circumference of the AZ rotation. 808mm dia.
-  #define AZ_CIRCUMFERENCE 2538.4
+  #define AZ_CIRCUMFERENCE 2538.4f
   // the Circumference of the AZ rotation. 770mm dia.
   #define ALT_CIRCUMFERENCE 2419
   // the ratio of the ALT gearbox (40:3)
-  #define ALT_WORMGEAR_RATIO (40/3)
+  #define ALT_WORMGEAR_RATIO (40.0f / 3.0f)
 
   #define AZIMUTH_STEPS_PER_REV           (AZ_CORRECTION_FACTOR * (AZ_CIRCUMFERENCE / (AZ_PULLEY_TEETH * GT2_BELT_PITCH)) * AZ_STEPPER_SPR * AZ_MICROSTEPPING)   // Actually u-steps/rev
   #define ALTITUDE_STEPS_PER_REV          (ALT_CORRECTION_FACTOR * (ALT_CIRCUMFERENCE / (ALT_PULLEY_TEETH * GT2_BELT_PITCH)) * ALT_STEPPER_SPR * ALT_MICROSTEPPING * ALT_WORMGEAR_RATIO)   // Actually u-steps/rev

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,8 @@
 [platformio]
 ; default_envs = mega2560  
 include_dir = .
+src_dir = ./src
+lib_dir = ./src/libs
 
 [common]
 lib_deps = 
@@ -26,12 +28,39 @@ framework = arduino
 monitor_speed = 57600
 upload_speed = 115200
 test_build_project_src = true
+extra_scripts =
+	pre:pre_build_script.py
+build_unflags =
+	-Os
+build_flags =
+; Can change to -Os if we get size constrained
+	-O2
+src_filter =
+	+<*> -<../.git/> -<../test/>
+	-<*/.pio/> -<*/.platformio/> -<libs/>
+src_build_flags =
+; Warnings to be enabled as codebase is refined and fixed up
+	-Werror
+	-Wall
+	-Wextra
+;	-Wpedantic
+	-Wno-unused-parameter
+;	-Wold-style-cast
+	-Wlogical-op
+	-Wuseless-cast
+	-Wdouble-promotion
+;	-Wconversion
+;	-Wfloat-conversion
+;	-Wsign-conversion
+	-Wshadow
+;	-Wsuggest-final-types
 
 [env:mega2560]
 platform = atmelavr
 board = ATmega2560
 upload_protocol = wiring
-build_flags = 
+build_flags =
+	${env.build_flags}
 	-D BOARD=BOARD_AVR_MEGA2560
 lib_deps = 
 	${common.lib_deps}
@@ -40,7 +69,8 @@ lib_deps =
 platform = atmelavr
 board = ATmega2560
 upload_protocol = wiring
-build_flags = 
+build_flags =
+	${env.build_flags}
 	-D BOARD=BOARD_AVR_MKS_GEN_L_V21
 lib_deps = 
 	${common.lib_deps}
@@ -49,7 +79,8 @@ lib_deps =
 platform = atmelavr
 board = ATmega2560
 upload_protocol = wiring
-build_flags = 
+build_flags =
+	${env.build_flags}
 	-D BOARD=BOARD_AVR_MKS_GEN_L_V2
 lib_deps = 
 	${common.lib_deps}
@@ -58,7 +89,8 @@ lib_deps =
 platform = atmelavr
 board = ATmega2560
 upload_protocol = wiring
-build_flags = 
+build_flags =
+	${env.build_flags}
 	-D BOARD=BOARD_AVR_MKS_GEN_L_V1
 lib_deps = 
 	${common.lib_deps}
@@ -68,7 +100,8 @@ platform = espressif32
 board = esp32dev
 upload_speed = 460800 
 monitor_filters = esp32_exception_decoder
-build_flags = 
+build_flags =
+	${env.build_flags}
 	-D BOARD=BOARD_ESP32_ESP32DEV
 lib_deps = 
 	${common.lib_deps}

--- a/pre_build_script.py
+++ b/pre_build_script.py
@@ -1,0 +1,35 @@
+Import("env")
+
+import platform
+
+extra_macros = {
+    # PP indirection needed
+    'DO_PRAGMA_(x)': '_Pragma(#x)',
+    'DO_PRAGMA(x)': 'DO_PRAGMA_(x)',
+
+    # Useful for disabling warnings on system headers that we don't care about
+    'PUSH_NO_WARNINGS': ''.join([
+        'DO_PRAGMA(GCC diagnostic push);',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wconversion");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wshadow");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wsign-conversion");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wsign-compare");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wignored-qualifiers");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wuseless-cast");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wall");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wextra");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wpedantic");',
+    ]),
+    'POP_NO_WARNINGS': 'DO_PRAGMA(GCC diagnostic pop);'
+}
+
+def escape_str(s):
+    if 'windows' not in platform.system().lower():
+        # This stuff breaks windows builds
+        if ' ' not in s:
+            s = s.replace('(', '\\(')
+            s = s.replace(')', '\\)')
+    s = s.replace('"', '\\"')
+    return s
+
+env.Append(CPPDEFINES={escape_str(k): escape_str(v) for k, v in extra_macros.items()})

--- a/src/DayTime.cpp
+++ b/src/DayTime.cpp
@@ -79,7 +79,7 @@ DayTime::DayTime(int h, int m, int s)
 DayTime::DayTime(float timeInHours)
 {
   long sgn = fsign(timeInHours);
-  timeInHours = fabs(timeInHours);
+  timeInHours = fabsf(timeInHours);
   totalSeconds = sgn * round(timeInHours * 60 * 60);
 }
 
@@ -277,7 +277,7 @@ const char *DayTime::formatStringImpl(char *targetBuffer, const char *format, ch
   printTwoDigits(achMins, mins);
   printTwoDigits(achSecs, secs);
 
-  char macro;
+  char macro = '\0';
   bool inMacro = false;
   while (*f)
   {

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -1,4 +1,7 @@
+#include "inc/Globals.hpp"
+PUSH_NO_WARNINGS
 #include <EEPROM.h>
+POP_NO_WARNINGS
 
 #include "../Configuration.hpp"
 #include "Utility.hpp"
@@ -249,8 +252,8 @@ bool EEPROMStore::isPresent(ItemFlag item)
 {
   uint16_t marker = readUint16(MAGIC_MARKER_AND_FLAGS_ADDR);
 
-  int check = (MAGIC_MARKER_MASK | item);
-  int result=(MAGIC_MARKER_VALUE | item);
+  unsigned check = (MAGIC_MARKER_MASK | item);
+  unsigned result=(MAGIC_MARKER_VALUE | item);
   bool res = ((marker & check) == result);
   LOGV6(DEBUG_EEPROM, F("EEPROM: IsDataPresent (%x). Checking (%x & %x) == %x => %d"), item, marker, check, result, res);
 
@@ -469,7 +472,7 @@ float EEPROMStore::getSpeedFactor()
 void EEPROMStore::storeSpeedFactor(float speedFactor)
 {
   // Store the fractional speed factor since it is a number very close to 1
-  int32_t val = (speedFactor - 1.0) * 10000.0;
+  int32_t val = (speedFactor - 1.0f) * 10000.0f;
   val = clamp(val, (int32_t)INT16_MIN, (int32_t)INT16_MAX);
   LOGV3(DEBUG_EEPROM, "EEPROM: Storing Speed Factor to %d (%f)", val, speedFactor);
 

--- a/src/Gyro.cpp
+++ b/src/Gyro.cpp
@@ -4,7 +4,9 @@
 
 #if USE_GYRO_LEVEL == 1
 
+PUSH_NO_WARNINGS
 #include <Wire.h> // I2C communication library
+POP_NO_WARNINGS
 
 /**
  * Tilt, roll, and temperature measurementusing the MPU-6050 MEMS gyro.
@@ -88,9 +90,9 @@ angle_t Gyro::getCurrentAngles()
         int16_t AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
 
         // Calculating the Pitch angle (rotation around Y-axis)
-        result.pitchAngle += ((atan(-1 * AcX / sqrt(pow(AcY, 2) + pow(AcZ, 2))) * 180.0 / PI) * 2.0) / 2.0;
+        result.pitchAngle += ((atanf(-1 * AcX / sqrtf(powf(AcY, 2) + powf(AcZ, 2))) * 180.0f / static_cast<float>(PI)) * 2.0f) / 2.0f;
         // Calculating the Roll angle (rotation around X-axis)
-        result.rollAngle += ((atan(-1 * AcY / sqrt(pow(AcX, 2) + pow(AcZ, 2))) * 180.0 / PI) * 2.0) / 2.0;
+        result.rollAngle += ((atanf(-1 * AcY / sqrtf(powf(AcX, 2) + powf(AcZ, 2))) * 180.0f / static_cast<float>(PI)) * 2.0f) / 2.0f;
 
         delay(10);  // Decorrelate measurements
     }
@@ -111,7 +113,7 @@ float Gyro::getCurrentTemperature()
 */
 {
     if (!isPresent)
-        return 99;     // Gyro is not available
+        return 99.0f;     // Gyro is not available
 
     // Execute 2 byte read from MPU6050_REG_TEMP_OUT_H
     Wire.beginTransmission(MPU6050_I2C_ADDR);
@@ -121,7 +123,7 @@ float Gyro::getCurrentTemperature()
     int16_t tempValue = Wire.read() << 8 | Wire.read(); // Raw Temperature value
     
     // Calculating the actual temperature value
-    float result = float(tempValue) / 340 + 36.53;
+    float result = static_cast<float>(tempValue) / 340.0f + 36.53f;
     return result;
 }
 #endif

--- a/src/InterruptCallback.cpp
+++ b/src/InterruptCallback.cpp
@@ -15,7 +15,9 @@
   #define USE_TIMER_3     false
   #define USE_TIMER_4     false
   #define USE_TIMER_5     false
+  PUSH_NO_WARNINGS
   #include "libs/TimerInterrupt/TimerInterrupt.h"
+  POP_NO_WARNINGS
 #else
   #error Unrecognized board selected. Either implement interrupt code or define the board here.
 #endif

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -58,8 +58,8 @@ const char *Longitude::ToString() const
     secs += 360L * 3600L;
   }
 
-  String totalDegs = String((float)(1.0f * abs(totalSeconds) / 3600.0), 2);
-  String degs = String((float)(1.0f * secs / 3600.0), 2);
+  String totalDegs = String(1.0f * abs(totalSeconds) / 3600.0f, 2);
+  String degs = String(1.0f * secs / 3600.0f, 2);
   strcpy(achBufLong, degs.c_str());
   strcat(achBufLong, " (");
   strcat(achBufLong, totalDegs.c_str());

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1048,7 +1048,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
     }
     else if (inCmd[1] == 'M') // :XGM#
     {
-      return String(_mount->getMountHardwareInfo()) + "#";
+      return _mount->getMountHardwareInfo() + "#";
     }
     else if (inCmd[1] == 'O') // :XGO#
     {

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -318,7 +318,7 @@ public:
   DayTime getLocalTime();
   LocalDate getLocalDate();
 
-  const int getLocalUtcOffset() const;
+  int getLocalUtcOffset() const;
 
   void setLocalStartDate( int year, int month, int day );
   void setLocalStartTime( DayTime localTime );

--- a/src/Sidereal.cpp
+++ b/src/Sidereal.cpp
@@ -1,40 +1,43 @@
+#include "inc/Globals.hpp"
 #include "../Configuration.hpp"
 #include "Sidereal.hpp"
 
 // Constants for sidereal calculation       
 // Source: http://www.stargazing.net/kepler/altaz.html
-#define C1              100.46
-#define C2              0.985647
-#define C3              15.0
-#define C4              -0.5125
-#define J2000           2000
+const double C1      = 100.46;
+const double C2      = 0.985647;
+const double C3      = 15.0;
+const double C4      = -0.5125;
+const unsigned J2000 = 2000;
 
 #if USE_GPS == 1
+PUSH_NO_WARNINGS
 #include <TinyGPS++.h>
-DayTime Sidereal::calculateByGPS(TinyGPSPlus* gps){
+POP_NO_WARNINGS
+DayTime Sidereal::calculateByGPS(TinyGPSPlus* gps) {
     DayTime timeUTC = DayTime(gps->time.hour(), gps->time.minute(), gps->time.second());
     int deltaJd = calculateDeltaJd(gps->date.year(), gps->date.month(), gps->date.day());
-    double deltaJ = deltaJd + ((timeUTC.getTotalHours()) / 24.0);
-    return DayTime((float)(calculateTheta(deltaJ, gps->location.lng(), timeUTC.getTotalHours()) / 15.0));
+    double deltaJ = static_cast<float>(deltaJd) + (timeUTC.getTotalHours() / 24.0f);
+    return DayTime(static_cast<float>(calculateTheta(deltaJ, gps->location.lng(), timeUTC.getTotalHours()) / 15.0));
     }
 #endif // USE_GPS
 
 DayTime Sidereal::calculateByDateAndTime( double longitude, int year, int month, int day, DayTime *timeUTC ) {
     int deltaJd = calculateDeltaJd( year, month, day );
-    double deltaJ = deltaJd + ((timeUTC->getTotalHours()) / 24.0);
-    return DayTime((float)(calculateTheta(deltaJ, longitude, timeUTC->getTotalHours()) / 15.0));
+    double deltaJ = deltaJd + ((timeUTC->getTotalHours()) / 24.0f);
+    return DayTime(static_cast<float>(calculateTheta(deltaJ, longitude, timeUTC->getTotalHours()) / 15.0));
 }
 
-const double Sidereal::calculateTheta(double deltaJ, double longitude, float timeUTC){
+double Sidereal::calculateTheta(double deltaJ, double longitude, float timeUTC){
     double theta = C1;
     theta += C2 * deltaJ;
-    theta += C3 * timeUTC;
+    theta += C3 * static_cast<double>(timeUTC);
     theta += C4;
     theta += longitude;
     return fmod(theta, 360.0);
 }
 
-const int Sidereal::calculateDeltaJd(int year, int month, int day){
+int Sidereal::calculateDeltaJd(int year, int month, int day){
     const int daysInMonth[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     // Calculating days without leapdays

--- a/src/Sidereal.hpp
+++ b/src/Sidereal.hpp
@@ -15,6 +15,6 @@ class Sidereal
     static DayTime calculateHa( float lstTotalHours );
 
  private:
-    static const double calculateTheta(double deltaJ, double longitude, float timeUTC);
-    static const int calculateDeltaJd(int year, int month, int day);
+    static double calculateTheta(double deltaJ, double longitude, float timeUTC);
+    static int calculateDeltaJd(int year, int month, int day);
 };

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -1,3 +1,5 @@
+#include <math.h>
+
 #include "../Configuration.hpp"
 #include "Utility.hpp"
 
@@ -202,6 +204,24 @@ int fsign(float num)
     return -1;
   }
   return 1;
+}
+
+// float-type point implementation of fabs
+float fabsf(float x)
+{
+    return static_cast<float>(fabs(static_cast<double>(x)));
+}
+
+// float-type point implementation of round
+float roundf(float x)
+{
+    return static_cast<float>(round(static_cast<double>(x)));
+}
+
+// float-type point implementation of atan
+float atanf(float x)
+{
+    return static_cast<float>(atan(static_cast<double>(x)));
 }
 
 #if defined(ESP32)

--- a/src/Utility.hpp
+++ b/src/Utility.hpp
@@ -131,6 +131,20 @@ void logv(int levelFlags, String input, ...);
 
 #endif // DEBUG_LEVEL>0
 
+// For some reason arduino just defines all float functions to be as double
+#if defined(fabsf)
+#undef fabsf
+#endif
+#if defined(roundf)
+#undef roundf
+#endif
+#if defined(atanf)
+#undef atanf
+#endif
+float fabsf(float);
+float roundf(float);
+float atanf(float);
+
 // Adjust the given number by the given adjustment, wrap around the limits.
 // Limits are inclusive, so they represent the lowest and highest valid number.
 int adjustWrap(int current, int adjustBy, int minVal, int maxVal);

--- a/src/a_inits.hpp
+++ b/src/a_inits.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <AccelStepper.h>
 #include "inc/Globals.hpp"
+PUSH_NO_WARNINGS
+#include <AccelStepper.h>
+POP_NO_WARNINGS
 
 #include "Utility.hpp"
 #include "DayTime.hpp"
@@ -10,12 +12,16 @@
 
 // TODO: we have to change driver type to DRIVER_TYPE_TMC2209 and add a new definition for the actual mode (e.g. DRIVER_MODE_UART)
 #if (RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE) || (RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART) || (DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE) || (DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART) || (AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART) || (ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
+PUSH_NO_WARNINGS
   #include <TMCStepper.h>
+POP_NO_WARNINGS
 #endif
 
 #if USE_GPS == 1
+PUSH_NO_WARNINGS
   //#include <SoftwareSerial.h>
   #include <TinyGPS++.h>
+POP_NO_WARNINGS
 
   //SoftwareSerial SoftSerial(GPS_SERIAL_RX_PIN, GPS_SERIAL_TX_PIN); // RX, TX
   TinyGPSPlus gps;

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -61,9 +61,9 @@ TaskHandle_t StepperTask;
 // This task function is run on Core 0 of the ESP32 and never returns
 void IRAM_ATTR stepperControlTask(void* payload)
 {
-  Mount* mount = reinterpret_cast<Mount*>(payload);
+  Mount* mountCopy = reinterpret_cast<Mount*>(payload);
   for (;;) {
-    mount->interruptLoop();
+    mountCopy->interruptLoop();
     vTaskDelay(1);  // 1 ms 	// This will limit max stepping rate to 1 kHz
   }
 }
@@ -73,9 +73,9 @@ void IRAM_ATTR stepperControlTask(void* payload)
 // It should do very minimal work, only calling Mount::interruptLoop() to step the stepper motors as needed.
 // It is called every 500 us (2 kHz rate)
 void stepperControlTimerCallback(void* payload) {
-  Mount* mount = reinterpret_cast<Mount*>(payload);
-  if (mount)
-    mount->interruptLoop();
+  Mount* mountCopy = reinterpret_cast<Mount*>(payload);
+  if (mountCopy)
+    mountCopy->interruptLoop();
 }
 
 #endif

--- a/src/c72_menuHA_GPS.hpp
+++ b/src/c72_menuHA_GPS.hpp
@@ -210,7 +210,7 @@ void printHASubmenu()
     }
     else if (haState == STARTING_GPS)
     {
-        sprintf(satBuffer, "  Found %d sats", (unsigned int)gps.satellites.value());
+        sprintf(satBuffer, "  Found %d sats", gps.satellites.value());
         satBuffer[0] = ind[indicator];
     }
     else if (haState == ENTER_HA_MANUALLY)

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -177,11 +177,11 @@ void gotoNextHighlightState(int dir)
 
   if (calState == HIGHLIGHT_RA_STEPS)
   {
-    RAStepsPerDegree = mount.getStepsPerDegree(RA_STEPS) * 10.0;
+    RAStepsPerDegree = mount.getStepsPerDegree(RA_STEPS) * 10.0f;
   }
   else if (calState == HIGHLIGHT_DEC_STEPS)
   {
-    DECStepsPerDegree = mount.getStepsPerDegree(DEC_STEPS) * 10.0;
+    DECStepsPerDegree = mount.getStepsPerDegree(DEC_STEPS) * 10.0f;
   }
   else if (calState == HIGHLIGHT_BACKLASH_STEPS)
   {
@@ -189,7 +189,7 @@ void gotoNextHighlightState(int dir)
   }
   else if (calState == HIGHLIGHT_SPEED)
   {
-    SpeedCalibration = (mount.getSpeedCalibration() - 1.0) * 10000.0 + 0.5;
+    SpeedCalibration = (mount.getSpeedCalibration() - 1.0f) * 10000.0f + 0.5f;
   }
   else if (calState == HIGHLIGHT_BACKLIGHT)
   {
@@ -230,7 +230,7 @@ bool processCalibrationKeys()
       if (SpeedCalibration < 32760)
       {                        // Don't overflow 16 bit signed
         SpeedCalibration += 1; //0.0001;
-        mount.setSpeedCalibration(1.0 + SpeedCalibration / 10000.0, false);
+        mount.setSpeedCalibration(1.0f + SpeedCalibration / 10000.0f, false);
       }
 
       mount.delay(calDelay);
@@ -242,7 +242,7 @@ bool processCalibrationKeys()
       if (SpeedCalibration > -32760)
       {                        // Don't overflow 16 bit signed
         SpeedCalibration -= 1; //0.0001;
-        mount.setSpeedCalibration(1.0 + SpeedCalibration / 10000.0, false);
+        mount.setSpeedCalibration(1.0f + SpeedCalibration / 10000.0f, false);
       }
 
       mount.delay(calDelay);
@@ -397,14 +397,14 @@ bool processCalibrationKeys()
       // UP and DOWN are handled above
       if (key == btnSELECT)
       {
-        mount.setSpeedCalibration(1.0 + SpeedCalibration / 10000.0, true);
+        mount.setSpeedCalibration(1.0f + SpeedCalibration / 10000.0f, true);
         lcdMenu.printMenu("Speed Stored.");
         mount.delay(500);
         calState = HIGHLIGHT_SPEED;
       }
       else if (key == btnRIGHT)
       {
-        mount.setSpeedCalibration(1.0 + SpeedCalibration / 10000.0, true);
+        mount.setSpeedCalibration(1.0f + SpeedCalibration / 10000.0f, true);
         gotoNextMenu();
 
         calState = HIGHLIGHT_SPEED;
@@ -1031,7 +1031,7 @@ bool processCalibrationKeys()
 void makeIndicator(char *scratchBuffer, float angle)
 {
   angle = clamp(angle, -9.9f, 9.9f);
-  dtostrf(fabs(angle), 3, 1, &scratchBuffer[8]);
+  dtostrf(fabsf(angle), 3, 1, &scratchBuffer[8]);
   for (int i = 0; i < 5; i++)
   {
     scratchBuffer[3 + i] = '-';

--- a/src/c78_menuINFO.hpp
+++ b/src/c78_menuINFO.hpp
@@ -2,6 +2,8 @@
 
 #if DISPLAY_TYPE > 0
 
+#include "Utility.hpp"
+
 #if SUPPORT_INFO_DISPLAY == 1
 byte infoIndex = 0;
 byte maxInfoIndex = 15;
@@ -106,8 +108,8 @@ void printStatusSubmenu()
 
     case 3:
     {
-      float lat = fabs(mount.latitude().getTotalHours());
-      float lng = fabs(mount.longitude().getTotalHours());
+      float lat = fabsf(mount.latitude().getTotalHours());
+      float lng = fabsf(mount.longitude().getTotalHours());
       const char dirLat = (mount.latitude().getTotalHours() < 0) ? 'S' : 'N';
       const char dirLong = (mount.longitude().getTotalHours() < 0) ? 'W' : 'E';
       sprintf(scratchBuffer, "Loc %s%c %s%c", String(lat, 1).c_str(), dirLat, String(lng, 1).c_str(), dirLong);
@@ -118,8 +120,8 @@ void printStatusSubmenu()
     case 4:
     {
 #if USE_GYRO_LEVEL == 1
-      int celsius = (int)round(Gyro::getCurrentTemperature());
-      int fahrenheit = (int)round(32.0 + 9.0 * Gyro::getCurrentTemperature() / 5.0);
+      int celsius = static_cast<int>(roundf(Gyro::getCurrentTemperature()));
+      int fahrenheit = static_cast<int>(roundf(32.0f + 9.0f * Gyro::getCurrentTemperature() / 5.0f));
 
       sprintf(scratchBuffer, "Temp: %d@C %d@F", celsius, fahrenheit);
       lcdMenu.printMenu(scratchBuffer);

--- a/src/inc/Globals.hpp
+++ b/src/inc/Globals.hpp
@@ -1,6 +1,19 @@
 #pragma once
 
+/**
+ * These are only necessary for the Arduino IDE build, these are actually
+ * defined in `pre_build_script.py` which is run by platformio.
+ */
+#if !defined(PUSH_NO_WARNINGS)
+#define PUSH_NO_WARNINGS ;
+#endif
+#if !defined(POP_NO_WARNINGS)
+#define POP_NO_WARNINGS ;
+#endif
+
+PUSH_NO_WARNINGS
 #include <Arduino.h>
 #include <WString.h>
+POP_NO_WARNINGS
 
 extern bool inSerialControl; // True when the serial port is in control


### PR DESCRIPTION
* Added the following compiler flags to the source tree:
```
-Werror
-Wall
-Wextra
-Wno-unused-parameter
-Wlogical-op
-Wuseless-cast
-Wdouble-promotion
-Wshadow
```
as well as a couple more useful ones that can be un-commented with future refactoring
* Added PUSH_NO_WARNINGS/POP_NO_WARNINGS macro because we don't care about warnings from libraries / library headers
* Changed from `-Os` to `-O2` optimization because we aren't size constrained (yet :grin: )