### PR TITLE
Fix Arduino IDE build

### DIFF
--- a/boards/AVR_MEGA2560/pins_MEGA2560.hpp
+++ b/boards/AVR_MEGA2560/pins_MEGA2560.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Constants.hpp"
-
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  22

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Constants.hpp"
-
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  63

--- a/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
+++ b/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Constants.hpp"
-
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  13  


### PR DESCRIPTION
Fixes #51 
The Arduino IDE expects all source files to be in the src/ directory,
else it will not be able to find and include them in the build process.

This kinda sucks, since people with `Configuration_local.hpp` files will have to move them into `src/` else they wont be included... Do we have mechanisms to tell people about this change?
@ClutchplateDude @andre-stefanov 