### PR TITLE
Fix double promotion errors when using Arduino's round() macro

### DIFF
--- a/pre_build_script.py
+++ b/pre_build_script.py
@@ -11,6 +11,7 @@ extra_macros = {
     'PUSH_NO_WARNINGS': ''.join([
         'DO_PRAGMA(GCC diagnostic push);',
         'DO_PRAGMA(GCC diagnostic ignored "-Wconversion");',
+        'DO_PRAGMA(GCC diagnostic ignored "-Wdouble-promotion");',
         'DO_PRAGMA(GCC diagnostic ignored "-Wshadow");',
         'DO_PRAGMA(GCC diagnostic ignored "-Wsign-conversion");',
         'DO_PRAGMA(GCC diagnostic ignored "-Wsign-compare");',

--- a/src/DayTime.cpp
+++ b/src/DayTime.cpp
@@ -80,7 +80,7 @@ DayTime::DayTime(float timeInHours)
 {
   long sgn = fsign(timeInHours);
   timeInHours = fabsf(timeInHours);
-  totalSeconds = sgn * round(timeInHours * 60 * 60);
+  totalSeconds = sgn * static_cast<long>(roundf(timeInHours * 60.0f * 60.0f));
 }
 
 int DayTime::getHours() const

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -539,7 +539,7 @@ Latitude EEPROMStore::getLatitude()
 // Store the configured location Latitude.
 void EEPROMStore::storeLatitude(Latitude const &latitude)
 {
-  int32_t val = round(latitude.getTotalHours() * 100);
+  int32_t val = static_cast<int32_t>(roundf(latitude.getTotalHours() * 100.0f));
   val = clamp(val, (int32_t)INT16_MIN, (int32_t)INT16_MAX);
   LOGV3(DEBUG_EEPROM, "EEPROM: Storing Latitude as %d (%f)", val, latitude.getTotalHours());
 
@@ -570,7 +570,7 @@ Longitude EEPROMStore::getLongitude()
 // Store the configured location Longitude.
 void EEPROMStore::storeLongitude(Longitude const &longitude)
 {
-  int32_t val = round(longitude.getTotalHours() * 100);
+  int32_t val = static_cast<int32_t>(roundf(longitude.getTotalHours() * 100.0f));
   val = clamp(val, (int32_t)INT16_MIN, (int32_t)INT16_MAX);
   LOGV3(DEBUG_EEPROM, "EEPROM: Storing Longitude as %d (%f)", val, longitude.getTotalHours());
 


### PR DESCRIPTION
Build was failing for me, not sure if that's a global issue. Perhaps an Arduno core update? Regardless this is the correct usage and the builds succeed!