### PR TITLE
Fix RA UART rms current initialization

### DIFF
--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -367,9 +367,8 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverRA, "RA" );
     #endif
-    _driverRA->toff(4);
     _driverRA->blank_time(24);
-    _driverRA->rms_current(rmscurrent);
+    _driverRA->rms_current(rmscurrent, 1.0f);
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
     _driverRA->fclktrim(4);
     _driverRA->TCOOLTHRS(0xFFFFF);  //xFFFFF);
@@ -390,16 +389,11 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
       connectToDriver( _driverRA, "RA" );
     #endif
     //#endif
-    _driverRA->toff(4);
     _driverRA->blank_time(24);
-    _driverRA->rms_current(rmscurrent);
+    _driverRA->rms_current(rmscurrent, 1.0f);
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
     _driverRA->fclktrim(4);
     _driverRA->TCOOLTHRS(0xFFFFF);  //xFFFFF);
-    //_driverRA->semin(2);
-    //_driverRA->semax(5);
-    //_driverRA->sedn(0b01);
-    //_driverRA->SGTHRS(10);
   }
 #endif
 #endif
@@ -422,7 +416,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverDEC, "DEC" );
     #endif
-    _driverDEC->rms_current(rmscurrent);
+    _driverDEC->rms_current(rmscurrent, 1.0f);
     _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);   // If 1 then disable microstepping
     _driverDEC->TCOOLTHRS(0xFFFFF);
     _driverDEC->semin(5);
@@ -467,9 +461,8 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if AZ_AUDIO_FEEDBACK == 1
       _driverAZ->en_spreadCycle(1);
     #endif
-    _driverAZ->toff(4);
     _driverAZ->blank_time(24);
-    _driverAZ->rms_current(rmscurrent);
+    _driverAZ->rms_current(rmscurrent, 1.0f);
     _driverAZ->microsteps(AZ_MICROSTEPPING == 1 ? 0 : AZ_MICROSTEPPING);   // If 1 then disable microstepping
     _driverAZ->fclktrim(4);
     _driverAZ->TCOOLTHRS(0xFFFFF);  //xFFFFF);
@@ -485,9 +478,8 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverAZ, "AZ" );
     #endif
-    _driverAZ->toff(4);
     _driverAZ->blank_time(24);
-    _driverAZ->rms_current(rmscurrent);
+    _driverAZ->rms_current(rmscurrent, 1.0f);
     _driverAZ->microsteps(AZ_MICROSTEPPING == 1 ? 0 : AZ_MICROSTEPPING);   // If 1 then disable microstepping
     _driverAZ->fclktrim(4);
     _driverAZ->TCOOLTHRS(0xFFFFF);  //xFFFFF);
@@ -509,9 +501,8 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if ALT_AUDIO_FEEDBACK == 1
       _driverALT->en_spreadCycle(1);
     #endif
-    _driverALT->toff(4);
     _driverALT->blank_time(24);
-    _driverALT->rms_current(rmscurrent);
+    _driverALT->rms_current(rmscurrent, 1.0f);
     _driverALT->microsteps(ALT_MICROSTEPPING == 1 ? 0 : ALT_MICROSTEPPING);   // If 1 then disable microstepping
     _driverALT->fclktrim(4);
     _driverALT->TCOOLTHRS(0xFFFFF);  //xFFFFF);
@@ -527,9 +518,8 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverAZ, "ALT" );
     #endif
-    _driverALT->toff(4);
     _driverALT->blank_time(24);
-    _driverALT->rms_current(rmscurrent);
+    _driverALT->rms_current(rmscurrent, 1.0f);
     _driverALT->microsteps(ALT_MICROSTEPPING == 1 ? 0 : ALT_MICROSTEPPING);   // If 1 then disable microstepping
     _driverALT->fclktrim(4);
     _driverALT->TCOOLTHRS(0xFFFFF);  //xFFFFF);

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -373,12 +373,10 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
     _driverRA->fclktrim(4);
     _driverRA->TCOOLTHRS(0xFFFFF);  //xFFFFF);
-    _driverRA->ihold(1); // its save to assume that the only time RA stands still is during parking and the current can be limited to a minimum
     //_driverRA->semin(2);
     //_driverRA->semax(5);
     //_driverRA->sedn(0b01);
     //_driverRA->SGTHRS(10);
-    _driverRA->irun(31);
   }
 #elif SW_SERIAL_UART == 1
   void Mount::configureRAdriver(uint16_t RA_SW_RX, uint16_t RA_SW_TX, float rsense, byte driveraddress, int rmscurrent, int stallvalue)
@@ -398,12 +396,10 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
     _driverRA->fclktrim(4);
     _driverRA->TCOOLTHRS(0xFFFFF);  //xFFFFF);
-    _driverRA->ihold(1); // its save to assume that the only time RA stands still is during parking and the current can be limited to a minimum
     //_driverRA->semin(2);
     //_driverRA->semax(5);
     //_driverRA->sedn(0b01);
     //_driverRA->SGTHRS(10);
-    _driverRA->irun(31);
   }
 #endif
 #endif
@@ -433,7 +429,6 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverDEC->semax(2);
     _driverDEC->sedn(0b01);
     _driverDEC->SGTHRS(stallvalue);
-    _driverDEC->ihold(DEC_HOLDCURRENT);
   }
 #elif SW_SERIAL_UART == 1
   void Mount::configureDECdriver(uint16_t DEC_SW_RX, uint16_t DEC_SW_TX, float rsense, byte driveraddress, int rmscurrent, int stallvalue)
@@ -454,7 +449,6 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverDEC->semax(2);
     _driverDEC->sedn(0b01);
     _driverDEC->SGTHRS(stallvalue);
-    _driverDEC->ihold(DEC_HOLDCURRENT);
   }
 #endif
 #endif

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -367,6 +367,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverRA, "RA" );
     #endif
+    _driverRA->toff(4);
     _driverRA->blank_time(24);
     _driverRA->rms_current(rmscurrent, 1.0f);
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
@@ -389,6 +390,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
       connectToDriver( _driverRA, "RA" );
     #endif
     //#endif
+    _driverRA->toff(4);
     _driverRA->blank_time(24);
     _driverRA->rms_current(rmscurrent, 1.0f);
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
@@ -409,6 +411,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverDEC = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverDEC->begin();
+    _driverDEC->toff(4);
     _driverDEC->blank_time(24);
     #if DEC_AUDIO_FEEDBACK == 1
     _driverDEC->en_spreadCycle(1);
@@ -436,7 +439,8 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverDEC, "DEC" );
     #endif
-    _driverDEC->rms_current(rmscurrent);
+    _driverDEC->toff(4);
+    _driverDEC->rms_current(rmscurrent, 1.0f);
     _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);   // If 1 then disable microstepping
     _driverDEC->TCOOLTHRS(0xFFFFF);
     _driverDEC->semin(5);
@@ -461,6 +465,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if AZ_AUDIO_FEEDBACK == 1
       _driverAZ->en_spreadCycle(1);
     #endif
+    _driverAZ->toff(4);
     _driverAZ->blank_time(24);
     _driverAZ->rms_current(rmscurrent, 1.0f);
     _driverAZ->microsteps(AZ_MICROSTEPPING == 1 ? 0 : AZ_MICROSTEPPING);   // If 1 then disable microstepping
@@ -478,6 +483,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverAZ, "AZ" );
     #endif
+    _driverAZ->toff(4);
     _driverAZ->blank_time(24);
     _driverAZ->rms_current(rmscurrent, 1.0f);
     _driverAZ->microsteps(AZ_MICROSTEPPING == 1 ? 0 : AZ_MICROSTEPPING);   // If 1 then disable microstepping
@@ -501,6 +507,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if ALT_AUDIO_FEEDBACK == 1
       _driverALT->en_spreadCycle(1);
     #endif
+    _driverALT->toff(4);
     _driverALT->blank_time(24);
     _driverALT->rms_current(rmscurrent, 1.0f);
     _driverALT->microsteps(ALT_MICROSTEPPING == 1 ? 0 : ALT_MICROSTEPPING);   // If 1 then disable microstepping
@@ -518,6 +525,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     #if UART_CONNECTION_TEST == 1
       connectToDriver( _driverAZ, "ALT" );
     #endif
+    _driverALT->toff(4);
     _driverALT->blank_time(24);
     _driverALT->rms_current(rmscurrent, 1.0f);
     _driverALT->microsteps(ALT_MICROSTEPPING == 1 ? 0 : ALT_MICROSTEPPING);   // If 1 then disable microstepping


### PR DESCRIPTION
Currently when the RA driver is initialized, the TMCStepper rms_current() function is called to set the RMS current for the motor.

Immediately afterward both the ihold() and irun() functions are called, which overrides what was set by rms_current().

irun(31) is called, setting the RMS run current to maximum (with the Vref potentiometer as the only method to control RA current).

The DEC/AZ/ALT driver initializations appear to be correct.