### PR TITLE
Fixup/cs/turn more defines into enums

### DIFF
--- a/src/LcdMenu.hpp
+++ b/src/LcdMenu.hpp
@@ -111,14 +111,18 @@ private:
   byte _brightness;
 
 #if DISPLAY_TYPE != DISPLAY_TYPE_LCD_JOY_I2C_SSD1306
-  byte _degrees = 1;
-  byte _minutes = 2;
-  byte _leftArrow = 3;
-  byte _rightArrow = 4;
-  byte _upArrow = 5;
-  byte _downArrow = 6;
-  byte _tracking = 7;
-  byte _noTracking = 0;
+  enum specialChar_t : byte {
+      _degrees,
+      _minutes,
+      _leftArrow,
+      _rightArrow,
+      _upArrow,
+      _downArrow,
+      _tracking,
+      _noTracking,
+      SPECIAL_CHAR_MAX,
+  };
+  static_assert(SPECIAL_CHAR_MAX <= 8, "LCD only supports a maximum of 8 special characters");
 
   // The special character bitmaps
   static byte RightArrowBitmap[8];

--- a/src/MappedDict.hpp
+++ b/src/MappedDict.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+/**
+ * @brief A simple class to deal with 1-1 value mapping, a la python dictionaries
+ * @details Operations operate on pointers so that this class has no data storage,
+ * data should be set up by the caller and passed in to the constructor.
+ * @tparam KeyType Type that should be the 'key'
+ * @tparam ValueType Type that should be the 'value'
+ */
+template<class KeyType, class ValueType>
+class MappedDict {
+public:
+    typedef struct {
+        KeyType in;
+        ValueType out;
+    } DictEntry_t;
+
+    MappedDict(DictEntry_t *dictPtr, size_t dictSize)
+            : _dictPtr(dictPtr), _dictSize(dictSize) {
+    }
+
+    /**
+     * Try to retrieve a value from the mapping
+     * @param[in] query Key to look for in the dictionary
+     * @param[out] rtnValPtr Pointer to store the return value in, if successful
+     * @return true if the query was found in the dictionary, false otherwise
+     */
+    bool tryGet(KeyType query, ValueType *rtnValPtr) {
+        bool foundElement = false;
+        for (unsigned i = 0; i < _dictSize; i++) {
+            if (_dictPtr[i].in == query) {
+                foundElement = true;
+                *rtnValPtr = _dictPtr[i].out;
+                break;
+            }
+        }
+        return foundElement;
+    }
+
+private:
+    DictEntry_t *_dictPtr;  ///< Pointer to dictionary storage
+    size_t _dictSize;       ///< Number of elements in the dictionary
+};

--- a/src/Utility.hpp
+++ b/src/Utility.hpp
@@ -171,4 +171,6 @@ int sign(long num);
 // Return -1 if the given number is less than zero, 1 if not.
 int fsign(float num);
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+
 #endif

--- a/src/c75_menuCTRL.hpp
+++ b/src/c75_menuCTRL.hpp
@@ -5,52 +5,58 @@
 
 bool setZeroPoint = true;
 
-#define HIGHLIGHT_MANUAL 1
-#define HIGHLIGHT_SERIAL 2
+enum ctrlState_t {
+    HIGHLIGHT_MANUAL,
+    HIGHLIGHT_SERIAL,
+    MANUAL_CONTROL_MODE,
+    MANUAL_CONTROL_CONFIRM_HOME,
+};
 
-#define MANUAL_CONTROL_MODE 10
-#define MANUAL_CONTROL_CONFIRM_HOME 11
-#define SERIAL_DISPLAY_MODE 20
-
-int ctrlState = HIGHLIGHT_MANUAL;
-
-#define LOOPS_TO_CONFIRM_KEY 10
-byte loopsWithKeyPressed = 0;
-byte keyPressed = btnNONE;
+ctrlState_t ctrlState = HIGHLIGHT_MANUAL;
 
 void setControlMode(bool state)
 {
   ctrlState = state ? MANUAL_CONTROL_MODE : HIGHLIGHT_MANUAL;
 }
 
-bool processKeyStateChanges(int key, int dir)
+/**
+ * @brief Handle commanding the mount slew direction when in manual control
+ * @defails Meant to be called continuously with the current key pressed,
+ * a keypress is only 'valid' if it is held down for at least 10 cycles.
+ * @param[in] key The current key being pressed
+ * @param[in] dir The direction the mount should slew in associated with the key
+ * @return true if the mount was commanded, false otherwise
+ */
+bool controlManualSlew(lcdButton_t key, int dir)
 {
-  bool ret = false;
-  if (keyPressed != key)
-  {
-    loopsWithKeyPressed = 0;
-    keyPressed = key;
-  }
-  else
-  {
-    if (loopsWithKeyPressed == LOOPS_TO_CONFIRM_KEY)
-    {
-      mount.stopSlewing(ALL_DIRECTIONS);
-      mount.waitUntilStopped(ALL_DIRECTIONS);
-      if (dir != 0)
-      {
-        mount.startSlewing(dir);
-      }
-      loopsWithKeyPressed++;
-      ret = true;
-    }
-    else if (loopsWithKeyPressed < LOOPS_TO_CONFIRM_KEY)
-    {
-      loopsWithKeyPressed++;
-    }
-  }
+    const int LOOPS_TO_CONFIRM_KEY = 10;
+    /// Static counter that is reset whenever there is a key change
+    static unsigned countDown = 0;
+    /// Static storage for the key that is currently commanding the mount
+    static lcdButton_t currentKeyPressed = btnINVALID;
 
-  return ret;
+    const bool keyConfirmed = (countDown == 0);
+    bool isNewSlewDirection = false;
+    if (keyConfirmed && currentKeyPressed != key) {
+        // Store the current key press as it has been confirmed
+        currentKeyPressed = key;
+        mount.stopSlewing(ALL_DIRECTIONS);
+        mount.waitUntilStopped(ALL_DIRECTIONS);
+        if (dir != 0) {
+            // Slew the mount in the desired direction
+            mount.startSlewing(dir);
+        }
+        isNewSlewDirection = true;
+    } else if (currentKeyPressed != key) {
+        countDown = LOOPS_TO_CONFIRM_KEY;
+    }
+
+    if (countDown > 0) {
+        // Always try to count down if possible
+        countDown -= 1;
+    }
+
+    return isNewSlewDirection;
 }
 
 bool processControlKeys()
@@ -62,7 +68,6 @@ bool processControlKeys()
   switch (ctrlState)
   {
   case HIGHLIGHT_MANUAL:
-  {
     if (lcdButtons.keyChanged(&key))
     {
       waitForRelease = true;
@@ -80,11 +85,9 @@ bool processControlKeys()
         lcdMenu.setNextActive();
       }
     }
-  }
   break;
 
   case HIGHLIGHT_SERIAL:
-  {
     if (lcdButtons.keyChanged(&key))
     {
       waitForRelease = true;
@@ -102,11 +105,9 @@ bool processControlKeys()
         lcdMenu.setNextActive();
       }
     }
-  }
   break;
 
   case MANUAL_CONTROL_CONFIRM_HOME:
-  {
     if (lcdButtons.keyChanged(&key))
     {
       waitForRelease = true;
@@ -142,41 +143,30 @@ bool processControlKeys()
         setZeroPoint = !setZeroPoint;
       }
     }
-  }
   break;
 
   case MANUAL_CONTROL_MODE:
-  {
     key = lcdButtons.currentState();
     switch (key)
     {
     case btnUP:
-    {
-      processKeyStateChanges(btnUP, NORTH);
-    }
+        controlManualSlew(btnUP, NORTH);
     break;
 
     case btnDOWN:
-    {
-      processKeyStateChanges(btnDOWN, SOUTH);
-    }
+        controlManualSlew(btnDOWN, SOUTH);
     break;
 
     case btnLEFT:
-    {
-      processKeyStateChanges(btnLEFT, WEST);
-    }
+        controlManualSlew(btnLEFT, WEST);
     break;
 
     case btnRIGHT:
-    {
-      processKeyStateChanges(btnRIGHT, EAST);
-    }
+        controlManualSlew(btnRIGHT, EAST);
     break;
 
     case btnSELECT:
-    {
-      if (processKeyStateChanges(btnSELECT, 0))
+      if (controlManualSlew(btnSELECT, 0))
       {
 #if SUPPORT_GUIDED_STARTUP == 1
         if (startupState == StartupWaitForPoleCompletion)
@@ -196,17 +186,13 @@ bool processControlKeys()
           waitForRelease = true;
         }
       }
-    }
     break;
 
     case btnNONE:
     case btnINVALID:
-    {
-      processKeyStateChanges(btnNONE, 0);
-    }
+        controlManualSlew(btnNONE, 0);
     break;
     }
-  }
   break;
   }
 
@@ -218,14 +204,10 @@ void printControlSubmenu()
   switch (ctrlState)
   {
   case HIGHLIGHT_MANUAL:
-  {
     lcdMenu.printMenu(">Manual slewing");
-  }
   break;
   case HIGHLIGHT_SERIAL:
-  {
     lcdMenu.printMenu(">Serial display");
-  }
   break;
   case MANUAL_CONTROL_CONFIRM_HOME:
   {
@@ -236,9 +218,7 @@ void printControlSubmenu()
   }
   break;
   default:
-  {
     mount.displayStepperPositionThrottled();
-  }
   break;
   }
 }

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -290,7 +290,7 @@ bool processCalibrationKeys()
     {
       Brightness = clamp(Brightness, 0, 255);
       lcdMenu.setBacklightBrightness(Brightness, false);
-      LOGV2(DEBUG_INFO, F("CAL: Brightness set %d"), (int)lcdMenu.getBacklightBrightness());
+      LOGV2(DEBUG_INFO, F("CAL: Brightness set %i"), lcdMenu.getBacklightBrightness());
     }
   }
   else if (calState == POLAR_CALIBRATION_WAIT_HOME)


### PR DESCRIPTION
Biggest addition in this PR is the `MappedDict` class which allows the simple lookup of one value to another value. It's meant to act like `std::map` ([docs](https://en.cppreference.com/w/cpp/container/map)) because we do not really have the STL on embedded platforms.
The `bool get(KeyType query, ValueType *rtnValPtr)` method semantics (return code and pointer for output value) are such because we do not have exceptions on embedded platforms either. If there were exceptions, we could simply return the value if it is in the map else throw an exception but unfortunately we do not.
Using `MappedDict` in certain places where a `switch` or `if/else` chain would be used makes the intention of the developer a lot more clear. :smile: Let me know your thoughts and if you think there is a cleaner way to go about the implementation!

The latest commit (3638d780333) does deeper refactoring of `c75_menuCTRL.hpp`, it's not necessary and if wanted I will drop it, however I do think it is a bit of a cleaner implementation!

Additionally, I believe that the refactoring of `processKeyStateChanges()` (now `controlManualSlew()`) in 913057f9fea fixes a bug where pressing alternating buttons quickly would lead to locking up the logic and effectively locking out any further keypresses.