### PR TITLE
Enable LCD brightness again for keypad displays

### DIFF
--- a/src/LcdMenu.hpp
+++ b/src/LcdMenu.hpp
@@ -39,6 +39,11 @@ public:
 
   void startup();
 
+  #if DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD && defined(LCD_BRIGHTNESS_PIN)
+  // Function to test LCD hardware, some units are shipped with defects
+  static bool testIfLcdIsBad();
+  #endif
+
   // Find a menu item by its ID
   MenuItem* findById(byte id);
 
@@ -56,7 +61,8 @@ public:
 
   // Set and get the brightness of the backlight
   void setBacklightBrightness(int level, bool persist = true);
-  int getBacklightBrightness();
+  int getBacklightBrightness() const;
+  void getBacklightBrightnessRange(int *minPtr, int *maxPtr) const;
 
   // Pass thru utility function
   void clear();
@@ -99,6 +105,7 @@ private:
   byte const _rows;
   byte const _maxItems;
   byte const _charHeightRows;   // Height of character in display native rows
+  bool _lcdBadHw;
 
   MenuItem** _menuItems;  // The first menu item (linked list)
   byte _numMenuItems;

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -288,7 +288,10 @@ bool processCalibrationKeys()
     checkForKeyChange = checkProgressiveUpDown(&Brightness);
     if (!checkForKeyChange)
     {
-      Brightness = clamp(Brightness, 0, 255);
+      int minBrightness;
+      int maxBrightness;
+      lcdMenu.getBacklightBrightnessRange(&minBrightness, &maxBrightness);
+      Brightness = clamp(Brightness, minBrightness, maxBrightness);
       lcdMenu.setBacklightBrightness(Brightness, false);
       LOGV2(DEBUG_INFO, F("CAL: Brightness set %i"), lcdMenu.getBacklightBrightness());
     }


### PR DESCRIPTION
This is an interesting one! Turns out the crashes reported earlier were because of manufacturing defects which cause the brightness pin to short to ground. When the LCD brightness pin is turned on it consumes too much power and thus cause a brownout.

This fix (helped largely by finding https://forum.arduino.cc/index.php?topic=96747.0) will 'test' the LCD display at startup and store a value if it exhibits the electrical fault. We can then check that value at runtime to:
- limit the faulty LCD to full brightness or completely off
- change how we control said brightness (either `pinMode(INPUT);` for ON or `pinMode(OUTPUT);` for OFF)