### PR TITLE
V1.9.03 - Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+**V1.9.03 - Updates**
+- Removed connection test check and made it standard.
+- Switched motors to normal mode (better perf), but allowed silent mode through XX_UART_STEALTH_MODE defines.
+- Made DEC driver be in Guide microstep mode unless slewing.
+- Added command to Meade protocol to calculate stepper positions for stellar coordinates.
+- Fixed an overflow bug in the CAL LCD menu for RA/DEC steps (esoteric mounts).
+
 **V1.9.00 - Updates**
 - Fixes RMS current setting for TMC2209 UART to be more accurate and consistent
 - Disables i_scale_analog (aka "USE_VREF") by default so that results are more consistent between users. rms_current will no longer depend on Vref, unless specifically configured by the user.

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -48,9 +48,7 @@
     // Serial bus address must be specified for TMC2209 in UART mode
     #error RA driver address for DRIVER_TYPE_TMC2209_UART not specified.
   #endif
-  #ifndef RA_UART_STEALTH_MODE 
-    #error RA stealth mode not set! 
-  #elif (RA_UART_STEALTH_MODE != 0) && (RA_UART_STEALTH_MODE != 1)
+  #if (RA_UART_STEALTH_MODE != 0) && (RA_UART_STEALTH_MODE != 1)
     // Stealth mode must be zero or 1
     #error RA stealth mode must be 0 (off) or 1 (on)
   #endif
@@ -61,16 +59,14 @@
     // Serial bus address must be specified for TMC2209 in UART mode
     #error DEC driver address for DRIVER_TYPE_TMC2209_UART not specified.
   #endif
-  #ifndef DEC_UART_STEALTH_MODE 
-    #error DEC stealth mode not set! 
-  #elif (DEC_UART_STEALTH_MODE != 0) && (DEC_UART_STEALTH_MODE != 1)
+  #if (DEC_UART_STEALTH_MODE != 0) && (DEC_UART_STEALTH_MODE != 1)
     // Stealth mode must be zero or 1
     #error DEC stealth mode must be 0 (off) or 1 (on)
   #endif
 #endif
 
 #ifdef UART_CONNECTION_TEST_TXRX
-    #error The UART Connection test is now standard. This directive is obsolete and can be removed from your configuration.
+    #warning The UART Connection test is now standard. This directive is obsolete and can be removed from your configuration.
 #endif
 
 #if (AZIMUTH_ALTITUDE_MOTORS == 0)

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -48,6 +48,12 @@
     // Serial bus address must be specified for TMC2209 in UART mode
     #error RA driver address for DRIVER_TYPE_TMC2209_UART not specified.
   #endif
+  #ifndef RA_UART_STEALTH_MODE 
+    #error RA stealth mode not set! 
+  #elif (RA_UART_STEALTH_MODE != 0) && (RA_UART_STEALTH_MODE != 1)
+    // Stealth mode must be zero or 1
+    #error RA stealth mode must be 0 (off) or 1 (on)
+  #endif
 #endif
 
 #if (DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
@@ -55,6 +61,16 @@
     // Serial bus address must be specified for TMC2209 in UART mode
     #error DEC driver address for DRIVER_TYPE_TMC2209_UART not specified.
   #endif
+  #ifndef DEC_UART_STEALTH_MODE 
+    #error DEC stealth mode not set! 
+  #elif (DEC_UART_STEALTH_MODE != 0) && (DEC_UART_STEALTH_MODE != 1)
+    // Stealth mode must be zero or 1
+    #error DEC stealth mode must be 0 (off) or 1 (on)
+  #endif
+#endif
+
+#ifdef UART_CONNECTION_TEST_TXRX
+    #error The UART Connection test is now standard. This directive is obsolete and can be removed from your configuration.
 #endif
 
 #if (AZIMUTH_ALTITUDE_MOTORS == 0)

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -65,10 +65,6 @@
   #endif
 #endif
 
-#ifdef UART_CONNECTION_TEST_TXRX
-    #warning The UART Connection test is now standard. This directive is obsolete and can be removed from your configuration.
-#endif
-
 #if (AZIMUTH_ALTITUDE_MOTORS == 0)
   // Baseline configuration without azimuth & altitude control is valid
 #elif defined(__AVR_ATmega2560__)

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -156,6 +156,12 @@
     #define USE_VREF 0      //By default Vref is ignored when using UART to specify rms current. Only enable if you know what you are doing.
   #endif
   
+  #ifndef UART_CONNECTION_TEST_TXRX
+    #define UART_CONNECTION_TEST_TXRX 0
+  #endif
+  #ifndef UART_CONNECTION_TEST_TX
+    #define UART_CONNECTION_TEST_TX 0
+  #endif  
 #endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -97,6 +97,9 @@
   #ifndef RA_TRACKING_MICROSTEPPING 
     #define RA_TRACKING_MICROSTEPPING 8     // The fine microstep mode for tracking RA axis
   #endif
+  #ifndef RA_UART_STEALTH_MODE
+    #define RA_UART_STEALTH_MODE   0
+  #endif
 #elif (RA_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC) || (RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE)
   #define RA_SLEW_MICROSTEPPING 8         // Microstep mode set by MS pin strapping. Use the same microstep mode for both slewing & tracking   
   #define RA_TRACKING_MICROSTEPPING RA_SLEW_MICROSTEPPING   
@@ -113,6 +116,9 @@
   #endif
   #ifndef DEC_GUIDE_MICROSTEPPING 
     #define DEC_GUIDE_MICROSTEPPING 16  // The fine microstep mode used for guiding DEC only
+  #endif
+  #ifndef DEC_UART_STEALTH_MODE
+    #define DEC_UART_STEALTH_MODE   0
   #endif
 #elif (DEC_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC) || (DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE)
   #define DEC_SLEW_MICROSTEPPING  16  // Only UART drivers support dynamic switching. Use the same microstep mode for both slewing & guiding
@@ -150,12 +156,6 @@
     #define USE_VREF 0      //By default Vref is ignored when using UART to specify rms current. Only enable if you know what you are doing.
   #endif
   
-  #ifndef UART_CONNECTION_TEST_TXRX
-    #define UART_CONNECTION_TEST_TXRX 0
-  #endif
-  #ifndef UART_CONNECTION_TEST_TX
-    #define UART_CONNECTION_TEST_TX 0
-  #endif
 #endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.02"
+#define VERSION "V1.9.03"

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.00"
+#define VERSION "V1.9.01"

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.01"
+#define VERSION "V1.9.02"

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -95,7 +95,6 @@
 #endif
 
 #define SW_SERIAL_UART 1
-#define UART_CONNECTION_TEST_TXRX 1
   
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef AZ_IN1_PIN

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -95,6 +95,7 @@
 #endif
 
 #define SW_SERIAL_UART 1
+#define UART_CONNECTION_TEST_TXRX 1
   
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef AZ_IN1_PIN

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1073,7 +1073,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
         long raPos, decPos;
         float raCoord = coords.substring(0, star).toFloat();
         float decCoord = coords.substring(star + 1).toFloat();
-        _mount->calculatePositions(raCoord, decCoord, raPos, decPos);
+        _mount->calculateStepperPositions(raCoord, decCoord, raPos, decPos);
         char scratchBuffer[20];
         sprintf(scratchBuffer, "%ld|%ld#", raPos, decPos);
         return String(scratchBuffer);

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -338,6 +338,7 @@ void Mount::configureDECStepper(byte pin1, byte pin2, int maxSpeed, int maxAccel
 #endif
 
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART || DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART || AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART || ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART 
+#if UART_CONNECTION_TEST_TXRX == 1
 bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     LOGV2(DEBUG_STEPPERS, F("Testing UART Connection to %s driver..."), driverKind);
     for (int i = 0; i < UART_CONNECTION_TEST_RETRIES; i++) {
@@ -353,6 +354,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     return false;
 }
 #endif
+#endif
 
 /////////////////////////////////
 //
@@ -366,12 +368,13 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverRA->begin();
 
-    bool _UART_Rx_connected = false;
-    _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(RA_EN_PIN, HIGH);    // Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-    _driverRA->toff(0);    
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(RA_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
+    _driverRA->toff(0);     
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
       _driverRA->I_scale_analog(0);
     #endif
@@ -401,12 +404,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA->mstep_reg_select(true);
     _driverRA->pdn_disable(true);
 
-    bool _UART_Rx_connected = false;
-    _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(RA_EN_PIN, HIGH);    // Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(RA_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverRA->toff(0);   
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverRA->I_scale_analog(0);
@@ -441,12 +444,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverDEC = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverDEC->begin();
-    
-    bool _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(DEC_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(DEC_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverDEC->toff(0);
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverDEC->I_scale_analog(0);
@@ -475,11 +478,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverDEC->beginSerial(19200);
     _driverDEC->mstep_reg_select(true);
     _driverDEC->pdn_disable(true);
-
-    bool _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(DEC_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(DEC_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverDEC->toff(0);
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverDEC->I_scale_analog(0);
@@ -513,11 +517,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverAZ = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverAZ->begin();
-    bool _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(AZ_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-    
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(AZ_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverAZ->toff(0);
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverAZ->I_scale_analog(0);
@@ -546,11 +551,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverAZ->beginSerial(19200);
     _driverAZ->mstep_reg_select(true);
     _driverAZ->pdn_disable(true);
-    bool _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(AZ_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(AZ_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverAZ->toff(0);
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverAZ->I_scale_analog(0);
@@ -584,11 +590,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverALT = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverALT->begin();
-    bool _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(ALT_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(ALT_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverALT->toff(0);
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverALT->I_scale_analog(0);
@@ -617,11 +624,12 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverALT->beginSerial(19200);
     _driverALT->mstep_reg_select(true);
     _driverALT->pdn_disable(true);    
-    bool _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
-    if (!_UART_Rx_connected) {
-        digitalWrite(ALT_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
-    }
-
+    #if UART_CONNECTION_TEST_TXRX == 1
+        bool _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
+        if (!_UART_Rx_connected) {
+            digitalWrite(ALT_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
+        }
+    #endif
     _driverALT->toff(0);
     #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
         _driverALT->I_scale_analog(0);
@@ -2811,7 +2819,7 @@ DayTime Mount::calculateHa() {
 // testUART
 //
 /////////////////////////////////
-
+#if UART_CONNECTION_TEST_TX == 1
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART 
 void Mount::testRA_UART_TX(){
     int _speed = 1000;  //microsteps per driver clock tick
@@ -2838,4 +2846,5 @@ void Mount::testUART_vactual(TMC2209Stepper *driver, int _speed, int _duration) 
     driver->VACTUAL(0);
     delay(_duration);
 }
+#endif
 #endif

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -390,7 +390,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA->rms_current(rmscurrent, 1.0f); //holdMultiplier = 1 to set ihold = irun
     _driverRA->toff(1);
     _driverRA->blank_time(24);
-    _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
+    _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
     _driverRA->fclktrim(4);
     _driverRA->TCOOLTHRS(0xFFFFF);  //xFFFFF);
     _driverRA->semin(0); //disable CoolStep so that current is consistent
@@ -425,7 +425,7 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA->toff(1);
     _driverRA->blank_time(24);
     _driverRA->semin(0); //disable CoolStep so that current is consistent
-    _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
+    _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);   // System starts in tracking mode
     _driverRA->fclktrim(4);
     _driverRA->TCOOLTHRS(0xFFFFF);  //xFFFFF);
     _driverRA->SGTHRS(stallvalue);
@@ -1163,11 +1163,11 @@ void Mount::startSlewingToTarget() {
       // set Slew microsteps for TMC2209 UART once the TRK stepper has stopped
       #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         LOGV2(DEBUG_STEPPERS, F("STEP-startSlewingToTarget: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
-        _driverRA->microsteps(RA_SLEW_MICROSTEPPING);
+        _driverRA->microsteps(RA_SLEW_MICROSTEPPING== 1 ? 0 : RA_SLEW_MICROSTEPPING);
       #endif
       #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         LOGV2(DEBUG_STEPPERS, F("STEP-startSlewingToTarget: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
-        _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING);
+        _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
       #endif
 
       LOGV2(DEBUG_STEPPERS, F("STEP-startSlewingToTarget: TRK stopped at %lms"), _trackerStoppedAt);
@@ -1356,7 +1356,7 @@ void Mount::setManualSlewMode(bool state) {
     _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_MANUAL;
     #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
       LOGV2(DEBUG_STEPPERS, F("STEP-setManualSlewMode: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
-      _driverRA->microsteps(RA_SLEW_MICROSTEPPING);
+      _driverRA->microsteps(RA_SLEW_MICROSTEPPING== 1 ? 0 : RA_SLEW_MICROSTEPPING);
     #endif
   }
   else {
@@ -1808,7 +1808,7 @@ void Mount::startSlewing(int direction) {
       // Start tracking
       #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         LOGV2(DEBUG_STEPPERS, F("STEP-startSlewing: Tracking: Switching RA driver to microsteps(%d)"), RA_TRACKING_MICROSTEPPING);
-        _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);
+        _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
       #endif
       _stepperTRK->setSpeed(_trackingSpeed);
       
@@ -1834,11 +1834,11 @@ void Mount::startSlewing(int direction) {
       // Change microstep mode for slewing
       #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         LOGV2(DEBUG_STEPPERS, F("STEP-startSlewing: Slewing: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
-        _driverRA->microsteps(RA_SLEW_MICROSTEPPING);
+        _driverRA->microsteps(RA_SLEW_MICROSTEPPING== 1 ? 0 : RA_SLEW_MICROSTEPPING);
       #endif
       #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         LOGV2(DEBUG_STEPPERS, F("STEP-startSlewing: Slewing: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
-        _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING);
+        _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
       #endif
 
       if (direction & NORTH) {
@@ -2102,7 +2102,7 @@ void Mount::loop() {
         #if RA_STEPPER_TYPE == STEPPER_TYPE_NEMA17
           #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
             LOGV2(DEBUG_STEPPERS, F("STEP-loop: Arrived. RA driver setMicrosteps(%d)"), RA_TRACKING_MICROSTEPPING);
-            _driverRA->microsteps(RA_TRACKING_MICROSTEPPING);
+            _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
           #endif
           if (!isParking()) {
             if (_compensateForTrackerOff) {

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -367,9 +367,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverRA = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverRA->begin();
-
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
+        _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
         if (!_UART_Rx_connected) {
             digitalWrite(RA_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -403,9 +403,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverRA->beginSerial(19200);
     _driverRA->mstep_reg_select(true);
     _driverRA->pdn_disable(true);
-
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
+        _UART_Rx_connected = connectToDriver( _driverRA, "RA" );
         if (!_UART_Rx_connected) {
             digitalWrite(RA_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -444,8 +444,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverDEC = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverDEC->begin();
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
+        _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
         if (!_UART_Rx_connected) {
             digitalWrite(DEC_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -478,8 +479,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverDEC->beginSerial(19200);
     _driverDEC->mstep_reg_select(true);
     _driverDEC->pdn_disable(true);
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
+        _UART_Rx_connected = connectToDriver( _driverDEC, "DEC" );
         if (!_UART_Rx_connected) {
             digitalWrite(DEC_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -517,8 +519,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverAZ = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverAZ->begin();
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
+        _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
         if (!_UART_Rx_connected) {
             digitalWrite(AZ_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -551,8 +554,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverAZ->beginSerial(19200);
     _driverAZ->mstep_reg_select(true);
     _driverAZ->pdn_disable(true);
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
+        _UART_Rx_connected = connectToDriver( _driverAZ, "AZ" );
         if (!_UART_Rx_connected) {
             digitalWrite(AZ_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -590,8 +594,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
   {
     _driverALT = new TMC2209Stepper(serial, rsense, driveraddress);
     _driverALT->begin();
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
+        _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
         if (!_UART_Rx_connected) {
             digitalWrite(ALT_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }
@@ -624,8 +629,9 @@ bool Mount::connectToDriver( TMC2209Stepper* driver, const char *driverKind ) {
     _driverALT->beginSerial(19200);
     _driverALT->mstep_reg_select(true);
     _driverALT->pdn_disable(true);    
+    bool _UART_Rx_connected = false;
     #if UART_CONNECTION_TEST_TXRX == 1
-        bool _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
+        _UART_Rx_connected = connectToDriver( _driverALT, "ALT" );
         if (!_UART_Rx_connected) {
             digitalWrite(ALT_EN_PIN, HIGH);    //Disable motor for safety reasons if UART connection fails to avoid operating at incorrect rms_current
         }

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1247,7 +1247,8 @@ void Mount::guidePulse(byte direction, int duration) {
   switch (direction) {
     case NORTH:
     #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-      _driverDEC->microsteps(DEC_GUIDE_MICROSTEPPING == 1 ? 0 : DEC_GUIDE_MICROSTEPPING);   // If 1 then disable microstepping
+        LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse: Switching DEC driver to microsteps(%d)"), DEC_GUIDE_MICROSTEPPING);
+        _driverDEC->microsteps(DEC_GUIDE_MICROSTEPPING == 1 ? 0 : DEC_GUIDE_MICROSTEPPING);   // If 1 then disable microstepping
     #endif
     LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  DEC.setSpeed(%f)"), DEC_PULSE_MULTIPLIER * decGuidingSpeed);
     _stepperGUIDE->setSpeed(DEC_PULSE_MULTIPLIER * decGuidingSpeed);
@@ -1257,6 +1258,7 @@ void Mount::guidePulse(byte direction, int duration) {
 
     case SOUTH:
     #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
+      LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse: Switching DEC driver to microsteps(%d)"), DEC_GUIDE_MICROSTEPPING);
       _driverDEC->microsteps(DEC_GUIDE_MICROSTEPPING == 1 ? 0 : DEC_GUIDE_MICROSTEPPING);   // If 1 then disable microstepping
     #endif
     LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  DEC.setSpeed(%f)"), -DEC_PULSE_MULTIPLIER * decGuidingSpeed);
@@ -2331,6 +2333,21 @@ float Mount::getSpeed(int direction) {
   return 0;
 }
 
+/////////////////////////////////
+//
+// calculatePositions
+//
+// This code calculates the stepper locations to move to, given the right ascension and declination
+/////////////////////////////////
+void Mount::calculatePositions(float raCoord, float decCoord, long& raPos, long& decPos){
+  DayTime savedRA = _targetRA;
+  Declination savedDec = _targetDEC;
+  _targetRA = DayTime(raCoord);
+  _targetDEC = Declination::FromSeconds(decCoord * 3600.0f);
+  calculateRAandDECSteppers(raPos, decPos);
+  _targetRA = savedRA;
+  _targetDEC = savedDec;
+}
 
 /////////////////////////////////
 //

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -178,7 +178,7 @@ public:
   // Set the current RA and DEC position to be the given coordinates
   void syncPosition(DayTime ra, Declination dec);
 
-  void calculatePositions(float raCoord, float decCoord, long& raPos, long& decPos);
+  void calculateStepperPositions(float raCoord, float decCoord, long& raPos, long& decPos);
 
   // Calculates movement parameters and program steppers to move
   // there. Must call loop() frequently to actually move.

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -330,15 +330,17 @@ public:
   DayTime calculateLst();
   DayTime calculateHa();
   
-  #if UART_CONNECTION_TEST_TX == 1
+#if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART 
   void testRA_UART_TX();
+#endif
+#if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   void testDEC_UART_TX();
-  #endif
+#endif
 private:
 
-  #if UART_CONNECTION_TEST_TX == 1
+#if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART || DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   void testUART_vactual(TMC2209Stepper *driver, int speed, int duration);
-  #endif
+#endif
 
   // Reads values from EEPROM that configure the mount (if previously stored)
   void readPersistentData();

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -178,6 +178,8 @@ public:
   // Set the current RA and DEC position to be the given coordinates
   void syncPosition(DayTime ra, Declination dec);
 
+  void calculatePositions(float raCoord, float decCoord, long& raPos, long& decPos);
+
   // Calculates movement parameters and program steppers to move
   // there. Must call loop() frequently to actually move.
   void startSlewingToTarget();

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -330,16 +330,20 @@ public:
   DayTime calculateLst();
   DayTime calculateHa();
   
+#if UART_CONNECTION_TEST_TX == 1
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART 
   void testRA_UART_TX();
 #endif
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   void testDEC_UART_TX();
 #endif
+#endif
 private:
 
+#if UART_CONNECTION_TEST_TX == 1
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART || DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   void testUART_vactual(TMC2209Stepper *driver, int speed, int duration);
+#endif
 #endif
 
   // Reads values from EEPROM that configure the mount (if previously stored)

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -389,6 +389,7 @@ void setup() {
     }
   #endif
 
+#if UART_CONNECTION_TEST_TX == 1
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   LOGV1(DEBUG_STEPPERS, "Moving RA axis using UART commands...");
   mount.testRA_UART_TX();
@@ -399,6 +400,7 @@ void setup() {
   LOGV1(DEBUG_STEPPERS, "Moving DEC axis using UART commands...");
   mount.testDEC_UART_TX();
   LOGV1(DEBUG_STEPPERS, "Finished moving DEC axis using UART commands.");
+#endif
 #endif
 
   // Start the tracker.

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -389,10 +389,13 @@ void setup() {
     }
   #endif
 
-#if UART_CONNECTION_TEST_TX == 1
+#if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   LOGV1(DEBUG_STEPPERS, "Moving RA axis using UART commands...");
   mount.testRA_UART_TX();
   LOGV1(DEBUG_STEPPERS, "Finished moving RA axis using UART commands.");
+#endif
+
+#if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
   LOGV1(DEBUG_STEPPERS, "Moving DEC axis using UART commands...");
   mount.testDEC_UART_TX();
   LOGV1(DEBUG_STEPPERS, "Finished moving DEC axis using UART commands.");

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -172,7 +172,7 @@ bool checkProgressiveUpDown(int *val, int minDelay = 25)
 {
   long lval = *val;
   bool ret = checkProgressiveUpDown(&lval, minDelay);
-  if ((lval < 32766L) && (lval > -32765L))
+  if ((lval < INT16_MAX) && (lval > INT16_MIN))
   {
     *val = (int)lval;
   }

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -119,8 +119,8 @@ int UTCOffset = 0;
 int AzimuthMinutes = 0;
 int AltitudeMinutes = 0;
 
-int RAStepsPerDegree = RA_STEPS_PER_DEGREE * 10;   // menuCAL use higher resolution for editing
-int DECStepsPerDegree = DEC_STEPS_PER_DEGREE * 10; // menuCAL uses higher resolution for editing
+long RAStepsPerDegree = RA_STEPS_PER_DEGREE * 10L;   // menuCAL use higher resolution for editing
+long DECStepsPerDegree = DEC_STEPS_PER_DEGREE * 10L; // menuCAL uses higher resolution for editing
 
 // Pitch and roll offset
 #if USE_GYRO_LEVEL == 1
@@ -142,7 +142,7 @@ void gotoNextMenu()
 #endif
 }
 
-bool checkProgressiveUpDown(int *val, int minDelay = 25)
+bool checkProgressiveUpDown(long *val, int minDelay = 25)
 {
   bool ret = true;
 
@@ -165,6 +165,17 @@ bool checkProgressiveUpDown(int *val, int minDelay = 25)
     calDelay = 150;
   }
 
+  return ret;
+}
+
+bool checkProgressiveUpDown(int *val, int minDelay = 25)
+{
+  long lval = *val;
+  bool ret = checkProgressiveUpDown(&lval, minDelay);
+  if ((lval < INT_MAX) && (lval > INT_MIN))
+  {
+    *val = (int)lval;
+  }
   return ret;
 }
 

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -172,7 +172,7 @@ bool checkProgressiveUpDown(int *val, int minDelay = 25)
 {
   long lval = *val;
   bool ret = checkProgressiveUpDown(&lval, minDelay);
-  if ((lval < INT_MAX) && (lval > INT_MIN))
+  if ((lval < 32766L) && (lval > -32765L))
   {
     *val = (int)lval;
   }


### PR DESCRIPTION
- Removed connection test check and made it standard.
- Switched motors to normal mode (better perf), but allowed silent mode through XX_UART_STEALTH_MODE defines.
- Made DEC driver be in Guide microstep mode unless slewing.
- Added command to Meade protocol to calculate stepper positions for stellar coordinates.
- Fixed an overflow bug in the CAL LCD menu for RA/DEC steps (esoteric mounts).
