### PR TITLE
V1.9.04 - Updates

### DIFF
--- a/Constants.hpp
+++ b/Constants.hpp
@@ -53,7 +53,7 @@
 
 // USB serial port speed according to external controller
 #define SERIAL_BAUDRATE_STELLARIUM_DIRECT   9600
-#define SERIAL_BAUDRATE_ASCOM               57600
+#define SERIAL_BAUDRATE_ASCOM               19200
 
 // Wifi operating modes (ESP32 only)
 #define WIFI_MODE_INFRASTRUCTURE                        0   // Infrastructure Only - OAT connects to an existing Router

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.03"
+#define VERSION "V1.9.04"

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ src_dir = ./src
 lib_dir = ./src/libs
 
 [common]
+
 lib_deps = 
 	mikalhart/TinyGPSPlus @ ^1.0.2
 	teemuatlut/TMCStepper @ ^0.7.1
@@ -25,7 +26,7 @@ lib_deps =
 
 [env]
 framework = arduino
-monitor_speed = 57600
+monitor_speed = 19200
 upload_speed = 115200
 test_build_project_src = true
 extra_scripts =
@@ -109,3 +110,4 @@ build_flags =
 lib_deps = 
 	${common.lib_deps}
 	WiFi
+

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -152,15 +152,15 @@ bool gpsAqcuisitionComplete(int &indicator); // defined in c72_menuHA_GPS.hpp
 // -- GET Extensions --
 // :GIS#
 //      Get DEC or RA Slewing
-//      Returns: 1 if either RA or DEC is slewing. 0 if not.
+//      Returns: 1# if either RA or DEC is slewing. 0# if not.
 //
 // :GIT#
 //      Get Tracking
-//      Returns: 1 if tracking is on. 0 if not.
+//      Returns: 1# if tracking is on. 0# if not.
 //
 // :GIG#
 //      Get Guiding
-//      Returns: 1 if currently guiding. 0 if not.
+//      Returns: 1# if currently guiding. 0# if not.
 //
 // :GX#
 //      Get Mount Status
@@ -1237,7 +1237,7 @@ String MeadeCommandProcessor::handleMeadeQuit(String inCmd)
   {
     _mount->stopSlewing(ALL_DIRECTIONS | TRACKING);
     _mount->waitUntilStopped(ALL_DIRECTIONS);
-    return "1";
+    return "";
   }
 
   switch (inCmd[0])


### PR DESCRIPTION
- Reduced Serial communication rate to 19200 for better stability in communications
- Fixed an incorrect response in Meade (:Q# was sending a response, where ti shouldn't have)