### PR TITLE
V1.9.10 - Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 **V1.9.10 - Updates**
-- Fixed a compiler bug when enabling LCD_BUTTON_TEST
+- Fixed a bug that caused a compilation fail when enabling LCD_BUTTON_TEST
 - Allowed connection test to be set in local config
 
 **V1.9.09 - Updates**

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
+**V1.9.10 - Updates**
+- Fixed a compiler bug when enabling LCD_BUTTON_TEST
+- Allowed connection test to be set in local config
+
 **V1.9.09 - Updates**
-- Sample Local Config - Disabled as default
+- Sample Local Config - disabled as default
 
 **V1.9.08 - Updates**
 - Continuous integration improvements. Checking for version and changelog changes automatically

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.09"
+#define VERSION "V1.9.10"

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -95,7 +95,9 @@
 #endif
 
 #define SW_SERIAL_UART 1
-#define UART_CONNECTION_TEST_TXRX 1
+#ifndef UART_CONNECTION_TEST_TXRX
+  #define UART_CONNECTION_TEST_TXRX 1
+#endif
   
 // DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef AZ_IN1_PIN

--- a/src/c_buttons.hpp
+++ b/src/c_buttons.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "LcdButtons.hpp"
 #include "b_setup.hpp"
 #include "c65_startup.hpp"
 #include "c70_menuRA.hpp"
@@ -21,7 +22,7 @@
   int lastLoopKey = -1;
 
   #if LCD_BUTTON_TEST == 1
-    byte lastKey = btnNONE;
+    lcdButton_t lastKey = btnNONE;
   #endif
 
   lcdButton_t lcd_key;
@@ -52,6 +53,7 @@
         case btnRIGHT: state += "Right"; break;
         case btnUP: state += "Up"; break;
         case btnDOWN: state += "Down"; break;
+        default: state += "Invalid" ; break;
       }
 
       lcdMenu.printMenu(state);


### PR DESCRIPTION
- Fixed a compiler bug when enabling LCD_BUTTON_TEST
- Allowed connection test to be set in local config