### PR TITLE
Fix southern hemisphere returning DEC <-90

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.9.12 - Updates**
+- Fix southern hemisphere returning incorrect DEC values
+
 **V1.9.11 - Updates**
 - Add support for focuser on E1 motor for MKS board. 
 - Add focuser command support to LX200 protocol.

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.11"
+#define VERSION "V1.9.12"

--- a/src/Declination.cpp
+++ b/src/Declination.cpp
@@ -107,6 +107,6 @@ Declination Declination::FromSeconds(long seconds)
 const char *Declination::formatString(char *targetBuffer, const char *format, long *) const
 {
   long secs = totalSeconds;
-  secs = NORTHERN_HEMISPHERE ? (secs + arcSecondsPerHemisphere/2) : (-arcSecondsPerHemisphere/2 - secs);
+  secs = NORTHERN_HEMISPHERE ? (secs + arcSecondsPerHemisphere/2) : (secs - arcSecondsPerHemisphere/2);
   return DayTime::formatString(targetBuffer, format, &secs);
 }

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1219,7 +1219,7 @@ const Declination Mount::currentDEC() const {
   //LOGV2(DEBUG_MOUNT_VERBOSE,F("CurrentDEC: DEC Steps  : %d"), _stepperDEC->currentPosition());
   //LOGV2(DEBUG_MOUNT_VERBOSE,F("CurrentDEC: POS        : %s"), String(degreePos).c_str());
 
-  if (degreePos > 0)
+  if (degreePos > 0 && NORTHERN_HEMISPHERE)
   {
     degreePos = -degreePos;
     //LOGV1(DEBUG_MOUNT_VERBOSE,F("CurrentDEC: Greater Zero, flipping."));


### PR DESCRIPTION
As discussed on Discord with @ClutchplateDude. Was previously receiving nonsense DEC values of -135 that would crash OATControl. Now both target and current DEC displays work as expected.
Changes only affect southern hemisphere.