### PR TITLE
ESP32 make use of Serial.begin(baud-rate, protocol, RX pin, TX pin) for using 2 hardware serial

### DIFF
--- a/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
+++ b/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
@@ -1,10 +1,30 @@
 /**
  * @brief a pins configuration file for an ESP32-based OAT.
+ * 
+ *    3.3V  -|                  |-  GND
+ *    EN    -|                  |-  23
+ *    VP    -|                  |-  22
+ *    VN    -|                  |-  TX
+ *    34    -|                  |-  RX
+ *    35    -|                  |-  21
+ *    32    -|                  |-  GND
+ *    33    -|                  |-  19
+ *    25    -|                  |-  18
+ *    26    -|      ESP32       |-  5
+ *    27    -|      DevKit C    |-  17
+ *    14    -|      V4          |-  16
+ *    12    -|                  |-  4
+ *    GND   -|                  |-  0
+ *    13    -|                  |-  2
+ *    D2    -|                  |-  15
+ *    D3    -|                  |-  D1
+ *    CMD   -|                  |-  D0
+ *    5V    -|                  |-  CLK
  */
 
 #pragma once
 
-/*/ DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
+// DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  13  
 #endif
@@ -29,7 +49,7 @@
 #ifndef DEC_IN4_PIN
   #define DEC_IN4_PIN  32  
 #endif
-*/
+
 // DRIVER_TYPE_TMC2209_UART requires 4 digital pins in Arduino pin numbering
 #ifndef RA_STEP_PIN
   #define RA_STEP_PIN 18  // STEP

--- a/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
+++ b/boards/ESP32_ESP32DEV/pins_ESP32DEV.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-// DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
+/*/ DRIVER_TYPE_ULN2003 requires 4 digital outputs in Arduino pin numbering
 #ifndef RA_IN1_PIN
   #define RA_IN1_PIN  13  
 #endif
@@ -29,19 +29,21 @@
 #ifndef DEC_IN4_PIN
   #define DEC_IN4_PIN  32  
 #endif
+*/
 // DRIVER_TYPE_TMC2209_UART requires 4 digital pins in Arduino pin numbering
 #ifndef RA_STEP_PIN
-  #define RA_STEP_PIN 19  // STEP
+  #define RA_STEP_PIN 18  // STEP
 #endif
 #ifndef RA_DIR_PIN
-  #define RA_DIR_PIN  21  // DIR
+  #define RA_DIR_PIN  5  // DIR
 #endif
 #ifndef RA_EN_PIN
-  #define RA_EN_PIN   22  // Enable
+  #define RA_EN_PIN   19  // Enable
 #endif
 #ifndef RA_DIAG_PIN
-  #define RA_DIAG_PIN 23  // only needed for autohome function
+  #define RA_DIAG_PIN 3  // only needed for autohome function
 #endif
+/*
 #ifndef RA_MS0_PIN
   #define RA_MS0_PIN  4
 #endif
@@ -50,27 +52,35 @@
 #endif
 #ifndef RA_MS2_PIN
   #define RA_MS2_PIN  2
-#endif    
+#endif 
+*/   
 // DRIVER_TYPE_TMC2209_UART HardwareSerial port, can be shared across all drivers
 #ifndef RA_SERIAL_PORT
   #define RA_SERIAL_PORT Serial2
+#endif
+#ifndef RA_SERIAL_PORT_RX
+  #define RA_SERIAL_PORT_RX 16
+#endif
+#ifndef RA_SERIAL_PORT_TX
+  #define RA_SERIAL_PORT_TX 17
 #endif
 #ifndef RA_DRIVER_ADDRESS
   #define RA_DRIVER_ADDRESS 0b00  // Set by MS1/MS2. LOW/LOW in this case
 #endif
 // DRIVER_TYPE_TMC2209_UART requires 4 digital pins in Arduino pin numbering
 #ifndef DEC_STEP_PIN
-  #define DEC_STEP_PIN 16  // STEP
+  #define DEC_STEP_PIN 2  // STEP
 #endif
 #ifndef DEC_DIR_PIN
-  #define DEC_DIR_PIN  17  // DIR
+  #define DEC_DIR_PIN  15  // DIR
 #endif
 #ifndef DEC_EN_PIN
-  #define DEC_EN_PIN   5  // Enable
+  #define DEC_EN_PIN   25  // Enable
 #endif
 #ifndef DEC_DIAG_PIN
-  #define DEC_DIAG_PIN 18  // only needed for autohome function
+  #define DEC_DIAG_PIN 4  // only needed for autohome function
 #endif
+/*
 #ifndef DEC_MS0_PIN
   #define DEC_MS0_PIN  15
 #endif
@@ -80,9 +90,16 @@
 #ifndef DEC_MS2_PIN
   #define DEC_MS2_PIN  7
 #endif
+*/
 // DRIVER_TYPE_TMC2209_UART HardwareSerial port, can be shared across all drivers
 #ifndef DEC_SERIAL_PORT
   #define DEC_SERIAL_PORT Serial2 // SoftwareSerial TX port
+#endif
+#ifndef DEC_SERIAL_PORT_RX
+  #define DEC_SERIAL_PORT_RX 16
+#endif
+#ifndef DEC_SERIAL_PORT_TX
+  #define DEC_SERIAL_PORT_TX 17
 #endif
 #ifndef DEC_DRIVER_ADDRESS
   #define DEC_DRIVER_ADDRESS 0b01  // Set by MS1/MS2 (MS1 HIGH, MS2 LOW)
@@ -90,13 +107,23 @@
 
 #define SW_SERIAL_UART 0
 
+#ifndef GPS_SERIAL_PORT
+  #define GPS_SERIAL_PORT Serial1 // REMAP GPIO 27/26 to Serial1
+#endif
+#ifndef GPS_SERIAL_TX_PIN
+  #define GPS_SERIAL_TX_PIN 27
+#endif
+#ifndef GPS_SERIAL_RX_PIN
+  #define GPS_SERIAL_RX_PIN 26
+#endif
+
 // DISPLAY_TYPE_LCD_JOY_I2C_SSD1306 requires 3 analog inputs in Arduino pin numbering
 #ifndef LCD_KEY_SENSE_X_PIN
-  #define LCD_KEY_SENSE_X_PIN 34
+  #define LCD_KEY_SENSE_X_PIN 32
 #endif
 #ifndef LCD_KEY_SENSE_Y_PIN
-  #define LCD_KEY_SENSE_Y_PIN 39
+  #define LCD_KEY_SENSE_Y_PIN 35
 #endif
 #ifndef LCD_KEY_SENSE_PUSH_PIN
-  #define LCD_KEY_SENSE_PUSH_PIN 36
+  #define LCD_KEY_SENSE_PUSH_PIN 34
 #endif

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -106,7 +106,11 @@ void setup() {
 #endif
 
   #if USE_GPS == 1
-  GPS_SERIAL_PORT.begin(GPS_BAUD_RATE);
+    #if defined(ESP32)
+      GPS_SERIAL_PORT.begin(GPS_BAUD_RATE, SERIAL_8N1, GPS_SERIAL_RX_PIN, GPS_SERIAL_TX_PIN);
+    #elif
+      GPS_SERIAL_PORT.begin(GPS_BAUD_RATE);
+    #endif
   #endif
 
   //Turn on dew heater
@@ -152,10 +156,16 @@ void setup() {
       pinMode(RA_EN_PIN, OUTPUT);
       digitalWrite(RA_EN_PIN, LOW);
       #ifdef RA_SERIAL_PORT
-        RA_SERIAL_PORT.begin(57600);  // Start HardwareSerial comms with driver
+        #if defined(ESP32)
+          RA_SERIAL_PORT.begin(57600, SERIAL_8N1, RA_SERIAL_PORT_RX, RA_SERIAL_PORT_TX);  // Start HardwareSerial comms with driver
+        #else
+          RA_SERIAL_PORT.begin(57600);
+        #endif
       #endif
     #endif
   #endif
+
+
   #if DEC_STEPPER_TYPE == STEPPER_TYPE_NEMA17  // DEC driver startup (for A4988)
     #if DEC_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC  // DEC driver startup (for A4988)
       digitalWrite(DEC_EN_PIN, HIGH);
@@ -191,10 +201,15 @@ void setup() {
       //pinMode(DEC_MS1_PIN, OUTPUT);
       //digitalWrite(DEC_MS1_PIN, HIGH); // Logic HIGH to MS1 to get 0b01 address
       #ifdef DEC_SERIAL_PORT
-        DEC_SERIAL_PORT.begin(57600);  // Start HardwareSerial comms with driver
+        #if defined(ESP32)
+          DEC_SERIAL_PORT.begin(57600, SERIAL_8N1, DEC_SERIAL_PORT_RX, DEC_SERIAL_PORT_TX);  // Start HardwareSerial comms with driver
+        #else
+          DEC_SERIAL_PORT.begin(57600);
+        #endif
       #endif
     #endif
   #endif
+
   
   #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
     #if AZ_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC || AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE || AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART  


### PR DESCRIPTION
Changed/updated boarddefinition
Added ESP specific (baud-rate, protocol, RX pin, TX pin), to allow usage of Serial1 and Serial2.
So TMC2209s use Serial2 and GPS use Serial1.