### PR TITLE
Fix southern hemisphere -12hr RA offset

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 **V1.9.17 - Updates**
-- Fix southern hemisphere -12hr RA offset
+- Fix southern hemisphere returning RA offset by -12hr
 
 **V1.9.16 - Updates**
 - Add Meade extension command to move steppers by steps.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.9.17 - Updates**
+- Fix southern hemisphere -12hr RA offset
+
 **V1.9.16 - Updates**
 - Add Meade extension command to move steppers by steps.
 

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.16"
+#define VERSION "V1.9.17"

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1192,9 +1192,7 @@ const DayTime Mount::currentRA() const {
   // LOGV2(DEBUG_MOUNT_VERBOSE,F("CurrentRA: ZeroPos    : %s"), _zeroPosRA.ToString());
   // LOGV2(DEBUG_MOUNT_VERBOSE,F("CurrentRA: POS (+zp)  : %s"), DayTime(hourPos).ToString());
 
-  bool flipRA = NORTHERN_HEMISPHERE ?
-    _stepperDEC->currentPosition() < 0
-    : _stepperDEC->currentPosition() > 0;
+  bool flipRA = _stepperDEC->currentPosition() < 0;
   if (flipRA)
   {
     hourPos += 12;


### PR DESCRIPTION
RA was being flipped the wrong way which did not affect slewing, but would display the mount upside down in software.

I see there are other PRs ready to go, so maybe I should wait to update the version and changelog?