### PR TITLE
Small guiding improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.9.18 - Updates**
+- Fix RA guiding multiplier not being applied correct
+
 **V1.9.17 - Updates**
 - Fix southern hemisphere returning RA offset by -12hr
 

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.17"
+#define VERSION "V1.9.18"

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1412,8 +1412,8 @@ void Mount::guidePulse(byte direction, int duration) {
 
     case EAST:
     // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-    LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  TRK.setSpeed(%f)"), (raGuidingSpeed * (-1.0f * RA_PULSE_MULTIPLIER + 1) + raGuidingSpeed));
-    _stepperTRK->setSpeed(raGuidingSpeed * (-1.0f * RA_PULSE_MULTIPLIER + 1) + raGuidingSpeed);   // Slower than siderael
+    LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  TRK.setSpeed(%f)"), (raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER)));
+    _stepperTRK->setSpeed(raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER));   // Slower than siderael
     _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
     _guideRaEndTime = millis() + duration;
     break;

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -245,8 +245,8 @@ void Mount::configureRAStepper(byte pin1, byte pin2, int maxSpeed, int maxAccele
   // Use another AccelStepper to run the RA motor as well. This instance tracks earths rotation.
   _stepperTRK = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
 
-  _stepperTRK->setMaxSpeed(10000);
-  _stepperTRK->setAcceleration(5000);
+  _stepperTRK->setMaxSpeed(2000);
+  _stepperTRK->setAcceleration(15000);
 
   _stepperRA->setPinsInverted(NORTHERN_HEMISPHERE == RA_INVERT_DIR, false, false);
   _stepperTRK->setPinsInverted(NORTHERN_HEMISPHERE == RA_INVERT_DIR, false, false);
@@ -289,8 +289,8 @@ void Mount::configureDECStepper(byte pin1, byte pin2, int maxSpeed, int maxAccel
   // Use another AccelStepper to run the DEC motor as well. This instance is used for guiding.
   _stepperGUIDE = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
 
-  _stepperGUIDE->setMaxSpeed(10000);
-  _stepperGUIDE->setAcceleration(5000);
+  _stepperGUIDE->setMaxSpeed(2000);
+  _stepperGUIDE->setAcceleration(15000);
 
   #if DEC_INVERT_DIR == 1
   _stepperDEC->setPinsInverted(true, false, false);
@@ -1404,16 +1404,16 @@ void Mount::guidePulse(byte direction, int duration) {
 
     case WEST:
     // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-    LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  TRK.setSpeed(%f)"), (RA_PULSE_MULTIPLIER + 1) * raGuidingSpeed);
-    _stepperTRK->setSpeed((RA_PULSE_MULTIPLIER + 1) * raGuidingSpeed);   // Faster than siderael
+    LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  TRK.setSpeed(%f)"), (RA_PULSE_MULTIPLIER * raGuidingSpeed));
+    _stepperTRK->setSpeed(RA_PULSE_MULTIPLIER * raGuidingSpeed);   // Faster than siderael
     _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
     _guideRaEndTime = millis() + duration;
     break;
 
     case EAST:
     // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-    LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  TRK.setSpeed(%f)"), (RA_PULSE_MULTIPLIER - 1) * raGuidingSpeed);
-    _stepperTRK->setSpeed((RA_PULSE_MULTIPLIER - 1) * raGuidingSpeed);   // Slower than siderael
+    LOGV2(DEBUG_STEPPERS, F("STEP-guidePulse:  TRK.setSpeed(%f)"), (raGuidingSpeed * (-1.0f * RA_PULSE_MULTIPLIER + 1) + raGuidingSpeed));
+    _stepperTRK->setSpeed(raGuidingSpeed * (-1.0f * RA_PULSE_MULTIPLIER + 1) + raGuidingSpeed);   // Slower than siderael
     _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
     _guideRaEndTime = millis() + duration;
     break;


### PR DESCRIPTION
1. Speeds for TRK and GUIDE stepper instances should not exceed the maximum achievable speeds of accelstepper
2. Assuming a trackingspeed of 10 for simplicity sake, and a RA_PULSE_MULTIPLIER of e.g. 1.1, West speed should be 11 and East speed should be 9, not 21 W / 1 E. This also caused the East/West guidespeeds at the default multiplier of 1.5 to be wrong, at 25W / 5E. It must be 15W / 5E