### PR TITLE
Fix southern hemisphere reversed DEC free slew directions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.9.21 - Updates**
+- Fix southern hemisphere reversed DEC free slew directions
+
 **V1.9.20 - Updates**
 - Made github version check more robust
 

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.20"
+#define VERSION "V1.9.21"

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2199,7 +2199,7 @@ void Mount::startSlewing(int direction) {
       #endif
 
       if (direction & NORTH) {
-        long targetLocation = sign * 300000;
+        long targetLocation = 300000;
         if (_decUpperLimit != 0) {
           targetLocation = _decUpperLimit;
           LOGV3(DEBUG_STEPPERS, F("STEP-startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l"), _decUpperLimit, targetLocation);
@@ -2213,7 +2213,7 @@ void Mount::startSlewing(int direction) {
       }
 
       if (direction & SOUTH) {
-        long targetLocation = -sign * 300000;
+        long targetLocation = -300000;
         if (_decLowerLimit != 0) {
           targetLocation = _decLowerLimit;
           LOGV3(DEBUG_STEPPERS, F("STEP-startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l"), _decLowerLimit, targetLocation);


### PR DESCRIPTION
North/south directions were reversed. Tested with LCD buttons, OATControl, APT (ASCOM).