### PR TITLE
Focuser Always On

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.9.23 - Updates**
+- Add option to keep focuser motor enabled after moving.
+
 **V1.9.22 - Updates**
 - Add focuser pins for MKS Gen L v2.0.
 

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -422,6 +422,9 @@
       #define USE_VREF 0      //By default Vref is ignored when using UART to specify rms current. Only enable if you know what you are doing.
     #endif
   #endif
+  #ifndef FOCUSER_ALWAYS_ON
+    #define FOCUSER_ALWAYS_ON 0
+  #endif
 #endif
 
 #if DISPLAY_TYPE != DISPLAY_TYPE_NONE

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.22"
+#define VERSION "V1.9.23"

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2438,7 +2438,9 @@ void Mount::loop() {
       // either been stopped, or reached the target.
       _focuserMode = FOCUS_IDLE;
       _focuserWasRunning = false;
+    #if FOCUSER_ALWAYS_ON != 0
       disableFocusMotor();
+    #endif
     }
 
   #endif

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2438,7 +2438,7 @@ void Mount::loop() {
       // either been stopped, or reached the target.
       _focuserMode = FOCUS_IDLE;
       _focuserWasRunning = false;
-    #if FOCUSER_ALWAYS_ON != 0
+    #if FOCUSER_ALWAYS_ON == 0
       disableFocusMotor();
     #endif
     }


### PR DESCRIPTION
Add the option to keep the focuser motor enabled at all times to prevent focus shift (Default is to disable when not moving).