### PR TITLE
V1.9.36 Changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.9.35 - Updates**
+- Enable configuration of hold current setting for AZ and ALT steppers when always energized
+.
 **V1.9.34 - Updates**
 - Added two Meade commands: :XGDP# and :XSDPnnn# to retrieve and set the DEC parking offset.
 - Fixed a bug that incorrectly returned a Homing status when the Hall sensor was enabled.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+**V1.9.36 - Updates**
+- Removed auto-homing code that was based on stall guard
+- Converted Hall sensor based auto homing to be asynchronous (via state machine) instead of blocking
+- Allowed user to specify the distance (number of hours) to search for Hall sensor in Meade command
+- Allowed overriding the guide pulse multiplier in local config
+
 **V1.9.35 - Updates**
 - Enable configuration of hold current setting for AZ and ALT steppers when always energized
 .

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -368,6 +368,10 @@
     #if (AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #define AZ_RMSCURRENT AZ_MOTOR_CURRENT_RATING *(AZ_OPERATING_CURRENT_SETTING / 100.0f) / 1.414f
 
+        #ifndef AZ_MOTOR_HOLD_SETTING
+            #define AZ_MOTOR_HOLD_SETTING 100
+        #endif
+
         #define AZ_STALL_VALUE 10  // adjust this value if the RA autohoming sequence often false triggers, or triggers too late
 
         #ifndef USE_VREF
@@ -452,6 +456,10 @@
     // These settings work only with TMC2209 in UART connection (single wire to TX)
     #if (ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #define ALT_RMSCURRENT ALT_MOTOR_CURRENT_RATING *(ALT_OPERATING_CURRENT_SETTING / 100.0f) / 1.414f
+
+        #ifndef ALT_MOTOR_HOLD_SETTING
+            #define ALT_MOTOR_HOLD_SETTING 100
+        #endif
 
         #define ALT_STALL_VALUE 10  // adjust this value if the RA autohoming sequence often false triggers, or triggers too late
 

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -147,8 +147,7 @@
 
     #define RA_STALL_VALUE  100  // adjust this value if the RA autohoming sequence often false triggers, or triggers too late
     #define DEC_STALL_VALUE 10   // adjust this value if the RA autohoming sequence often false triggers, or triggers too late
-    #define USE_AUTOHOME    0    // Autohome with TMC2209 stall detection:  ON = 1  |  OFF = 0
-    //                  ^^^ leave at 0 for now, doesnt work properly yet
+
     #ifndef RA_AUDIO_FEEDBACK
         #define RA_AUDIO_FEEDBACK                                                                                                          \
             0  // If one of these are set to 1, the respective driver will shut off the stealthchop mode, resulting in a audible whine
@@ -236,7 +235,9 @@
 #if RA_STEPPER_TYPE == STEPPER_TYPE_28BYJ48
     #define RA_PULSE_MULTIPLIER 1.0f
 #elif RA_STEPPER_TYPE == STEPPER_TYPE_NEMA17
-    #define RA_PULSE_MULTIPLIER 1.5f
+    #ifndef RA_PULSE_MULTIPLIER
+        #define RA_PULSE_MULTIPLIER 1.5f
+    #endif
 #else
     #error New RA Stepper type? Add it here...
 #endif
@@ -244,7 +245,9 @@
 #if DEC_STEPPER_TYPE == STEPPER_TYPE_28BYJ48
     #define DEC_PULSE_MULTIPLIER 1.0f
 #elif DEC_STEPPER_TYPE == STEPPER_TYPE_NEMA17
-    #define DEC_PULSE_MULTIPLIER 1.0f
+    #ifndef DEC_PULSE_MULTIPLIER
+        #define DEC_PULSE_MULTIPLIER 1.0f
+    #endif
 #else
     #error New DEC Stepper type? Add it here...
 #endif

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.34"
+#define VERSION "V1.9.35"

--- a/Version.h
+++ b/Version.h
@@ -2,4 +2,4 @@
 // So 1.8.99 is ok, but 1.8.234 is not. Neither is 1.123.22
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
-#define VERSION "V1.9.35"
+#define VERSION "V1.9.36"

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1471,7 +1471,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         int distance = 2;
         if (inCmd.length() > 3)
         {
-            distance = clamp((int)inCmd.substring(3).toInt(), 1, 5);
+            distance = clamp((int) inCmd.substring(3).toInt(), 1, 5);
             LOGV2(DEBUG_MEADE, F("MEADE: Home by %d"), distance);
         }
 

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -505,7 +505,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //        "x" is either 'R' or 'L' and determines the direction in which the search starts (L is CW, R is CCW).
 //        "n" (Optional) is the maximum number of hours to move while searching for the sensor location. Defaults to 2h. Limited to the range 1h-5h.
 //      Remarks:
-//        The ring is first moved 30 degrees (or the given amount) in the initial direction. If no hall sensor is encountered, 
+//        The ring is first moved 30 degrees (or the given amount) in the initial direction. If no hall sensor is encountered,
 //        it will move twice the amount (60 degrees by default) in the opposite direction.
 //        If a hall sensor is not encountered during that slew, the homing exits with a failure.
 //        If the sensor is found, it will slew to the middle position of the Hall sensor trigger range and then to the offset
@@ -1469,11 +1469,9 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     else if ((inCmd[0] == 'H') && (inCmd.length() > 2) && inCmd[1] == 'R')
     {
         int distance = 2;
-        if (inCmd.length() > 3) 
+        if (inCmd.length() > 3)
         {
-            distance = inCmd.substring(3).toInt();
-            if (distance < 1) distance = 1;
-            if (distance > 5) distance = 5;
+            distance = clamp((int)inCmd.substring(3).toInt(), 1, 5);
             LOGV2(DEBUG_MEADE, F("MEADE: Home by %d"), distance);
         }
 

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1468,31 +1468,27 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     }
     else if ((inCmd[0] == 'H') && (inCmd.length() > 2) && inCmd[1] == 'R')
     {
+#if USE_HALL_SENSOR_RA_AUTOHOME == 1
         int distance = 2;
         if (inCmd.length() > 3)
         {
             distance = clamp((int) inCmd.substring(3).toInt(), 1, 5);
-            LOGV2(DEBUG_MEADE, F("MEADE: Home by %d"), distance);
+            LOGV2(DEBUG_MEADE, F("MEADE: RA AutoHome by %dh"), distance);
         }
 
         if (inCmd[2] == 'R')  // :MHRR
         {
-#if USE_HALL_SENSOR_RA_AUTOHOME == 1
             _mount->findRAHomeByHallSensor(-1, distance);
             return "1";
-#else
-            return "0";
-#endif
         }
         else if (inCmd[2] == 'L')  // :MHRL
         {
-#if USE_HALL_SENSOR_RA_AUTOHOME == 1
             _mount->findRAHomeByHallSensor(1, distance);
             return "1";
-#else
-            return "0";
-#endif
         }
+#else
+        return "0";
+#endif
     }
 
     return "0";

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -496,24 +496,26 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        "1" if successfully scheduled
 //
-// :MHRx#
+// :MHRxn#
 //      Description:
 //        Home RA stepper via Hall sensor
 //      Information:
 //        This attempts to find the hall sensor and to home the RA ring accordingly.
 //      Parameters:
 //        "x" is either 'R' or 'L' and determines the direction in which the search starts (L is CW, R is CCW).
+//        "n" (Optional) is the maximum number of hours to move while searching for the sensor location. Defaults to 2h. Limited to the range 1h-5h.
 //      Remarks:
-//        The ring is first moved 30 degrees in the initial direction. If no hall sensor is encountered, it will move 60 degrees in
-//        the opposite direction. If a hall sensor is not encountered during that slew, the homing exits with a failure code (0).
+//        The ring is first moved 30 degrees (or the given amount) in the initial direction. If no hall sensor is encountered, 
+//        it will move twice the amount (60 degrees by default) in the opposite direction.
+//        If a hall sensor is not encountered during that slew, the homing exits with a failure.
 //        If the sensor is found, it will slew to the middle position of the Hall sensor trigger range and then to the offset
 //        specified in the Home offset position (set with the ":XSHRnnnn#" command).
 //        If the RA ring is positioned such that the Hall sensor is already triggered when the command is received, the mount will move
-//        the RA ring off the trigger in the opposite direction specified for a max of 7.5 degrees before searching 30 degrees in the
+//        the RA ring off the trigger in the opposite direction specified for a max of 15 degrees before searching 30 degrees in the
 //        specified direction.
 //      Returns:
-//        "1" if successfully homed RA
-//        "0" if the hall sensor could not be found or homing has not been enabled in the local config
+//        "1" returns if search is started
+//        "0" if homing has not been enabled in the local config
 //
 // :MAZn.nn#
 //      Description:
@@ -1466,13 +1468,32 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     }
     else if ((inCmd[0] == 'H') && (inCmd.length() > 2) && inCmd[1] == 'R')
     {
+        int distance = 2;
+        if (inCmd.length() > 3) 
+        {
+            distance = inCmd.substring(3).toInt();
+            if (distance < 1) distance = 1;
+            if (distance > 5) distance = 5;
+            LOGV2(DEBUG_MEADE, F("MEADE: Home by %d"), distance);
+        }
+
         if (inCmd[2] == 'R')  // :MHRR
         {
-            return _mount->findRAHomeByHallSensor(-1) ? "1" : "0";
+#if USE_HALL_SENSOR_RA_AUTOHOME == 1
+            _mount->findRAHomeByHallSensor(-1, distance);
+            return "1";
+#else
+            return "0";
+#endif
         }
         else if (inCmd[2] == 'L')  // :MHRL
         {
-            return _mount->findRAHomeByHallSensor(1) ? "1" : "0";
+#if USE_HALL_SENSOR_RA_AUTOHOME == 1
+            _mount->findRAHomeByHallSensor(1, distance);
+            return "1";
+#else
+            return "0";
+#endif
         }
     }
 

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2509,10 +2509,15 @@ void Mount::stopSlewing(int direction)
         LOGV1(DEBUG_STEPPERS, F("STEP-stopSlewing: DEC stepper stop()"));
         _stepperDEC->stop();
     }
+
     if ((direction & (WEST | EAST)) != 0)
     {
         LOGV1(DEBUG_STEPPERS, F("STEP-stopSlewing: RA stepper stop()"));
         _stepperRA->stop();
+        if (isFindingHome())
+        {
+            _mountStatus &= ~STATUS_FINDING_HOME;
+        }
     }
 }
 

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -627,7 +627,7 @@ void Mount::configureAZdriver(Stream *serial, float rsense, byte driveraddress, 
     _driverAZ->I_scale_analog(false);
         #endif
     LOGV2(DEBUG_STEPPERS, F("Mount: Requested AZ motor rms_current: %d mA"), rmscurrent);
-    _driverAZ->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
+    _driverAZ->rms_current(rmscurrent, AZ_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverAZ->toff(1);
     _driverAZ->en_spreadCycle(0);
     _driverAZ->blank_time(24);
@@ -665,7 +665,7 @@ void Mount::configureAZdriver(uint16_t AZ_SW_RX, uint16_t AZ_SW_TX, float rsense
     _driverAZ->I_scale_analog(false);
         #endif
     LOGV2(DEBUG_STEPPERS, F("Mount: Requested AZ motor rms_current: %d mA"), rmscurrent);
-    _driverAZ->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
+    _driverAZ->rms_current(rmscurrent, AZ_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverAZ->toff(1);
     _driverAZ->en_spreadCycle(0);
     _driverAZ->blank_time(24);
@@ -708,7 +708,7 @@ void Mount::configureALTdriver(Stream *serial, float rsense, byte driveraddress,
     _driverALT->I_scale_analog(false);
         #endif
     LOGV2(DEBUG_STEPPERS, F("Mount: Requested ALT motor rms_current: %d mA"), rmscurrent);
-    _driverALT->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
+    _driverALT->rms_current(rmscurrent, ALT_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverALT->toff(1);
     _driverALT->en_spreadCycle(0);
     _driverALT->blank_time(24);
@@ -746,7 +746,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
     _driverALT->I_scale_analog(false);
         #endif
     LOGV2(DEBUG_STEPPERS, F("Mount: Requested ALT motor rms_current: %d mA"), rmscurrent);
-    _driverALT->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
+    _driverALT->rms_current(rmscurrent, ALT_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverALT->toff(1);
     _driverALT->en_spreadCycle(0);
     _driverALT->blank_time(24);

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -46,8 +46,8 @@ enum HomingState
     HOMING_NOT_ACTIVE
 };
 
-#define HOMING_START_PIN_POSITION 0
-#define HOMING_END_PIN_POSITION 1
+    #define HOMING_START_PIN_POSITION 0
+    #define HOMING_END_PIN_POSITION   1
 
 struct HomingData {
     HomingState state;

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -31,18 +31,36 @@ class TMC2209Stepper;
 #if USE_HALL_SENSOR_RA_AUTOHOME == 1
 enum HomingState
 {
-    HOMING_PIN_FINDING_START,
-    HOMING_PIN_FINDING_END,
-    HOMING_PIN_FOUND,
+    HOMING_MOVE_OFF,
+    HOMING_MOVING_OFF,
+    HOMING_STOP_AT_TIME,
+    HOMING_WAIT_FOR_STOP,
+    HOMING_START_FIND_START,
+    HOMING_FINDING_START,
+    HOMING_FINDING_START_REVERSE,
+    HOMING_FINDING_END,
+    HOMING_RANGE_FOUND,
+    HOMING_FAILED,
+    HOMING_SUCCESSFUL,
+
     HOMING_NOT_ACTIVE
 };
 
+#define HOMING_START_PIN_POSITION 0
+#define HOMING_END_PIN_POSITION 1
+
 struct HomingData {
     HomingState state;
+    HomingState nextState;
     int pinState;
     int lastPinState;
-    long position[HomingState::HOMING_PIN_FINDING_END + 1];
+    int savedRate;
+    int initialDir;
+    int searchDistance;
+    long position[2];
     long offsetRA;
+    long startPos;
+    unsigned long stopAt;
 };
 #endif
 
@@ -385,7 +403,10 @@ class Mount
     void focusStop();
 #endif
 
-    bool findRAHomeByHallSensor(int initialDirection);
+#if USE_HALL_SENSOR_RA_AUTOHOME == 1
+    bool findRAHomeByHallSensor(int initialDirection, int searchDistance);
+    void processRAHomingProgress();
+#endif
     void setHomingOffset(StepperAxis axis, long offset);
     long getHomingOffset(StepperAxis axis);
 

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -74,7 +74,7 @@ bool processStartupKeys()
                             startupState = StartupSetRoll;
                             LOGV1(DEBUG_INFO, F("STARTUP: State is set roll!"));
         #else
-                            startupState   = StartupSetHATime;
+                            startupState = StartupSetHATime;
         #endif
                         }
                         else if (isInHomePosition == NO)

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -79,24 +79,6 @@ bool processStartupKeys()
                         }
                         else if (isInHomePosition == NO)
                         {
-        #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART && USE_AUTOHOME == 1
-                            mount.startFindingHomeDEC();
-                            if (mount.isFindingHome())
-                            {
-                                startupState = StartupWaitForPoleCompletion;
-                                lcdMenu.clear();
-                                lcdMenu.setCursor(0, 0);
-                                lcdMenu.printMenu("Finding Home....");
-                                lcdMenu.setCursor(0, 1);
-                                lcdMenu.printMenu("Please Wait");
-                                //break;
-                            }
-                            else
-                            {
-                                startupState = StartupSetHATime;
-                            }
-
-        #else
                             startupState   = StartupWaitForPoleCompletion;
                             inStartup      = false;
                             okToUpdateMenu = false;
@@ -106,7 +88,6 @@ bool processStartupKeys()
 
                             // Skip the 'Manual control' prompt
                             setControlMode(true);
-        #endif
                         }
                         else if (isInHomePosition == CANCEL)
                         {


### PR DESCRIPTION
- Removed auto-homing code that was based on stall guard
- Converted Hall sensor based auto homing to be asynchronous (via state machine) instead of blocking
- Allowed user to specify the distance (number of hours) to search for Hall sensor in Meade command
- Allowed overriding the guide pulse multiplier in local config
