### PR TITLE
Allow setting DEC limits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
-**V1.10.1 - Updates**
+**V1.10.02 - Updates**
+- Add optional parameter to Meade Extension commands :XSDLL# and :XSDLU# to allow direct setting of DEC limits
+
+**V1.10.01 - Updates**
 - fix a bug with "Set Home" on OAM
 
 **V1.10.0 - Updates**

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,10 @@
-**V1.10.03 - Updates**
+**V1.10.3 - Updates**
 - Add optional parameter to Meade Extension commands :XSDLL# and :XSDLU# to allow direct setting of DEC limits
 
-**V1.10.02 - Updates**
+**V1.10.2 - Updates**
 - Revise default MKS LCD pins to match ribbon cable LCD assembly.
 
-**V1.10.01 - Updates**
+**V1.10.1 - Updates**
 - fix a bug with "Set Home" on OAM
 
 **V1.10.0 - Updates**

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.10.03"
+#define VERSION "V1.10.3"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.10.1"
+#define VERSION "V1.10.02"

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -854,7 +854,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Set DEC upper limit
 //      Information:
-//        Set the upper limit for the DEC stepper motor to the current position if no parameter is given, 
+//        Set the upper limit for the DEC stepper motor to the current position if no parameter is given,
 //        otherwise to the given parameter.
 //      Parameters:
 //        "nnnnn" is the number of steps from home that the DEC ring can travel upwards
@@ -873,7 +873,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Set DEC lower limit
 //      Information:
-//        Set the lowerlimit for the DEC stepper motor to the current position if no parameter is given, 
+//        Set the lowerlimit for the DEC stepper motor to the current position if no parameter is given,
 //        otherwise to the given parameter.
 //      Parameters:
 //        "nnnnn" is the number of steps from home that the DEC ring can travel downwards

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -384,9 +384,9 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //
 // :SHHH:MM#
 //      Description:
-//        Set Hour Time (HA)
+//        Set HA (Hour Angle of Polaris)
 //      Information:
-//        This sets the scopes HA.
+//        This sets the scopes HA, which should be that of Polaris.
 //      Returns:
 //        "1" if successfully set
 //        "0" otherwise
@@ -753,9 +753,9 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //
 // :XGH#
 //      Description:
-//        Get HA
+//        Get HA (Hour Angle of Polaris)
 //      Information:
-//        Get the current HA of the mount.
+//        Get the current HA of Polaris that the mount thinks it is.
 //      Returns:
 //        "HHMMSS#"
 //
@@ -850,11 +850,14 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        nothing
 //
-// :XSDLU#
+// :XSDLUnnnnn#
 //      Description:
 //        Set DEC upper limit
 //      Information:
-//        Set the upper limit for the DEC stepper motor to the current position
+//        Set the upper limit for the DEC stepper motor to the current position if no parameter is given, 
+//        otherwise to the given parameter.
+//      Parameters:
+//        "nnnnn" is the number of steps from home that the DEC ring can travel upwards
 //      Returns:
 //        nothing
 //
@@ -866,11 +869,14 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        nothing
 //
-// :XSDLL#
+// :XSDLLnnnnn#
 //      Description:
 //        Set DEC lower limit
 //      Information:
-//        Set the lowerlimit for the DEC stepper motor to the current position
+//        Set the lowerlimit for the DEC stepper motor to the current position if no parameter is given, 
+//        otherwise to the given parameter.
+//      Parameters:
+//        "nnnnn" is the number of steps from home that the DEC ring can travel downwards
 //      Returns:
 //        nothing
 //
@@ -1666,11 +1672,25 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
             {
                 if (inCmd[3] == 'L')  // :XSDLL
                 {
-                    _mount->setDecLimitPosition(false);
+                    if (inCmd.length() > 4)
+                    {
+                        _mount->setDecLimitPositionAbs(false, inCmd.substring(4).toInt());
+                    }
+                    else
+                    {
+                        _mount->setDecLimitPosition(false);
+                    }
                 }
                 else if (inCmd[3] == 'U')  // :XSDLU
                 {
-                    _mount->setDecLimitPosition(true);
+                    if (inCmd.length() > 4)
+                    {
+                        _mount->setDecLimitPositionAbs(true, inCmd.substring(4).toInt());
+                    }
+                    else
+                    {
+                        _mount->setDecLimitPosition(true);
+                    }
                 }
                 else if (inCmd[3] == 'l')  // :XSDLl
                 {

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -3014,7 +3014,6 @@ void Mount::setDecLimitPositionAbs(bool upper, long stepperPos)
     }
 }
 
-
 /////////////////////////////////
 //
 // clearDecLimitPosition

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2990,19 +2990,30 @@ void Mount::setDecParkingOffset(long offset)
 /////////////////////////////////
 void Mount::setDecLimitPosition(bool upper)
 {
+    setDecLimitPositionAbs(upper, _stepperDEC->currentPosition());
+}
+
+/////////////////////////////////
+//
+// setDecLimitPositionAbs
+//
+/////////////////////////////////
+void Mount::setDecLimitPositionAbs(bool upper, long stepperPos)
+{
     if (upper)
     {
-        _decUpperLimit = _stepperDEC->currentPosition();
+        _decUpperLimit = stepperPos;
         EEPROMStore::storeDECUpperLimit(_decUpperLimit);
         LOGV3(DEBUG_MOUNT, F("Mount::setDecLimitPosition(Upper): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
     }
     else
     {
-        _decLowerLimit = _stepperDEC->currentPosition();
+        _decLowerLimit = stepperPos;
         EEPROMStore::storeDECLowerLimit(_decLowerLimit);
         LOGV3(DEBUG_MOUNT, F("Mount::setDecLimitPosition(Lower): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
     }
 }
+
 
 /////////////////////////////////
 //

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -309,6 +309,9 @@ class Mount
     // Set the DEC limit position to the current stepper position. If upper is true, sets the upper limit, else the lower limit.
     void setDecLimitPosition(bool upper);
 
+    // Set the DEC limit position to the given position. If upper is true, sets the upper limit, else the lower limit.
+    void setDecLimitPositionAbs(bool upper, long stepperPos);
+
     // Clear the DEC limit position. If upper is true, clears upper limit, else the lower limit.
     void clearDecLimitPosition(bool upper);
 


### PR DESCRIPTION
- Add optional parameter to Meade Extension commands :XSDLL# and :XSDLU# to allow direct setting of DEC limits
