### PR TITLE
Fix Enable Pin Logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+**V1.10.6 - Updates**
+- Use consistent enable pin logic for all drivers.
+- Increase maximum current for TMC2209 to 2A in accordance with BigTreeTech's published maximum continuous drive current.
+
 **V1.10.5 - Updates**
 - Add ability to disable tracking at boot by default
 

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -389,3 +389,31 @@
         #endif
     #endif
 #endif
+
+#if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
+    #if !defined(FOCUS_MICROSTEPPING)
+        #error "Altitude microstepping must be defined. Default is 4.0f for 28BYJ steppers, 4.0f for NEMA."
+    #endif
+    #if (FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
+        #if defined(FOCUS_MOTOR_CURRENT_RATING)
+            #if (FOCUS_MOTOR_CURRENT_RATING > 2000)
+                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
+            #endif
+            #if (FOCUS_MOTOR_CURRENT_RATING == 0)
+                #error                                                                                                                     \
+                    "Focuser current rating/setting cannot be zero. Please configure the current rating of your motor in you local configuration file using the FOCUS_MOTOR_CURRENT_RATING keyword."
+            #endif
+        #else
+            #error                                                                                                                         \
+                "FOCUS_MOTOR_CURRENT_RATING is not defined. Please define the current rating of your motor in you local configuration file using the FOCUS_MOTOR_CURRENT_RATING keyword."
+        #endif
+        #if defined(FOCUS_OPERATING_CURRENT_SETTING)
+            #if (FOCUS_OPERATING_CURRENT_SETTING <= 0) || (FOCUS_OPERATING_CURRENT_SETTING > 100)
+                #error "FOCUS_OPERATING_CURRENT_SETTING is not within acceptable range (0-100)"
+            #endif
+        #else
+            #error                                                                                                                         \
+                "FOCUS_OPERATING_CURRENT_SETTING is not defined. Please define the operating percentage of your motor in you local configuration file using the FOCUS_OPERATING_CURRENT_SETTING keyword."
+        #endif
+    #endif
+#endif

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -314,7 +314,7 @@
 #if (RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
     #if defined(RA_MOTOR_CURRENT_RATING)
         #if (RA_MOTOR_CURRENT_RATING > 2000)
-            #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
+            #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what you're doing"
         #endif
         #if (RA_MOTOR_CURRENT_RATING == 0)
             #error                                                                                                                         \
@@ -341,7 +341,7 @@
     #if (AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #if defined(AZ_MOTOR_CURRENT_RATING)
             #if (AZ_MOTOR_CURRENT_RATING > 2000)
-                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
+                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what you're doing"
             #endif
             #if (AZ_MOTOR_CURRENT_RATING == 0)
                 #error                                                                                                                     \
@@ -369,7 +369,7 @@
     #if (ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #if defined(ALT_MOTOR_CURRENT_RATING)
             #if (ALT_MOTOR_CURRENT_RATING > 2000)
-                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
+                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what you're doing"
             #endif
             #if (ALT_MOTOR_CURRENT_RATING == 0)
                 #error                                                                                                                     \
@@ -392,12 +392,12 @@
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
     #if !defined(FOCUS_MICROSTEPPING)
-        #error "Altitude microstepping must be defined. Default is 4.0f for 28BYJ steppers, 4.0f for NEMA."
+        #error "Focuser microstepping must be defined. Default is 4.0f for 28BYJ steppers, 4.0f for NEMA."
     #endif
     #if (FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #if defined(FOCUS_MOTOR_CURRENT_RATING)
             #if (FOCUS_MOTOR_CURRENT_RATING > 2000)
-                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
+                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what you're doing"
             #endif
             #if (FOCUS_MOTOR_CURRENT_RATING == 0)
                 #error                                                                                                                     \

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -290,8 +290,8 @@
 
 #if (DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
     #if defined(DEC_MOTOR_CURRENT_RATING)
-        #if (DEC_MOTOR_CURRENT_RATING > 1700)
-            #error "The TMC2209 driver is only rated up to 1.7A output. Delete this error if you know what youre doing"
+        #if (DEC_MOTOR_CURRENT_RATING > 2000)
+            #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
         #endif
         #if (DEC_MOTOR_CURRENT_RATING == 0)
             #error                                                                                                                         \
@@ -313,8 +313,8 @@
 
 #if (RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
     #if defined(RA_MOTOR_CURRENT_RATING)
-        #if (RA_MOTOR_CURRENT_RATING > 1700)
-            #error "The TMC2209 driver is only rated up to 1.7A output. Delete this error if you know what youre doing"
+        #if (RA_MOTOR_CURRENT_RATING > 2000)
+            #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
         #endif
         #if (RA_MOTOR_CURRENT_RATING == 0)
             #error                                                                                                                         \
@@ -340,8 +340,8 @@
     #endif
     #if (AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #if defined(AZ_MOTOR_CURRENT_RATING)
-            #if (AZ_MOTOR_CURRENT_RATING > 1700)
-                #error "The TMC2209 driver is only rated up to 1.7A output. Delete this error if you know what youre doing"
+            #if (AZ_MOTOR_CURRENT_RATING > 2000)
+                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
             #endif
             #if (AZ_MOTOR_CURRENT_RATING == 0)
                 #error                                                                                                                     \
@@ -368,8 +368,8 @@
     #endif
     #if (ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
         #if defined(ALT_MOTOR_CURRENT_RATING)
-            #if (ALT_MOTOR_CURRENT_RATING > 1700)
-                #error "The TMC2209 driver is only rated up to 1.7A output. Delete this error if you know what youre doing"
+            #if (ALT_MOTOR_CURRENT_RATING > 2000)
+                #error "The TMC2209 driver is only rated up to 2A output. Delete this error if you know what youre doing"
             #endif
             #if (ALT_MOTOR_CURRENT_RATING == 0)
                 #error                                                                                                                     \

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.10.5"
+#define VERSION "V1.10.6"

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -114,27 +114,12 @@ void setup()
     digitalWrite(DEW_HEATER_2_PIN, HIGH);
 #endif
 
-/////////////////////////////////
-//   Microstepping/driver pins
-/////////////////////////////////
-#if RA_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC
-    // include A4988 microstep pins
-    //#error "Define Microstep pins and delete this error."
-    digitalWrite(RA_EN_PIN, HIGH);
-    #if defined(RA_MS0_PIN)
-    digitalWrite(RA_MS0_PIN, HIGH);  // MS0
-    #endif
-    #if defined(RA_MS1_PIN)
-    digitalWrite(RA_MS1_PIN, HIGH);  // MS1
-    #endif
-    #if defined(RA_MS2_PIN)
-    digitalWrite(RA_MS2_PIN, HIGH);  // MS2
-    #endif
-#endif
-#if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE
-    // include TMC2209 Standalone pins
+    /////////////////////////////////
+    //   Microstepping/driver pins
+    /////////////////////////////////
     pinMode(RA_EN_PIN, OUTPUT);
     digitalWrite(RA_EN_PIN, LOW);  // ENABLE, LOW to enable
+#if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE || RA_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC
     #if defined(RA_MS0_PIN)
     digitalWrite(RA_MS0_PIN, HIGH);  // MS0
     #endif
@@ -148,45 +133,26 @@ void setup()
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     // include TMC2209 UART pins
     pinMode(RA_DIAG_PIN, INPUT);
-    pinMode(RA_EN_PIN, OUTPUT);
-    digitalWrite(RA_EN_PIN, LOW);
     #ifdef RA_SERIAL_PORT
     RA_SERIAL_PORT.begin(57600);  // Start HardwareSerial comms with driver
     #endif
 #endif
-#if DEC_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC  // DEC driver startup (for A4988)
-    digitalWrite(DEC_EN_PIN, HIGH);
-    #if defined(RA_MS0_PIN)
-    digitalWrite(DEC_MS0_PIN, HIGH);  // MS1
-    #endif
-    #if defined(RA_MS0_PIN)
-    digitalWrite(DEC_MS1_PIN, HIGH);  // MS2
-    #endif
-    #if defined(RA_MS0_PIN)
-    digitalWrite(DEC_MS2_PIN, HIGH);  // MS3
-    #endif
-#endif
-#if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE
-    // include TMC2209 Standalone pins
     pinMode(DEC_EN_PIN, OUTPUT);
     digitalWrite(DEC_EN_PIN, LOW);  // ENABLE, LOW to enable
-    #if defined(RA_MS0_PIN)
+#if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_STANDALONE || DEC_DRIVER_TYPE == DRIVER_TYPE_A4988_GENERIC
+    #if defined(DEC_MS0_PIN)
     digitalWrite(DEC_MS0_PIN, HIGH);  // MS1
     #endif
-    #if defined(RA_MS0_PIN)
+    #if defined(DEC_MS1_PIN)
     digitalWrite(DEC_MS1_PIN, HIGH);  // MS2
     #endif
-    #if defined(RA_MS0_PIN)
+    #if defined(DEC_MS2_PIN)
     digitalWrite(DEC_MS2_PIN, HIGH);  // MS3
     #endif
 #endif
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     // include TMC2209 UART pins
     pinMode(DEC_DIAG_PIN, INPUT);
-    pinMode(DEC_EN_PIN, OUTPUT);
-    digitalWrite(DEC_EN_PIN, LOW);
-    //pinMode(DEC_MS1_PIN, OUTPUT);
-    //digitalWrite(DEC_MS1_PIN, HIGH); // Logic HIGH to MS1 to get 0b01 address
     #ifdef DEC_SERIAL_PORT
     DEC_SERIAL_PORT.begin(57600);  // Start HardwareSerial comms with driver
     #endif


### PR DESCRIPTION
Use consistent enable pin logic for all drivers.

Increase maximum current for TMC2209 to 2A in accordance with BigTreeTech's published maximum continuous drive current.

Closes #155 