### PR TITLE
LOGVx -> INFO

### DIFF
--- a/src/DayTime.cpp
+++ b/src/DayTime.cpp
@@ -17,7 +17,7 @@ DayTime DayTime::ParseFromMeade(String const &s)
     DayTime result;
     int i    = 0;
     long sgn = 1;
-    LOGV2(DEBUG_MEADE, F("[DAYTIME]: Parse Coord from [%s]"), s.c_str());
+    INFO(DEBUG_MEADE, "[DAYTIME]: Parse Coord from [%s]", s.c_str());
     // Check whether we have a sign. This should be able to parse RA and DEC strings (RA never has a sign, and DEC should always have one).
     if ((s[i] == '-') || (s[i] == '+'))
     {
@@ -27,34 +27,34 @@ DayTime DayTime::ParseFromMeade(String const &s)
 
     // Degs can be 2 or 3 digits
     long degs = s[i++] - '0';
-    LOGV3(DEBUG_MEADE, F("[DAYTIME]: 1st digit [%c] -> degs=%l"), s[i - 1], degs);
+    INFO(DEBUG_MEADE, "[DAYTIME]: 1st digit [%c] -> degs=%l", s[i - 1], degs);
     degs = degs * 10 + s[i++] - '0';
-    LOGV3(DEBUG_MEADE, F("[DAYTIME]: 2nd digit [%c] -> degs=%l"), s[i - 1], degs);
+    INFO(DEBUG_MEADE, "[DAYTIME]: 2nd digit [%c] -> degs=%l", s[i - 1], degs);
 
     // Third digit?
     if ((s[i] >= '0') && (s[i] <= '9'))
     {
         degs = degs * 10 + s[i++] - '0';
-        LOGV3(DEBUG_MEADE, F("[DAYTIME]: 3rd digit [%c] -> degs=%d"), s[i - 1], degs);
+        INFO(DEBUG_MEADE, "[DAYTIME]: 3rd digit [%c] -> degs=%d", s[i - 1], degs);
     }
     i++;  // Skip seperator
 
     int mins = s.substring(i, i + 2).toInt();
-    LOGV3(DEBUG_MEADE, F("[DAYTIME]: Minutes are [%s] -> mins=%d"), s.substring(i, i + 2).c_str(), mins);
+    INFO(DEBUG_MEADE, "[DAYTIME]: Minutes are [%s] -> mins=%d", s.substring(i, i + 2).c_str(), mins);
     int secs = 0;
     if (int(s.length()) > i + 4)
     {
         secs = s.substring(i + 3, i + 5).toInt();
-        LOGV3(DEBUG_MEADE, F("[DAYTIME]: Seconds are [%s] -> secs=%d"), s.substring(i + 3, i + 5).c_str(), secs);
+        INFO(DEBUG_MEADE, "[DAYTIME]: Seconds are [%s] -> secs=%d", s.substring(i + 3, i + 5).c_str(), secs);
     }
     else
     {
-        LOGV3(DEBUG_MEADE, F("[DAYTIME]: No Seconds. slen %d is not > %d"), s.length(), i + 4);
+        INFO(DEBUG_MEADE, "[DAYTIME]: No Seconds. slen %d is not > %d", s.length(), i + 4);
     }
     // Get the signed total seconds specified....
     result.totalSeconds = sgn * (((degs * 60L + mins) * 60L) + secs);
 
-    LOGV5(DEBUG_MEADE, F("[DAYTIME]: TotalSeconds are %l from %lh %dm %ds"), result.totalSeconds, degs, mins, secs);
+    INFO(DEBUG_MEADE, "[DAYTIME]: TotalSeconds are %l from %lh %dm %ds", result.totalSeconds, degs, mins, secs);
 
     return result;
 }

--- a/src/Declination.cpp
+++ b/src/Declination.cpp
@@ -50,12 +50,12 @@ void Declination::checkHours()
 {
     if (totalSeconds > 0)
     {
-        LOGV1(DEBUG_GENERAL, F("[DECLINATION]: CheckHours: Degrees is more than 0, clamping"));
+        INFO(DEBUG_GENERAL, "[DECLINATION]: CheckHours: Degrees is more than 0, clamping");
         totalSeconds = 0;
     }
     if (totalSeconds < -arcSecondsPerHemisphere)
     {
-        LOGV1(DEBUG_GENERAL, F("[DECLINATION]: CheckHours: Degrees is less than -180, clamping"));
+        INFO(DEBUG_GENERAL, "[DECLINATION]: CheckHours: Degrees is less than -180, clamping");
         totalSeconds = -arcSecondsPerHemisphere;
     }
 }
@@ -87,14 +87,14 @@ const char *Declination::ToString() const
 Declination Declination::ParseFromMeade(String const &s)
 {
     Declination result;
-    LOGV2(DEBUG_GENERAL, F("[DECLINATION]: Declination.Parse(%s)"), s.c_str());
+    INFO(DEBUG_GENERAL, "[DECLINATION]: Declination.Parse(%s)", s.c_str());
 
     // Use the DayTime code to parse it...
     DayTime dt = DayTime::ParseFromMeade(s);
 
     // ...and then correct for hemisphere
     result.totalSeconds = dt.getTotalSeconds() + (NORTHERN_HEMISPHERE ? -(arcSecondsPerHemisphere / 2) : (arcSecondsPerHemisphere / 2));
-    LOGV3(DEBUG_GENERAL, F("[DECLINATION]: Declination.Parse(%s) -> %s"), s.c_str(), result.ToString());
+    INFO(DEBUG_GENERAL, "[DECLINATION]: Declination.Parse(%s) -> %s", s.c_str(), result.ToString());
     return result;
 }
 

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -19,7 +19,7 @@ static uint8_t dummyEepromStorage[EEPROMStore::STORE_SIZE];
 // Initialize the EEPROM object for ESP boards, setting aside storage
 void EEPROMStore::initialize()
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Dummy: Startup with %d bytes"), EEPROMStore::STORE_SIZE);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Dummy: Startup with %d bytes", EEPROMStore::STORE_SIZE);
     memset(dummyEepromStorage, 0, sizeof(dummyEepromStorage));
 
     displayContents();  // Will always be empty at restart
@@ -28,7 +28,7 @@ void EEPROMStore::initialize()
 // Update the given location with the given value
 void EEPROMStore::update(uint8_t location, uint8_t value)
 {
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Dummy: Writing %x to %d"), value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Dummy: Writing %x to %d", value, location);
     dummyEepromStorage[location] = value;
 }
 
@@ -43,7 +43,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 {
     uint8_t value;
     value = dummyEepromStorage[location];
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Dummy: Read %x from %d"), value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Dummy: Read %x from %d", value, location);
     return value;
 }
 
@@ -52,7 +52,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 // Initialize the EEPROM object for ESP boards, setting aside space for storage
 void EEPROMStore::initialize()
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: ESP32: Startup with %d bytes"), STORE_SIZE);
+    INFO(DEBUG_EEPROM, "[EEPROM]: ESP32: Startup with %d bytes", STORE_SIZE);
     EEPROM.begin(STORE_SIZE);
 
     displayContents();
@@ -61,14 +61,14 @@ void EEPROMStore::initialize()
 // Update the given location with the given value
 void EEPROMStore::update(uint8_t location, uint8_t value)
 {
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ESP32: Writing %x to %d"), value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: ESP32: Writing %x to %d", value, location);
     EEPROM.write(location, value);
 }
 
 // Complete the transaction
 void EEPROMStore::commit()
 {
-    LOGV1(DEBUG_EEPROM, F("[EEPROM]: ESP32: Committing"));
+    INFO(DEBUG_EEPROM, "[EEPROM]: ESP32: Committing");
     EEPROM.commit();
 }
 
@@ -77,7 +77,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 {
     uint8_t value;
     value = EEPROM.read(location);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ESP32: Read %x from %d"), value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: ESP32: Read %x from %d", value, location);
     return value;
 }
 
@@ -86,7 +86,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 // Initialize the EEPROM storage in a platform-independent abstraction
 void EEPROMStore::initialize()
 {
-    LOGV1(DEBUG_EEPROM, F("[EEPROM]: ATMega: Startup"));
+    INFO(DEBUG_EEPROM, "[EEPROM]: ATMega: Startup");
 
     displayContents();
 }
@@ -94,7 +94,7 @@ void EEPROMStore::initialize()
 // Update the given location with the given value
 void EEPROMStore::update(uint8_t location, uint8_t value)
 {
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ATMega: Writing8 %x to %d"), value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: ATMega: Writing8 %x to %d", value, location);
     EEPROM.write(location, value);
 }
 
@@ -108,7 +108,7 @@ void EEPROMStore::commit()
 uint8_t EEPROMStore::read(uint8_t location)
 {
     uint8_t value = EEPROM.read(location);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ATMega: Read8 %x from %d"), value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: ATMega: Read8 %x from %d", value, location);
     return value;
 }
 
@@ -119,34 +119,33 @@ void EEPROMStore::displayContents()
 #if (DEBUG_LEVEL & (DEBUG_INFO | DEBUG_EEPROM))
     // Read the magic marker byte and state
     uint16_t marker = readUint16(MAGIC_MARKER_AND_FLAGS_ADDR);
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Magic Marker: %x"), marker);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Magic Marker: %x", marker);
 
-    LOGV1(DEBUG_INFO, ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? F("EEPROM: Has values") : F("[EEPROM]: Does NOT have values"));
-    LOGV1(DEBUG_INFO,
-          ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? F("EEPROM: Has extended values") : F("EEPROM: Does NOT have extended values"));
+    INFO(DEBUG_INFO, "[EEPROM]: Has %svalues", ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? "" : "NO");
+    INFO(DEBUG_INFO, "[EEPROM]: Has %sextended values", ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? "" : "NO");
     if (EEPROMStore::isPresent(EXTENDED_FLAG))
     {
-        LOGV1(DEBUG_INFO, F("[EEPROM]: IsPresent(EXTENDED): Yes"));
+        INFO(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED): Yes");
     }
     else
     {
-        LOGV1(DEBUG_INFO, F("[EEPROM]: IsPresent(EXTENDED): No"));
+        INFO(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED): No");
     }
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored HATime: %s"), getHATime().ToString());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored UTC Offset: %d"), getUtcOffset());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Brightness: %d"), getBrightness());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored RA Steps per Degree: %f"), getRAStepsPerDegree());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Steps per Degree: %f"), getDECStepsPerDegree());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Speed Factor: %f"), getSpeedFactor());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Backlash Correction Steps: %d"), getBacklashCorrectionSteps());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Latitude: %s"), getLatitude().ToString());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Longitude: %s"), getLongitude().ToString());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Pitch Calibration Angle: %f"), getPitchCalibrationAngle());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Roll Calibration Angle: %f"), getRollCalibrationAngle());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored RA Parking Position: %l"), getRAParkingPos());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Parking Position: %l"), getDECParkingPos());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Lower Limit: %l"), getDECLowerLimit());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Upper Limit: %l"), getDECUpperLimit());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored HATime: %s", getHATime().ToString());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored UTC Offset: %d", getUtcOffset());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Brightness: %d", getBrightness());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored RA Steps per Degree: %f", getRAStepsPerDegree());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored DEC Steps per Degree: %f", getDECStepsPerDegree());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Speed Factor: %f", getSpeedFactor());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Backlash Correction Steps: %d", getBacklashCorrectionSteps());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Latitude: %s", getLatitude().ToString());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Longitude: %s", getLongitude().ToString());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Pitch Calibration Angle: %f", getPitchCalibrationAngle());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored Roll Calibration Angle: %f", getRollCalibrationAngle());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored RA Parking Position: %l", getRAParkingPos());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored DEC Parking Position: %l", getDECParkingPos());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored DEC Lower Limit: %l", getDECLowerLimit());
+    INFO(DEBUG_INFO, "[EEPROM]: Stored DEC Upper Limit: %l", getDECUpperLimit());
 #endif
 }
 
@@ -156,7 +155,7 @@ void EEPROMStore::displayContents()
 // Helper to update the given location with the given 8-bit value
 void EEPROMStore::updateUint8(EEPROMStore::ItemAddress location, uint8_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing8 %x (%d) to %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Writing8 %x (%d) to %d", value, value, location);
     update(location, value);
 }
 
@@ -165,14 +164,14 @@ uint8_t EEPROMStore::readUint8(EEPROMStore::ItemAddress location)
 {
     uint8_t value;
     value = read(location);
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read8 %x (%d) from %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Read8 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 8-bit value
 void EEPROMStore::updateInt8(EEPROMStore::ItemAddress location, int8_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing8 %x (%d) to %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Writing8 %x (%d) to %d", value, value, location);
     update(location, static_cast<uint8_t>(value));
 }
 
@@ -181,14 +180,14 @@ int8_t EEPROMStore::readInt8(EEPROMStore::ItemAddress location)
 {
     int8_t value;
     value = static_cast<int8_t>(read(location));
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read8 %x (%d) from %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Read8 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 16-bit value
 void EEPROMStore::updateInt16(EEPROMStore::ItemAddress location, int16_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing16 %x (%d) to %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Writing16 %x (%d) to %d", value, value, location);
     update(location, value & 0x00FF);
     update(location + 1, (value >> 8) & 0x00FF);
 }
@@ -200,14 +199,14 @@ int16_t EEPROMStore::readInt16(EEPROMStore::ItemAddress location)
     uint8_t valHi   = read(location + 1);
     uint16_t uValue = (uint16_t) valLo + (uint16_t) valHi * 256;
     int16_t value   = static_cast<int16_t>(uValue);
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read16 %x (%d) from %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Read16 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 16-bit value
 void EEPROMStore::updateUint16(EEPROMStore::ItemAddress location, uint16_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing16 %x (%d) to %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Writing16 %x (%d) to %d", value, value, location);
     update(location, value & 0x00FF);
     update(location + 1, (value >> 8) & 0x00FF);
 }
@@ -218,14 +217,14 @@ uint16_t EEPROMStore::readUint16(EEPROMStore::ItemAddress location)
     uint8_t valLo  = read(location);
     uint8_t valHi  = read(location + 1);
     uint16_t value = (uint16_t) valLo + (uint16_t) valHi * 256;
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read16 %x (%d) from %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Read16 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 32-bit value
 void EEPROMStore::updateInt32(EEPROMStore::ItemAddress location, int32_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing32 %x (%l) to %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Writing32 %x (%l) to %d", value, value, location);
     update(location, value & 0x00FF);
     update(location + 1, (value >> 8) & 0x00FF);
     update(location + 2, (value >> 16) & 0x00FF);
@@ -241,7 +240,7 @@ int32_t EEPROMStore::readInt32(EEPROMStore::ItemAddress location)
     uint8_t val4    = read(location + 3);
     uint32_t uValue = (uint32_t) val1 + (uint32_t) val2 * 256 + (uint32_t) val3 * 256 * 256 + (uint32_t) val4 * 256 * 256 * 256;
     int32_t value   = static_cast<int32_t>(uValue);
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read32 %x (%l) from %d"), value, value, location);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Read32 %x (%l) from %d", value, value, location);
     return value;
 }
 
@@ -255,7 +254,7 @@ bool EEPROMStore::isPresent(ItemFlag item)
     unsigned check  = (MAGIC_MARKER_MASK | item);
     unsigned result = (MAGIC_MARKER_VALUE | item);
     bool res        = ((marker & check) == result);
-    LOGV6(DEBUG_EEPROM, F("[EEPROM]: IsDataPresent (%x). Checking (%x & %x) == %x => %d"), item, marker, check, result, res);
+    INFO(DEBUG_EEPROM, "[EEPROM]: IsDataPresent (%x). Checking (%x & %x) == %x => %d", item, marker, check, result, res);
 
     // Data is only present if both magic marker and item flag are present
     //return ((marker & (MAGIC_MARKER_MASK | item)) == (MAGIC_MARKER_VALUE | item));
@@ -275,7 +274,7 @@ bool EEPROMStore::isPresentExtended(ExtendedItemFlag item)
     uint16_t marker = readUint16(EXTENDED_FLAGS_ADDR);
 
     bool result = (marker & item);
-    LOGV5(DEBUG_EEPROM, F("[EEPROM]: IsExtendedDataPresent (%x). Checking (%x & %x) => %d"), item, marker, item, result);
+    INFO(DEBUG_EEPROM, "[EEPROM]: IsExtendedDataPresent (%x). Checking (%x & %x) => %d", item, marker, item, result);
 
     return result;
 }
@@ -294,7 +293,7 @@ void EEPROMStore::updateFlags(ItemFlag item)
     updateUint16(MAGIC_MARKER_AND_FLAGS_ADDR, newMarkerAndFlags);
     // We will not commit until the actual item value has been written
 
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Marker & flags updated from %x to %x"), existingMarkerAndFlags, newMarkerAndFlags);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Marker & flags updated from %x to %x", existingMarkerAndFlags, newMarkerAndFlags);
 }
 
 // Updates the core & extended flags for the specified extended item to indicate it is present.
@@ -310,7 +309,7 @@ void EEPROMStore::updateFlagsExtended(ExtendedItemFlag item)
     updateUint16(EXTENDED_FLAGS_ADDR, extendedFlags | item);
     // We will not commit until the actual item value has been written
 
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Extended flags updated from %x to %x"), extendedFlags, extendedFlags | item);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Extended flags updated from %x to %x", extendedFlags, extendedFlags | item);
 }
 
 ///////////////////////////////////////
@@ -348,11 +347,11 @@ int EEPROMStore::getUtcOffset()
     if (isPresentExtended(UTC_OFFSET_MARKER_FLAG))
     {
         utcOffset = readInt8(UTC_OFFSET_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: UTC OFfset Marker OK! UTC Offset is %d"), utcOffset);
+        INFO(DEBUG_EEPROM, "[EEPROM]: UTC OFfset Marker OK! UTC Offset is %d", utcOffset);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for UTC Offset"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for UTC Offset");
     }
 
     return utcOffset;
@@ -394,11 +393,11 @@ float EEPROMStore::getRAStepsPerDegree()
     if (isPresent(RA_STEPS_FLAG))
     {
         raStepsPerDegree = 0.1 * readInt16(RA_STEPS_DEGREE_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: RA Marker OK! RA steps/deg is %f"), raStepsPerDegree);
+        INFO(DEBUG_EEPROM, "[EEPROM]: RA Marker OK! RA steps/deg is %f", raStepsPerDegree);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for RA steps"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for RA steps");
     }
 
     return raStepsPerDegree;  // microsteps per degree
@@ -409,7 +408,7 @@ void EEPROMStore::storeRAStepsPerDegree(float raStepsPerDegree)
 {
     int32_t val = raStepsPerDegree * 10;  // Store as tenths of degree
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing RA steps to %d (%f)"), val, raStepsPerDegree);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing RA steps to %d (%f)", val, raStepsPerDegree);
 
     updateInt16(RA_STEPS_DEGREE_ADDR, val);
     updateFlags(RA_STEPS_FLAG);
@@ -425,11 +424,11 @@ float EEPROMStore::getDECStepsPerDegree()
     if (isPresent(DEC_STEPS_FLAG))
     {
         decStepsPerDegree = 0.1 * readInt16(DEC_STEPS_DEGREE_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC Marker OK! DEC steps/deg is %f"), decStepsPerDegree);
+        INFO(DEBUG_EEPROM, "[EEPROM]: DEC Marker OK! DEC steps/deg is %f", decStepsPerDegree);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for DEC steps"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for DEC steps");
     }
 
     return decStepsPerDegree;  // microsteps per degree
@@ -440,7 +439,7 @@ void EEPROMStore::storeDECStepsPerDegree(float decStepsPerDegree)
 {
     int32_t val = decStepsPerDegree * 10;  // Store as tenths of degree
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing DEC steps to %d (%f)"), val, decStepsPerDegree);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing DEC steps to %d (%f)", val, decStepsPerDegree);
 
     updateInt16(DEC_STEPS_DEGREE_ADDR, val);
     updateFlags(DEC_STEPS_FLAG);
@@ -458,11 +457,11 @@ float EEPROMStore::getSpeedFactor()
         // Speed factor bytes are in split locations :-(
         int val     = readUint8(SPEED_FACTOR_LOW_ADDR) + (int) readUint8(SPEED_FACTOR_HIGH_ADDR) * 256;
         speedFactor = 1.0 + val / 10000.0;
-        LOGV3(DEBUG_EEPROM, F("[EEPROM]: Speed Marker OK! Speed adjust is %d, speedFactor is %f"), val, speedFactor);
+        INFO(DEBUG_EEPROM, "[EEPROM]: Speed Marker OK! Speed adjust is %d, speedFactor is %f", val, speedFactor);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for speed factor"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for speed factor");
     }
 
     return speedFactor;
@@ -474,7 +473,7 @@ void EEPROMStore::storeSpeedFactor(float speedFactor)
     // Store the fractional speed factor since it is a number very close to 1
     int32_t val = (speedFactor - 1.0f) * 10000.0f;
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Speed Factor to %d (%f)"), val, speedFactor);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing Speed Factor to %d (%f)", val, speedFactor);
 
     // Speed factor bytes are in split locations :-(
     updateUint8(SPEED_FACTOR_LOW_ADDR, val & 0xFF);
@@ -493,11 +492,11 @@ int16_t EEPROMStore::getBacklashCorrectionSteps()
     if (isPresent(BACKLASH_STEPS_FLAG))
     {
         backlashCorrectionSteps = readInt16(BACKLASH_STEPS_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: Backlash Steps Marker OK! Backlash correction is %d"), backlashCorrectionSteps);
+        INFO(DEBUG_EEPROM, "[EEPROM]: Backlash Steps Marker OK! Backlash correction is %d", backlashCorrectionSteps);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for backlash correction"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for backlash correction");
     }
 
     return backlashCorrectionSteps;  // Microsteps (slew)
@@ -506,7 +505,7 @@ int16_t EEPROMStore::getBacklashCorrectionSteps()
 // Store the Backlash Correction step count (microsteps).
 void EEPROMStore::storeBacklashCorrectionSteps(int16_t backlashCorrectionSteps)
 {
-    LOGV2(DEBUG_EEPROM, F("EEPROM Write: Updating Backlash to %d"), backlashCorrectionSteps);
+    INFO(DEBUG_EEPROM, "EEPROM Write: Updating Backlash to %d", backlashCorrectionSteps);
 
     updateInt16(BACKLASH_STEPS_ADDR, backlashCorrectionSteps);
     updateFlags(BACKLASH_STEPS_FLAG);
@@ -522,11 +521,11 @@ Latitude EEPROMStore::getLatitude()
     if (isPresent(LATITUDE_FLAG))
     {
         latitude = Latitude(1.0f * readInt16(LATITUDE_ADDR) / 100.0f);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: Latitude Marker OK! Latitude is %s"), latitude.ToString());
+        INFO(DEBUG_EEPROM, "[EEPROM]: Latitude Marker OK! Latitude is %s", latitude.ToString());
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for latitude"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for latitude");
     }
 
     return latitude;  // Object
@@ -537,7 +536,7 @@ void EEPROMStore::storeLatitude(Latitude const &latitude)
 {
     int32_t val = static_cast<int32_t>(roundf(latitude.getTotalHours() * 100.0f));
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Latitude as %d (%f)"), val, latitude.getTotalHours());
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing Latitude as %d (%f)", val, latitude.getTotalHours());
 
     updateInt16(LATITUDE_ADDR, val);
     updateFlags(LATITUDE_FLAG);
@@ -553,11 +552,11 @@ Longitude EEPROMStore::getLongitude()
     if (isPresent(LONGITUDE_FLAG))
     {
         longitude = Longitude(1.0f * readInt16(LONGITUDE_ADDR) / 100.0f);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: Longitude Marker OK! Longitude is %s"), longitude.ToString());
+        INFO(DEBUG_EEPROM, "[EEPROM]: Longitude Marker OK! Longitude is %s", longitude.ToString());
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for longitude"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for longitude");
     }
 
     return longitude;  // Object
@@ -568,7 +567,7 @@ void EEPROMStore::storeLongitude(Longitude const &longitude)
 {
     int32_t val = static_cast<int32_t>(roundf(longitude.getTotalHours() * 100.0f));
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Longitude as %d (%f)"), val, longitude.getTotalHours());
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing Longitude as %d (%f)", val, longitude.getTotalHours());
 
     updateInt16(LONGITUDE_ADDR, val);
     updateFlags(LONGITUDE_FLAG);
@@ -585,11 +584,11 @@ float EEPROMStore::getPitchCalibrationAngle()
     {
         int32_t val           = readUint16(PITCH_OFFSET_ADDR);
         pitchCalibrationAngle = (val - 16384) / 100.0;
-        LOGV3(DEBUG_EEPROM, F("[EEPROM]: Pitch Offset Marker OK! Pitch Offset is %d (%f)"), val, pitchCalibrationAngle);
+        INFO(DEBUG_EEPROM, "[EEPROM]: Pitch Offset Marker OK! Pitch Offset is %d (%f)", val, pitchCalibrationAngle);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Pitch Offset"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for Pitch Offset");
     }
 
     return pitchCalibrationAngle;  // degrees
@@ -600,7 +599,7 @@ void EEPROMStore::storePitchCalibrationAngle(float pitchCalibrationAngle)
 {
     int32_t val = (pitchCalibrationAngle * 100) + 16384;
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Pitch calibration %d (%f)"), val, pitchCalibrationAngle);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing Pitch calibration %d (%f)", val, pitchCalibrationAngle);
 
     updateInt16(PITCH_OFFSET_ADDR, val);
     updateFlags(PITCH_OFFSET_FLAG);
@@ -617,11 +616,11 @@ float EEPROMStore::getRollCalibrationAngle()
     {
         int32_t val          = readUint16(ROLL_OFFSET_ADDR);
         rollCalibrationAngle = (val - 16384) / 100.0;
-        LOGV3(DEBUG_EEPROM, F("[EEPROM]: Roll Offset Marker OK! Roll Offset is %d (%f)"), val, rollCalibrationAngle);
+        INFO(DEBUG_EEPROM, "[EEPROM]: Roll Offset Marker OK! Roll Offset is %d (%f)", val, rollCalibrationAngle);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Roll Offset"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for Roll Offset");
     }
 
     return rollCalibrationAngle;  // degrees
@@ -632,7 +631,7 @@ void EEPROMStore::storeRollCalibrationAngle(float rollCalibrationAngle)
 {
     int32_t val = (rollCalibrationAngle * 100) + 16384;
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Roll calibration %d (%f)"), val, rollCalibrationAngle);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Storing Roll calibration %d (%f)", val, rollCalibrationAngle);
 
     updateInt16(ROLL_OFFSET_ADDR, val);
     updateFlags(ROLL_OFFSET_FLAG);
@@ -649,11 +648,11 @@ int32_t EEPROMStore::getRAParkingPos()
     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
     {
         raParkingPos = readInt32(RA_PARKING_POS_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: RA Parking position read as %l"), raParkingPos);
+        INFO(DEBUG_EEPROM, "[EEPROM]: RA Parking position read as %l", raParkingPos);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Parking position"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
     }
 
     return raParkingPos;  // microsteps (slew)
@@ -662,7 +661,7 @@ int32_t EEPROMStore::getRAParkingPos()
 // Store the configured RA Parking Pos (slew microsteps relative to home).
 void EEPROMStore::storeRAParkingPos(int32_t raParkingPos)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Updating RA Parking Pos to %l"), raParkingPos);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Updating RA Parking Pos to %l", raParkingPos);
 
     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
     updateInt32(RA_PARKING_POS_ADDR, raParkingPos);
@@ -680,11 +679,11 @@ int32_t EEPROMStore::getDECParkingPos()
     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
     {
         decParkingPos = readInt32(DEC_PARKING_POS_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC Parking position read as %l"), decParkingPos);
+        INFO(DEBUG_EEPROM, "[EEPROM]: DEC Parking position read as %l", decParkingPos);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Parking position"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
     }
 
     return decParkingPos;  // microsteps (slew)
@@ -693,7 +692,7 @@ int32_t EEPROMStore::getDECParkingPos()
 // Store the configured DEC Parking Pos (slew microsteps relative to home).
 void EEPROMStore::storeDECParkingPos(int32_t decParkingPos)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Updating DEC Parking Pos to %l"), decParkingPos);
+    INFO(DEBUG_EEPROM, "[EEPROM]: Updating DEC Parking Pos to %l", decParkingPos);
 
     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
     updateInt32(DEC_PARKING_POS_ADDR, decParkingPos);
@@ -711,11 +710,11 @@ int32_t EEPROMStore::getDECLowerLimit()
     if (isPresentExtended(DEC_LIMIT_MARKER_FLAG))
     {
         decLowerLimit = readInt32(DEC_LOWER_LIMIT_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC lower limit read as %l"), decLowerLimit);
+        INFO(DEBUG_EEPROM, "[EEPROM]: DEC lower limit read as %l", decLowerLimit);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored values for DEC limits"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored values for DEC limits");
     }
 
     return decLowerLimit;  // microsteps (slew)
@@ -724,7 +723,7 @@ int32_t EEPROMStore::getDECLowerLimit()
 // Store the configured DEC Lower Limit Pos (slew microsteps relative to home).
 void EEPROMStore::storeDECLowerLimit(int32_t decLowerLimit)
 {
-    LOGV2(DEBUG_EEPROM, F("EEPROM Write: Updating DEC Lower Limit to %l"), decLowerLimit);
+    INFO(DEBUG_EEPROM, "EEPROM Write: Updating DEC Lower Limit to %l", decLowerLimit);
 
     // Note that flags doesn't verify that _both_ DEC limits have been written - these should always be stored as a pair
     updateInt32(DEC_LOWER_LIMIT_ADDR, decLowerLimit);
@@ -742,11 +741,11 @@ int32_t EEPROMStore::getDECUpperLimit()
     if (isPresentExtended(DEC_LIMIT_MARKER_FLAG))
     {
         decUpperLimit = readInt32(DEC_UPPER_LIMIT_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC upper limit read as %l"), decUpperLimit);
+        INFO(DEBUG_EEPROM, "[EEPROM]: DEC upper limit read as %l", decUpperLimit);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored values for DEC limits"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored values for DEC limits");
     }
 
     return decUpperLimit;  // microsteps (slew)
@@ -755,7 +754,7 @@ int32_t EEPROMStore::getDECUpperLimit()
 // Store the configured DEC Upper Limit Pos (slew microsteps relative to home).
 void EEPROMStore::storeDECUpperLimit(int32_t decUpperLimit)
 {
-    LOGV2(DEBUG_EEPROM, F("EEPROM Write: Updating DEC Upper Limit to %l"), decUpperLimit);
+    INFO(DEBUG_EEPROM, "EEPROM Write: Updating DEC Upper Limit to %l", decUpperLimit);
 
     // Note that flags doesn't verify that _both_ DEC limits have been written - these should always be stored as a pair
     updateInt32(DEC_UPPER_LIMIT_ADDR, decUpperLimit);
@@ -771,11 +770,11 @@ int32_t EEPROMStore::getRAHomingOffset()
     if (isPresentExtended(RA_HOMING_MARKER_FLAG))
     {
         raHomingOffset = readInt32(RA_HOMING_OFFSET_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: RA Homing offset read as %l"), raHomingOffset);
+        INFO(DEBUG_EEPROM, "[EEPROM]: RA Homing offset read as %l", raHomingOffset);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored values for RA Homing offset"));
+        INFO(DEBUG_EEPROM, "[EEPROM]: No stored values for RA Homing offset");
     }
 
     return raHomingOffset;  // microsteps (slew)
@@ -784,7 +783,7 @@ int32_t EEPROMStore::getRAHomingOffset()
 // Store the configured RA Homing offset for Hall sensor homing (slew microsteps relative to home).
 void EEPROMStore::storeRAHomingOffset(int32_t raHomingOffset)
 {
-    LOGV2(DEBUG_EEPROM, F("EEPROM Write: Updating RA Homing offset to %l"), raHomingOffset);
+    INFO(DEBUG_EEPROM, "EEPROM Write: Updating RA Homing offset to %l", raHomingOffset);
 
     updateInt32(RA_HOMING_OFFSET_ADDR, raHomingOffset);
     updateFlagsExtended(RA_HOMING_MARKER_FLAG);

--- a/src/Gyro.cpp
+++ b/src/Gyro.cpp
@@ -25,7 +25,7 @@ void Gyro::startup()
 */
 {
     // Initialize interface to the MPU6050
-    LOGV1(DEBUG_INFO, F("[GYRO]:: Starting"));
+    INFO(DEBUG_INFO, "[GYRO]:: Starting");
     Wire.begin();
 
     // Execute 1 byte read from MPU6050_REG_WHO_AM_I
@@ -38,7 +38,7 @@ void Gyro::startup()
     isPresent = (id == 0x34);
     if (!isPresent)
     {
-        LOGV1(DEBUG_INFO, F("[GYRO]:: Not found!"));
+        INFO(DEBUG_INFO, "[GYRO]:: Not found!");
         return;
     }
 
@@ -54,7 +54,7 @@ void Gyro::startup()
     Wire.write(6);  // 5Hz bandwidth (lowest) for smoothing
     Wire.endTransmission(true);
 
-    LOGV1(DEBUG_INFO, F("[GYRO]:: Started"));
+    INFO(DEBUG_INFO, "[GYRO]:: Started");
 }
 
 void Gyro::shutdown()
@@ -62,7 +62,7 @@ void Gyro::shutdown()
    Currently does nothing.
 */
 {
-    LOGV1(DEBUG_INFO, F("[GYRO]: Shutdown"));
+    INFO(DEBUG_INFO, "[GYRO]: Shutdown");
     // Nothing to do
 }
 

--- a/src/Latitude.cpp
+++ b/src/Latitude.cpp
@@ -21,12 +21,12 @@ void Latitude::checkHours()
 {
     if (totalSeconds > 90L * 3600L)
     {
-        LOGV1(DEBUG_GENERAL, F("[LATITUDE]: CheckHours: Degrees is more than 90, clamping"));
+        INFO(DEBUG_GENERAL, "[LATITUDE]: CheckHours: Degrees is more than 90, clamping");
         totalSeconds = 90L * 3600L;
     }
     if (totalSeconds < (-90L * 3600L))
     {
-        LOGV1(DEBUG_GENERAL, F("[LATITUDE]: CheckHours: Degrees is less than -90, clamping"));
+        INFO(DEBUG_GENERAL, "[LATITUDE]: CheckHours: Degrees is less than -90, clamping");
         totalSeconds = -90L * 3600L;
     }
 }
@@ -35,11 +35,11 @@ Latitude Latitude::ParseFromMeade(String const &s)
 {
     Latitude result(0.0);
 
-    LOGV2(DEBUG_GENERAL, F("[LATITUDE]: Latitude.Parse(%s)"), s.c_str());
+    INFO(DEBUG_GENERAL, "[LATITUDE]: Latitude.Parse(%s)", s.c_str());
     // Use the DayTime code to parse it.
     DayTime dt          = DayTime::ParseFromMeade(s);
     result.totalSeconds = dt.getTotalSeconds();
     result.checkHours();
-    LOGV3(DEBUG_GENERAL, F("[LATITUDE]: Latitude.Parse(%s) -> %s"), s.c_str(), result.ToString());
+    INFO(DEBUG_GENERAL, "[LATITUDE]: Latitude.Parse(%s) -> %s", s.c_str(), result.ToString());
     return result;
 }

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -35,7 +35,7 @@ LcdMenu::LcdMenu(byte cols, byte rows, int maxItems)
 
 void LcdMenu::startup()
 {
-    LOGV1(DEBUG_INFO, F("[LCD]: LcdMenu startup"));
+    INFO(DEBUG_INFO, "[LCD]: LcdMenu startup");
 
     #if DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD
     _lcd.begin(_cols, _rows);
@@ -55,7 +55,7 @@ void LcdMenu::startup()
     #endif
 
     _brightness = EEPROMStore::getBrightness();
-    LOGV2(DEBUG_INFO, F("[LCD]: Brightness from EEPROM is %d"), _brightness);
+    INFO(DEBUG_INFO, "[LCD]: Brightness from EEPROM is %d", _brightness);
     setBacklightBrightness(_brightness, false);
 
     _numMenuItems    = 0;
@@ -129,7 +129,7 @@ bool LcdMenu::testIfLcdIsBad()
      * pin is being driven HIGH by the AVR.
      */
     const bool lcdIsBad = (pinValue != HIGH);
-    LOGV2(DEBUG_INFO, F("[LCD]: HW is bad? %s"), lcdIsBad ? "YES" : "NO");
+    INFO(DEBUG_INFO, "[LCD]: HW is bad? %s", lcdIsBad ? "YES" : "NO");
     return lcdIsBad;
 }
     #endif
@@ -217,7 +217,7 @@ void LcdMenu::setBacklightBrightness(int level, bool persist)
 
     if (persist)
     {
-        LOGV2(DEBUG_INFO, F("[LCD]: Saving %d as brightness"), _brightness);
+        INFO(DEBUG_INFO, "[LCD]: Saving %d as brightness", _brightness);
         EEPROMStore::storeBrightness(_brightness);
     }
 }

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -22,12 +22,12 @@ void Longitude::checkHours()
 {
     while (totalSeconds > 180L * 3600L)
     {
-        LOGV1(DEBUG_GENERAL, F("[LONGITUDE]: CheckHours: Degrees is more than 180, wrapping"));
+        INFO(DEBUG_GENERAL, "[LONGITUDE]: CheckHours: Degrees is more than 180, wrapping");
         totalSeconds -= 360L * 3600L;
     }
     while (totalSeconds < (-180L * 3600L))
     {
-        LOGV1(DEBUG_GENERAL, F("[LONGITUDE]: CheckHours: Degrees is less than -180, wrapping"));
+        INFO(DEBUG_GENERAL, "[LONGITUDE]: CheckHours: Degrees is less than -180, wrapping");
         totalSeconds += 360L * 3600L;
     }
 }
@@ -35,7 +35,7 @@ void Longitude::checkHours()
 Longitude Longitude::ParseFromMeade(String const &s)
 {
     Longitude result(0.0);
-    LOGV2(DEBUG_GENERAL, F("[LONGITUDE]: Parse(%s)"), s.c_str());
+    INFO(DEBUG_GENERAL, "[LONGITUDE]: Parse(%s)", s.c_str());
 
     // Use the DayTime code to parse it.
     DayTime dt = DayTime::ParseFromMeade(s);
@@ -44,7 +44,7 @@ Longitude Longitude::ParseFromMeade(String const &s)
     result.totalSeconds = 180L * 3600L - dt.getTotalSeconds();
     result.checkHours();
 
-    LOGV4(DEBUG_GENERAL, F("[LONGITUDE]: Parse(%s) -> %s = %ls"), s.c_str(), result.ToString(), result.getTotalSeconds());
+    INFO(DEBUG_GENERAL, "[LONGITUDE]: Parse(%s) -> %s = %ls", s.c_str(), result.ToString(), result.getTotalSeconds());
     return result;
 }
 

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1200,13 +1200,13 @@ String MeadeCommandProcessor::handleMeadeGPSCommands(String inCmd)
         {
             if (gpsAqcuisitionComplete(indicator))
             {
-                LOGV1(DEBUG_MEADE, F("[MEADE]: GPS startup, GPS acquired"));
+                INFO(DEBUG_MEADE, "[MEADE]: GPS startup, GPS acquired");
                 return "1";
             }
         }
     }
 #endif
-    LOGV1(DEBUG_MEADE, F("[MEADE]: GPS startup, no GPS signal"));
+    INFO(DEBUG_MEADE, "[MEADE]: GPS startup, no GPS signal");
     return "0";
 }
 
@@ -1238,7 +1238,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
         {
             Declination dec     = Declination::ParseFromMeade(inCmd.substring(1));
             _mount->targetDEC() = dec;
-            LOGV2(DEBUG_MEADE, F("[MEADE]: SetInfo: Received Target DEC: %s"), _mount->targetDEC().ToString());
+            INFO(DEBUG_MEADE, "[MEADE]: SetInfo: Received Target DEC: %s", _mount->targetDEC().ToString());
             return "1";
         }
         else
@@ -1256,7 +1256,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
         if ((inCmd[3] == ':') && (inCmd[6] == ':'))
         {
             _mount->targetRA().set(inCmd.substring(1, 3).toInt(), inCmd.substring(4, 6).toInt(), inCmd.substring(7, 9).toInt());
-            LOGV2(DEBUG_MEADE, F("[MEADE]: SetInfo: Received Target RA: %s"), _mount->targetRA().ToString());
+            INFO(DEBUG_MEADE, "[MEADE]: SetInfo: Received Target RA: %s", _mount->targetRA().ToString());
             return "1";
         }
         else
@@ -1279,7 +1279,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
             }
 
             DayTime lst(hLST, minLST, secLST);
-            LOGV4(DEBUG_MEADE, F("[MEADE]: SetInfo: Received LST: %d:%d:%d"), hLST, minLST, secLST);
+            INFO(DEBUG_MEADE, "[MEADE]: SetInfo: Received LST: %d:%d:%d", hLST, minLST, secLST);
             _mount->setLST(lst);
         }
         else if (inCmd[1] == 'P')
@@ -1293,7 +1293,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
             // Set HA
             int hHA   = inCmd.substring(1, 3).toInt();
             int minHA = inCmd.substring(4, 6).toInt();
-            LOGV4(DEBUG_MEADE, F("[MEADE]: SetInfo: Received HA: %d:%d:%d"), hHA, minHA, 0);
+            INFO(DEBUG_MEADE, "[MEADE]: SetInfo: Received HA: %d:%d:%d", hHA, minHA, 0);
             _mount->setHA(DayTime(hHA, minHA, 0));
         }
 
@@ -1413,7 +1413,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     }
     else if (inCmd[0] == 'A')
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Move Az/Alt"));
+        INFO(DEBUG_MEADE, "[MEADE]: Move Az/Alt");
 
         // Move Azimuth or Altitude by given arcminutes
         // :MAZ+32.1# or :MAL-32.1#
@@ -1421,7 +1421,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         if (inCmd[1] == 'Z')  // :MAZ
         {
             float arcMinute = inCmd.substring(2).toFloat();
-            LOGV2(DEBUG_MEADE, F("[MEADE]: Move AZ by %f arcmins"), arcMinute);
+            INFO(DEBUG_MEADE, "[MEADE]: Move AZ by %f arcmins", arcMinute);
             _mount->moveBy(AZIMUTH_STEPS, arcMinute);
         }
 #endif
@@ -1457,7 +1457,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     else if (inCmd[0] == 'X')  // :MX
     {
         long steps = inCmd.substring(2).toInt();
-        LOGV3(DEBUG_MEADE, F("[MEADE]: Move: %l in %d"), steps, inCmd[1]);
+        INFO(DEBUG_MEADE, "[MEADE]: Move: %l in %d", steps, inCmd[1]);
         if (inCmd[1] == 'r')
             _mount->moveStepperBy(RA_STEPS, steps);
         else if (inCmd[1] == 'd')
@@ -1479,7 +1479,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         if (inCmd.length() > 3)
         {
             distance = clamp((int) inCmd.substring(3).toInt(), 1, 5);
-            LOGV2(DEBUG_MEADE, F("[MEADE]: RA AutoHome by %dh"), distance);
+            INFO(DEBUG_MEADE, "[MEADE]: RA AutoHome by %dh", distance);
         }
 
         if (inCmd[2] == 'R')  // :MHRR
@@ -1872,57 +1872,57 @@ String MeadeCommandProcessor::handleMeadeFocusCommands(String inCmd)
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
     if (inCmd[0] == '+')  // :F+
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus focusContinuousMove IN"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus focusContinuousMove IN");
         _mount->focusContinuousMove(FOCUS_BACKWARD);
     }
     else if (inCmd[0] == '-')  // :F-
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus focusContinuousMove OUT"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus focusContinuousMove OUT");
         _mount->focusContinuousMove(FOCUS_FORWARD);
     }
     else if (inCmd[0] == 'M')  // :FMnnnn
     {
         long steps = inCmd.substring(1).toInt();
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Focus move by %l steps"), steps);
+        INFO(DEBUG_MEADE, "[MEADE]: Focus move by %l steps", steps);
         _mount->focusMoveBy(steps);
     }
     else if ((inCmd[0] >= '1') && (inCmd[0] <= '4'))  // :F1 - Slowest, F4 fastest
     {
         int speed = inCmd[0] - '0';
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Focus setSpeed %d"), speed);
+        INFO(DEBUG_MEADE, "[MEADE]: Focus setSpeed %d", speed);
         _mount->focusSetSpeedByRate(speed);
     }
     else if (inCmd[0] == 'F')  // :FF
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus setSpeed fastest"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus setSpeed fastest");
         _mount->focusSetSpeedByRate(4);
     }
     else if (inCmd[0] == 'S')  // :FS
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus setSpeed slowest"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus setSpeed slowest");
         _mount->focusSetSpeedByRate(1);
     }
     else if (inCmd[0] == 'p')  // :Fp
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus get stepperPosition"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus get stepperPosition");
         long focusPos = _mount->focusGetStepperPosition();
         return String(focusPos) + "#";
     }
     else if (inCmd[0] == 'P')  // :FPnnn
     {
         long steps = inCmd.substring(1).toInt();
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Focus set stepperPosition %d"), steps);
+        INFO(DEBUG_MEADE, "[MEADE]: Focus set stepperPosition %d", steps);
         _mount->focusSetStepperPosition(steps);
         return "1";
     }
     else if (inCmd[0] == 'B')  // :FB
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus isRunningFocus"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus isRunningFocus");
         return _mount->isRunningFocus() ? "1" : "0";
     }
     else if (inCmd[0] == 'Q')  // :FQ
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus stop"));
+        INFO(DEBUG_MEADE, "[MEADE]: Focus stop");
         _mount->focusStop();
     }
 #else
@@ -1943,7 +1943,7 @@ String MeadeCommandProcessor::processCommand(String inCmd)
 {
     if (inCmd[0] == ':')
     {
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Received command '%s'"), inCmd.c_str());
+        INFO(DEBUG_MEADE, "[MEADE]: Received command '%s'", inCmd.c_str());
 
         // Apparently some LX200 implementations put spaces in their commands..... remove them with impunity.
         int spacePos;
@@ -1952,7 +1952,7 @@ String MeadeCommandProcessor::processCommand(String inCmd)
             inCmd.remove(spacePos, 1);
         }
 
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Processing command '%s'"), inCmd.c_str());
+        INFO(DEBUG_MEADE, "[MEADE]: Processing command '%s'", inCmd.c_str());
         char command = inCmd[1];
         inCmd        = inCmd.substring(2);
         switch (command)
@@ -1982,7 +1982,7 @@ String MeadeCommandProcessor::processCommand(String inCmd)
             case 'F':
                 return handleMeadeFocusCommands(inCmd);
             default:
-                LOGV2(DEBUG_MEADE, F("[MEADE]: Received unknown command '%s'"), inCmd.c_str());
+                INFO(DEBUG_MEADE, "[MEADE]: Received unknown command '%s'", inCmd.c_str());
                 break;
         }
     }

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -155,9 +155,9 @@ void Mount::clearConfiguration()
 /////////////////////////////////
 void Mount::readConfiguration()
 {
-    LOGV1(DEBUG_INFO, F("[MOUNT]: Reading configuration data from EEPROM"));
+    INFO(DEBUG_INFO, "[MOUNT]: Reading configuration data from EEPROM");
     readPersistentData();
-    LOGV1(DEBUG_INFO, F("[MOUNT]: Done reading configuration data from EEPROM"));
+    INFO(DEBUG_INFO, "[MOUNT]: Done reading configuration data from EEPROM");
 }
 
 /////////////////////////////////
@@ -170,46 +170,46 @@ void Mount::readPersistentData()
     // EEPROMStore will always return valid data, even if no data is present in the store
 
     _stepsPerRADegree = EEPROMStore::getRAStepsPerDegree();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: RA steps/deg is %f"), _stepsPerRADegree);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: RA steps/deg is %f", _stepsPerRADegree);
 
     _stepsPerDECDegree = EEPROMStore::getDECStepsPerDegree();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: DEC steps/deg is %f"), _stepsPerDECDegree);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: DEC steps/deg is %f", _stepsPerDECDegree);
 
     float speed = EEPROMStore::getSpeedFactor();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Speed factor is %f"), speed);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Speed factor is %f", speed);
     setSpeedCalibration(speed, false);
 
     _backlashCorrectionSteps = EEPROMStore::getBacklashCorrectionSteps();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Backlash correction is %d"), _backlashCorrectionSteps);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Backlash correction is %d", _backlashCorrectionSteps);
 
     _latitude = EEPROMStore::getLatitude();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Latitude is %s"), _latitude.ToString());
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Latitude is %s", _latitude.ToString());
 
     _longitude = EEPROMStore::getLongitude();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Longitude is %s"), _longitude.ToString());
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Longitude is %s", _longitude.ToString());
 
     _localUtcOffset = EEPROMStore::getUtcOffset();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: UTC offset is %d"), _localUtcOffset);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: UTC offset is %d", _localUtcOffset);
 
 #if USE_GYRO_LEVEL == 1
     _pitchCalibrationAngle = EEPROMStore::getPitchCalibrationAngle();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Pitch Offset is %f"), _pitchCalibrationAngle);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Pitch Offset is %f", _pitchCalibrationAngle);
 
     _rollCalibrationAngle = EEPROMStore::getRollCalibrationAngle();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Roll Offset is %f"), _rollCalibrationAngle);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Roll Offset is %f", _rollCalibrationAngle);
 #endif
 
     _raParkingPos  = EEPROMStore::getRAParkingPos();
     _decParkingPos = EEPROMStore::getDECParkingPos();
-    LOGV3(DEBUG_INFO, F("[MOUNT]: EEPROM: Parking position read as R:%l, D:%l"), _raParkingPos, _decParkingPos);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: Parking position read as R:%l, D:%l", _raParkingPos, _decParkingPos);
 
     _decLowerLimit = EEPROMStore::getDECLowerLimit();
     _decUpperLimit = EEPROMStore::getDECUpperLimit();
-    LOGV3(DEBUG_INFO, F("[MOUNT]: EEPROM: DEC limits read as %l -> %l"), _decLowerLimit, _decUpperLimit);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: DEC limits read as %l -> %l", _decLowerLimit, _decUpperLimit);
 
 #if USE_HALL_SENSOR_RA_AUTOHOME == 1
     _homing.offsetRA = EEPROMStore::getRAHomingOffset();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: RA Homing offset read as %l"), _homing.offsetRA);
+    INFO(DEBUG_INFO, "[MOUNT]: EEPROM: RA Homing offset read as %l", _homing.offsetRA);
 #endif
 }
 
@@ -318,12 +318,12 @@ void Mount::configureFocusStepper(byte pin1, byte pin2, int maxSpeed, int maxAcc
     #if UART_CONNECTION_TEST_TXRX == 1
 bool Mount::connectToDriver(TMC2209Stepper *driver, const char *driverKind)
 {
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: Testing UART Connection to %s driver..."), driverKind);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: Testing UART Connection to %s driver...", driverKind);
     for (int i = 0; i < UART_CONNECTION_TEST_RETRIES; i++)
     {
         if (driver->test_connection() == 0)
         {
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: UART connection to %s driver successful."), driverKind);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: UART connection to %s driver successful.", driverKind);
             return true;
         }
         else
@@ -331,7 +331,7 @@ bool Mount::connectToDriver(TMC2209Stepper *driver, const char *driverKind)
             delay(500);
         }
     }
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: UART connection to %s driver failed."), driverKind);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: UART connection to %s driver failed.", driverKind);
     return false;
 }
     #endif
@@ -361,7 +361,7 @@ void Mount::configureRAdriver(Stream *serial, float rsense, byte driveraddress, 
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverRA->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested RA motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested RA motor rms_current: %d mA", rmscurrent);
     _driverRA->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverRA->toff(1);
     _driverRA->en_spreadCycle(RA_UART_STEALTH_MODE == 0);
@@ -373,9 +373,9 @@ void Mount::configureRAdriver(Stream *serial, float rsense, byte driveraddress, 
     _driverRA->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA motor rms_current: %d mA"), _driverRA->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA CS value: %d"), _driverRA->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA vsense: %d"), _driverRA->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual RA motor rms_current: %d mA", _driverRA->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual RA CS value: %d", _driverRA->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual RA vsense: %d", _driverRA->vsense());
     }
 }
 
@@ -400,7 +400,7 @@ void Mount::configureRAdriver(uint16_t RA_SW_RX, uint16_t RA_SW_TX, float rsense
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverRA->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested RA motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested RA motor rms_current: %d mA", rmscurrent);
     _driverRA->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverRA->toff(1);
     _driverRA->en_spreadCycle(RA_UART_STEALTH_MODE == 0);
@@ -412,9 +412,9 @@ void Mount::configureRAdriver(uint16_t RA_SW_RX, uint16_t RA_SW_TX, float rsense
     _driverRA->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA motor rms_current: %d mA"), _driverRA->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA CS value: %d"), _driverRA->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA vsense: %d"), _driverRA->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual RA motor rms_current: %d mA", _driverRA->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual RA CS value: %d", _driverRA->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual RA vsense: %d", _driverRA->vsense());
     }
 }
     #endif
@@ -444,7 +444,7 @@ void Mount::configureDECdriver(Stream *serial, float rsense, byte driveraddress,
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverDEC->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested DEC motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested DEC motor rms_current: %d mA", rmscurrent);
     _driverDEC->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverDEC->toff(1);
     _driverDEC->en_spreadCycle(DEC_UART_STEALTH_MODE == 0);
@@ -456,9 +456,9 @@ void Mount::configureDECdriver(Stream *serial, float rsense, byte driveraddress,
     _driverDEC->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC motor rms_current: %d mA"), _driverDEC->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC CS value: %d"), _driverDEC->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC vsense: %d"), _driverDEC->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual DEC motor rms_current: %d mA", _driverDEC->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual DEC CS value: %d", _driverDEC->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual DEC vsense: %d", _driverDEC->vsense());
     }
 }
 
@@ -483,7 +483,7 @@ void Mount::configureDECdriver(uint16_t DEC_SW_RX, uint16_t DEC_SW_TX, float rse
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverDEC->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested DEC motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested DEC motor rms_current: %d mA", rmscurrent);
     _driverDEC->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverDEC->toff(1);
     _driverDEC->en_spreadCycle(DEC_UART_STEALTH_MODE == 0);
@@ -495,9 +495,9 @@ void Mount::configureDECdriver(uint16_t DEC_SW_RX, uint16_t DEC_SW_TX, float rse
     _driverDEC->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC motor rms_current: %d mA"), _driverDEC->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC CS value: %d"), _driverDEC->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC vsense: %d"), _driverDEC->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual DEC motor rms_current: %d mA", _driverDEC->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual DEC CS value: %d", _driverDEC->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual DEC vsense: %d", _driverDEC->vsense());
     }
 }
     #endif
@@ -527,7 +527,7 @@ void Mount::configureAZdriver(Stream *serial, float rsense, byte driveraddress, 
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverAZ->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested AZ motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested AZ motor rms_current: %d mA", rmscurrent);
     _driverAZ->rms_current(rmscurrent, AZ_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverAZ->toff(1);
     _driverAZ->en_spreadCycle(0);
@@ -538,9 +538,9 @@ void Mount::configureAZdriver(Stream *serial, float rsense, byte driveraddress, 
     _driverAZ->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ motor rms_current: %d mA"), _driverAZ->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ CS value: %d"), _driverAZ->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ vsense: %d"), _driverAZ->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual AZ motor rms_current: %d mA", _driverAZ->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual AZ CS value: %d", _driverAZ->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual AZ vsense: %d", _driverAZ->vsense());
     }
 }
 
@@ -565,7 +565,7 @@ void Mount::configureAZdriver(uint16_t AZ_SW_RX, uint16_t AZ_SW_TX, float rsense
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverAZ->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested AZ motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested AZ motor rms_current: %d mA", rmscurrent);
     _driverAZ->rms_current(rmscurrent, AZ_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverAZ->toff(1);
     _driverAZ->en_spreadCycle(0);
@@ -576,9 +576,9 @@ void Mount::configureAZdriver(uint16_t AZ_SW_RX, uint16_t AZ_SW_TX, float rsense
     _driverAZ->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ motor rms_current: %d mA"), _driverAZ->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ CS value: %d"), _driverAZ->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ vsense: %d"), _driverAZ->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual AZ motor rms_current: %d mA", _driverAZ->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual AZ CS value: %d", _driverAZ->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual AZ vsense: %d", _driverAZ->vsense());
     }
 }
     #endif
@@ -608,7 +608,7 @@ void Mount::configureALTdriver(Stream *serial, float rsense, byte driveraddress,
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverALT->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested ALT motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested ALT motor rms_current: %d mA", rmscurrent);
     _driverALT->rms_current(rmscurrent, ALT_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverALT->toff(1);
     _driverALT->en_spreadCycle(0);
@@ -619,9 +619,9 @@ void Mount::configureALTdriver(Stream *serial, float rsense, byte driveraddress,
     _driverALT->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT motor rms_current: %d mA"), _driverALT->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT CS value: %d"), _driverALT->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT vsense: %d"), _driverALT->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual ALT motor rms_current: %d mA", _driverALT->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual ALT CS value: %d", _driverALT->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual ALT vsense: %d", _driverALT->vsense());
     }
 }
 
@@ -646,7 +646,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverALT->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested ALT motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS, "[MOUNT]: Requested ALT motor rms_current: %d mA", rmscurrent);
     _driverALT->rms_current(rmscurrent, ALT_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverALT->toff(1);
     _driverALT->en_spreadCycle(0);
@@ -658,9 +658,9 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
         #if UART_CONNECTION_TEST_TXRX == 1
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT motor rms_current: %d mA"), _driverALT->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT CS value: %d"), _driverALT->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT vsense: %d"), _driverALT->vsense());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual ALT motor rms_current: %d mA", _driverALT->rms_current());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual ALT CS value: %d", _driverALT->cs_actual());
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Actual ALT vsense: %d", _driverALT->vsense());
     }
         #endif
 }
@@ -691,7 +691,7 @@ void Mount::configureFocusDriver(Stream *serial, float rsense, byte driveraddres
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverFocus->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Requested Focus motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Requested Focus motor rms_current: %d mA", rmscurrent);
     _driverFocus->rms_current(rmscurrent, FOCUSER_MOTOR_HOLD_SETTING / 100.f);  //holdMultiplier = 1 to set ihold = irun
     _driverFocus->toff(1);
     _driverFocus->en_spreadCycle(FOCUS_UART_STEALTH_MODE == 0);
@@ -703,14 +703,14 @@ void Mount::configureFocusDriver(Stream *serial, float rsense, byte driveraddres
         #if UART_CONNECTION_TEST_TXRX == 1
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus motor rms_current: %d mA"), _driverFocus->rms_current());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus CS value: %d"), _driverFocus->cs_actual());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus vsense: %d"), _driverFocus->vsense());
+        INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus motor rms_current: %d mA", _driverFocus->rms_current());
+        INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus CS value: %d", _driverFocus->cs_actual());
+        INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus vsense: %d", _driverFocus->vsense());
     }
         #endif
 
         #if FOCUSER_ALWAYS_ON == 1
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: Always on -> TMC2209U enabling driver pin."));
+    INFO(DEBUG_FOCUS, "[FOCUS]: Always on -> TMC2209U enabling driver pin.");
     digitalWrite(FOCUS_EN_PIN, LOW);  // Logic LOW to enable driver
         #endif
 }
@@ -737,7 +737,7 @@ void Mount::configureFocusDriver(
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverFocus->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Requested Focus motor rms_current: %d mA"), rmscurrent);
+    INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Requested Focus motor rms_current: %d mA", rmscurrent);
     _driverFocus->rms_current(rmscurrent, FOCUSER_MOTOR_HOLD_SETTING / 100.f);  //holdMultiplier = 1 to set ihold = irun
     _driverFocus->toff(1);
     _driverFocus->en_spreadCycle(FOCUS_UART_STEALTH_MODE == 0);
@@ -749,13 +749,13 @@ void Mount::configureFocusDriver(
         #if UART_CONNECTION_TEST_TXRX == 1
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus motor rms_current: %d mA"), _driverFocus->rms_current());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus CS value: %d"), _driverFocus->cs_actual());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus vsense: %d"), _driverFocus->vsense());
+        INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus motor rms_current: %d mA", _driverFocus->rms_current());
+        INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus CS value: %d", _driverFocus->cs_actual());
+        INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus vsense: %d", _driverFocus->vsense());
     }
         #endif
         #if FOCUSER_ALWAYS_ON == 1
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: Always on -> TMC2209U enabling driver pin."));
+    INFO(DEBUG_FOCUS, "[FOCUS]: Always on -> TMC2209U enabling driver pin.");
     digitalWrite(FOCUS_EN_PIN, LOW);  // Logic LOW to enable driver
         #endif
 }
@@ -779,20 +779,20 @@ float Mount::getSpeedCalibration()
 /////////////////////////////////
 void Mount::setSpeedCalibration(float val, bool saveToStorage)
 {
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: Updating speed calibration from %f to %f"), _trackingSpeedCalibration, val);
+    INFO(DEBUG_MOUNT, "[MOUNT]: Updating speed calibration from %f to %f", _trackingSpeedCalibration, val);
     _trackingSpeedCalibration = val;
 
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: Current tracking speed is %f steps/sec"), _trackingSpeed);
+    INFO(DEBUG_MOUNT, "[MOUNT]: Current tracking speed is %f steps/sec", _trackingSpeed);
 
     // Tracking speed has to be exactly the rotation speed of the earth. The earth rotates 360° per astronomical day.
     // This is 23h 56m 4.0905s, therefore the dimensionless _trackingSpeedCalibration = (23h 56m 4.0905s / 24 h) * mechanical calibration factor
     // Also compensate for higher precision microstepping in tracking mode
     _trackingSpeed = _trackingSpeedCalibration * _stepsPerRADegree * (RA_TRACKING_MICROSTEPPING / RA_SLEW_MICROSTEPPING) * 360.0f
                      / secondsPerDay;  // (fraction of day) * u-steps/deg * (u-steps/u-steps) * deg / (sec/day) = u-steps / sec
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: RA steps per degree is %f steps/deg"), _stepsPerRADegree);
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: New tracking speed is %f steps/sec"), _trackingSpeed);
+    INFO(DEBUG_MOUNT, "[MOUNT]: RA steps per degree is %f steps/deg", _stepsPerRADegree);
+    INFO(DEBUG_MOUNT, "[MOUNT]: New tracking speed is %f steps/sec", _trackingSpeed);
 
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: FactorToSpeed : %s, %s"), String(val, 6).c_str(), String(_trackingSpeed, 6).c_str());
+    INFO(DEBUG_MOUNT, "[MOUNT]: FactorToSpeed : %s, %s", String(val, 6).c_str(), String(_trackingSpeed, 6).c_str());
 
     if (saveToStorage)
         EEPROMStore::storeSpeedFactor(_trackingSpeedCalibration);
@@ -800,7 +800,7 @@ void Mount::setSpeedCalibration(float val, bool saveToStorage)
     // If we are currently tracking, update the speed. No need to update microstepping mode
     if (isSlewingTRK())
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: SpeedCalibration TRK.setSpeed(%f)"), _trackingSpeed);
+        INFO(DEBUG_STEPPERS, "[MOUNT]: SpeedCalibration TRK.setSpeed(%f)", _trackingSpeed);
         _stepperTRK->setSpeed(_trackingSpeed);
     }
 }
@@ -1041,10 +1041,10 @@ void Mount::setSlewRate(int rate)
 {
     _moveRate           = clamp(rate, 1, 4);
     float speedFactor[] = {0, 0.05, 0.2, 0.5, 1.0};
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: setSlewRate, rate is %d -> %f"), _moveRate, speedFactor[_moveRate]);
+    INFO(DEBUG_MOUNT, "[MOUNT]: setSlewRate, rate is %d -> %f", _moveRate, speedFactor[_moveRate]);
     _stepperDEC->setMaxSpeed(speedFactor[_moveRate] * _maxDECSpeed);
     _stepperRA->setMaxSpeed(speedFactor[_moveRate] * _maxRASpeed);
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: setSlewRate, new speeds are RA: %f  DEC: %f"), _stepperRA->maxSpeed(), _stepperDEC->maxSpeed());
+    INFO(DEBUG_MOUNT, "[MOUNT]: setSlewRate, new speeds are RA: %f  DEC: %f", _stepperRA->maxSpeed(), _stepperDEC->maxSpeed());
 }
 
 /////////////////////////////////
@@ -1054,7 +1054,7 @@ void Mount::setSlewRate(int rate)
 /////////////////////////////////
 void Mount::setHA(const DayTime &haTime)
 {
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: setHA:  HA is %s"), haTime.ToString());
+    INFO(DEBUG_MOUNT, "[MOUNT]: setHA:  HA is %s", haTime.ToString());
     DayTime lst = DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND);
     lst.addTime(haTime);
     setLST(lst);
@@ -1068,12 +1068,12 @@ void Mount::setHA(const DayTime &haTime)
 /////////////////////////////////
 const DayTime Mount::HA() const
 {
-    // LOGV1(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: Get HA."));
-    // LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: Polaris adjust: %s"), DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND).ToString());
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: Get HA.");
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: Polaris adjust: %s", DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND).ToString());
     DayTime ha = _LST;
-    // LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: LST: %s"), _LST.ToString());
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: LST: %s", _LST.ToString());
     ha.subtractTime(DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND));
-    // LOGV2(DEBUG_MOUNT, F("[MOUNT]: GetHA: LST-Polaris is HA %s"), ha.ToString());
+    // INFO(DEBUG_MOUNT, "[MOUNT]: GetHA: LST-Polaris is HA %s", ha.ToString());
     return ha;
 }
 
@@ -1099,7 +1099,7 @@ void Mount::setLST(const DayTime &lst)
 #ifdef OAM
     _zeroPosRA.addHours(6);  // shift allcoordinates by 90° for EQ mount movement
 #endif
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: Set LST and ZeroPosRA to: %s"), _LST.ToString());
+    INFO(DEBUG_MOUNT, "[MOUNT]: Set LST and ZeroPosRA to: %s", _LST.ToString());
 }
 
 /////////////////////////////////
@@ -1179,16 +1179,16 @@ const DayTime Mount::currentRA() const
     float stepsPerSiderealHour = _stepsPerRADegree * siderealDegreesInHour;              // u-steps/degree * degrees/hr = u-steps/hr
     float hourPos              = -_stepperRA->currentPosition() / stepsPerSiderealHour;  // u-steps / u-steps/hr = hr
 
-    LOGV4(DEBUG_MOUNT_VERBOSE,
-          F("MOUNT: CurrentRA: Steps/h    : %s (%f x %s)"),
+    INFO(DEBUG_MOUNT_VERBOSE,
+          "MOUNT: CurrentRA: Steps/h    : %s (%f x %s)",
           String(stepsPerSiderealHour, 2).c_str(),
           _stepsPerRADegree,
           String(siderealDegreesInHour, 5).c_str());
-    LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: CurrentRA: RA Steps   : %d"), _stepperRA->currentPosition());
-    LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: CurrentRA: POS        : %s"), String(hourPos).c_str());
+    INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: RA Steps   : %d", _stepperRA->currentPosition());
+    INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: POS        : %s", String(hourPos).c_str());
     hourPos += _zeroPosRA.getTotalHours();
-    // LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentRA: ZeroPos    : %s"), _zeroPosRA.ToString());
-    // LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentRA: POS (+zp)  : %s"), DayTime(hourPos).ToString());
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: ZeroPos    : %s", _zeroPosRA.ToString());
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: POS (+zp)  : %s", DayTime(hourPos).ToString());
 
     bool flipRA = _stepperDEC->currentPosition() < 0;
     if (flipRA)
@@ -1196,7 +1196,7 @@ const DayTime Mount::currentRA() const
         hourPos += 12;
         if (hourPos > 24)
             hourPos -= 24;
-        // LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentRA: RA (+12h): %s"), DayTime(hourPos).ToString());
+        // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: RA (+12h): %s", DayTime(hourPos).ToString());
     }
 
     // Make sure we are normalized
@@ -1205,7 +1205,7 @@ const DayTime Mount::currentRA() const
     if (hourPos > 24)
         hourPos -= 24;
 
-    // LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentRA: RA Pos  -> : %s"), DayTime(hourPos).ToString());
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: RA Pos  -> : %s", DayTime(hourPos).ToString());
     return hourPos;
 }
 
@@ -1218,17 +1218,17 @@ const DayTime Mount::currentRA() const
 const Declination Mount::currentDEC() const
 {
     float degreePos = _stepperDEC->currentPosition() / _stepsPerDECDegree;  // u-steps / u-steps/deg = deg
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentDEC: Steps/deg  : %f"), _stepsPerDECDegree);
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentDEC: DEC Steps  : %d"), _stepperDEC->currentPosition());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentDEC: POS        : %s"), String(degreePos).c_str());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentDEC: Steps/deg  : %f", _stepsPerDECDegree);
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentDEC: DEC Steps  : %d", _stepperDEC->currentPosition());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentDEC: POS        : %s", String(degreePos).c_str());
 
     if (NORTHERN_HEMISPHERE ? degreePos > 0 : degreePos < 0)
     {
         degreePos = -degreePos;
-        //LOGV1(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentDEC: Greater Zero, flipping."));
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentDEC: Greater Zero, flipping.");
     }
 
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CurrentDEC: POS      : %s"), Declination(degreePos).ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentDEC: POS      : %s", Declination(degreePos).ToString());
     return degreePos;
 }
 
@@ -1246,17 +1246,17 @@ void Mount::syncPosition(DayTime ra, Declination dec)
     _targetDEC = dec;
 
     long targetRAPosition, targetDECPosition;
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: Sync Position to RA: %s and DEC: %s"), _targetRA.ToString(), _targetDEC.ToString());
+    INFO(DEBUG_MOUNT, "[MOUNT]: Sync Position to RA: %s and DEC: %s", _targetRA.ToString(), _targetDEC.ToString());
     calculateRAandDECSteppers(targetRAPosition, targetDECPosition, solutions);
 
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: syncPosition: Solution 1: RA %l and DEC: %l"), solutions[0], solutions[1]);
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: syncPosition: Solution 2: RA %l and DEC: %l"), solutions[2], solutions[3]);
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: syncPosition: Solution 3: RA %l and DEC: %l"), solutions[4], solutions[5]);
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: syncPosition: Chose solution RA: %l and DEC: %l"), targetRAPosition, targetDECPosition);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: syncPosition: Solution 1: RA %l and DEC: %l", solutions[0], solutions[1]);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: syncPosition: Solution 2: RA %l and DEC: %l", solutions[2], solutions[3]);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: syncPosition: Solution 3: RA %l and DEC: %l", solutions[4], solutions[5]);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: syncPosition: Chose solution RA: %l and DEC: %l", targetRAPosition, targetDECPosition);
 
     long raMove  = targetRAPosition - _stepperRA->currentPosition();
     long decMove = targetDECPosition - _stepperDEC->currentPosition();
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: syncPosition: Moving steppers by RA: %l and DEC: %l"), raMove, decMove);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: syncPosition: Moving steppers by RA: %l and DEC: %l", raMove, decMove);
     _homeOffsetRA -= raMove;
     _homeOffsetDEC -= decMove;
     _stepperRA->setCurrentPosition(targetRAPosition);    // u-steps (in slew mode)
@@ -1278,9 +1278,9 @@ void Mount::startSlewingToTarget()
     }
 
     // Make sure we're slewing at full speed on a GoTo
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Set DEC to MaxSpeed(%d)"), _maxDECSpeed);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Set DEC to MaxSpeed(%d)", _maxDECSpeed);
     _stepperDEC->setMaxSpeed(_maxDECSpeed);
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Set RA  to MaxSpeed(%d)"), _maxRASpeed);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Set RA  to MaxSpeed(%d)", _maxRASpeed);
     _stepperRA->setMaxSpeed(_maxRASpeed);
 
     // Calculate new RA stepper target (and DEC). We are never in guding mode here.
@@ -1300,28 +1300,28 @@ void Mount::startSlewingToTarget()
     _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_TO_TARGET;
     _totalDECMove = 1.0f * _stepperDEC->distanceToGo();
     _totalRAMove  = 1.0f * _stepperRA->distanceToGo();
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: RA Dist: %l,   DEC Dist: %l"), _stepperRA->distanceToGo(), _stepperDEC->distanceToGo());
+    INFO(DEBUG_MOUNT, "[MOUNT]: RA Dist: %l,   DEC Dist: %l", _stepperRA->distanceToGo(), _stepperDEC->distanceToGo());
     if ((_stepperRA->distanceToGo() != 0) || (_stepperDEC->distanceToGo() != 0))
     {
         // Only stop tracking if we're actually going to slew somewhere else, otherwise the
         // mount::loop() code won't detect the end of the slewing operation...
-        LOGV1(DEBUG_STEPPERS, F("[MOUNT]: Stop tracking (NEMA steppers)"));
+        INFO(DEBUG_STEPPERS, "[MOUNT]: Stop tracking (NEMA steppers)");
         stopSlewing(TRACKING);
         _trackerStoppedAt        = millis();
         _compensateForTrackerOff = true;
 
 // set Slew microsteps for TMC2209 UART once the TRK stepper has stopped
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
         _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: TRK stopped at %lms"), _trackerStoppedAt);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: TRK stopped at %lms", _trackerStoppedAt);
     }
 
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
     _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 }
@@ -1341,14 +1341,14 @@ void Mount::stopGuiding(bool ra, bool dec)
     // Stop RA guide first, since it's just a speed change back to tracking speed
     if (ra && (_mountStatus & STATUS_GUIDE_PULSE_RA))
     {
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: stopGuiding(RA): TRK.setSpeed(%f)"), _trackingSpeed);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: stopGuiding(RA): TRK.setSpeed(%f)", _trackingSpeed);
         _stepperTRK->setSpeed(_trackingSpeed);
         _mountStatus &= ~STATUS_GUIDE_PULSE_RA;
     }
 
     if (dec && (_mountStatus & STATUS_GUIDE_PULSE_DEC))
     {
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopGuiding(DEC): Stop motor"));
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: stopGuiding(DEC): Stop motor");
 
         // Stop DEC guiding and wait for it to stop.
         _stepperGUIDE->stop();
@@ -1359,7 +1359,7 @@ void Mount::stopGuiding(bool ra, bool dec)
             _stepperTRK->runSpeed();
         }
 
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: stopGuiding(DEC): GuideStepper stopped at %l"), _stepperGUIDE->currentPosition());
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: stopGuiding(DEC): GuideStepper stopped at %l", _stepperGUIDE->currentPosition());
 
         _mountStatus &= ~STATUS_GUIDE_PULSE_DEC;
     }
@@ -1378,7 +1378,7 @@ void Mount::stopGuiding(bool ra, bool dec)
 /////////////////////////////////
 void Mount::guidePulse(byte direction, int duration)
 {
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse: > Guide Pulse %d for %dms"), direction, duration);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: guidePulse: > Guide Pulse %d for %dms", direction, duration);
 
     // DEC stepper moves at sidereal rate in both directions
     // RA stepper moves at either 2.5x sidereal rate or 0.5x sidereal rate.
@@ -1397,14 +1397,14 @@ void Mount::guidePulse(byte direction, int duration)
     switch (direction)
     {
         case NORTH:
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  DEC.setSpeed(%f)"), DEC_PULSE_MULTIPLIER * decGuidingSpeed);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  DEC.setSpeed(%f)", DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _stepperGUIDE->setSpeed(DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_DEC;
             _guideDecEndTime = millis() + duration;
             break;
 
         case SOUTH:
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  DEC.setSpeed(%f)"), -DEC_PULSE_MULTIPLIER * decGuidingSpeed);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  DEC.setSpeed(%f)", -DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _stepperGUIDE->setSpeed(-DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_DEC;
             _guideDecEndTime = millis() + duration;
@@ -1412,7 +1412,7 @@ void Mount::guidePulse(byte direction, int duration)
 
         case WEST:
             // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  TRK.setSpeed(%f)"), (RA_PULSE_MULTIPLIER * raGuidingSpeed));
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  TRK.setSpeed(%f)", (RA_PULSE_MULTIPLIER * raGuidingSpeed));
             _stepperTRK->setSpeed(RA_PULSE_MULTIPLIER * raGuidingSpeed);  // Faster than siderael
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
             _guideRaEndTime = millis() + duration;
@@ -1420,14 +1420,14 @@ void Mount::guidePulse(byte direction, int duration)
 
         case EAST:
             // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  TRK.setSpeed(%f)"), (raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER)));
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  TRK.setSpeed(%f)", (raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER)));
             _stepperTRK->setSpeed(raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER));  // Slower than siderael
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
             _guideRaEndTime = millis() + duration;
             break;
     }
 
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse: < Guide Pulse"));
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: guidePulse: < Guide Pulse");
 }
 
 /////////////////////////////////
@@ -1505,7 +1505,7 @@ void Mount::setManualSlewMode(bool state)
         waitUntilStopped(ALL_DIRECTIONS);
         _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_MANUAL;
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: setManualSlewMode: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setManualSlewMode: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
         _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
     }
@@ -1514,8 +1514,8 @@ void Mount::setManualSlewMode(bool state)
         _mountStatus &= ~STATUS_SLEWING_MANUAL;
         stopSlewing(ALL_DIRECTIONS);
         waitUntilStopped(ALL_DIRECTIONS);
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setManualSlewMode: Set RA  speed/accel:  %f  / %f"), _maxRASpeed, _maxRAAcceleration);
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setManualSlewMode: Set DEC speed/accel:  %f  / %f"), _maxDECSpeed, _maxDECAcceleration);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setManualSlewMode: Set RA  speed/accel:  %f  / %f", _maxRASpeed, _maxRAAcceleration);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setManualSlewMode: Set DEC speed/accel:  %f  / %f", _maxDECSpeed, _maxDECAcceleration);
         _stepperRA->setAcceleration(_maxRAAcceleration);
         _stepperRA->setMaxSpeed(_maxRASpeed);
         _stepperDEC->setMaxSpeed(_maxDECSpeed);
@@ -1534,14 +1534,14 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
     if (which == RA_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerRADegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set RA speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set RA speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         // TODO: Are we already in slew mode?
         _stepperRA->setSpeed(stepsPerSec);
     }
     else if (which == DEC_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerDECDegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set DEC speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set DEC speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         // TODO: Are we already in slew mode?
         _stepperDEC->setSpeed(stepsPerSec);
     }
@@ -1549,7 +1549,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
     else if (which == AZIMUTH_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerAZDegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set AZ speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set AZ speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         _stepperAZ->setSpeed(stepsPerSec);
     }
 #endif
@@ -1557,7 +1557,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
     else if (which == ALTITUDE_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerALTDegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set ALT speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set ALT speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         _stepperALT->setSpeed(stepsPerSec);
     }
 #endif
@@ -1565,11 +1565,11 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
     else if (which == FOCUS_STEPS)
     {
-        LOGV2(DEBUG_MOUNT | DEBUG_FOCUS, F("[FOCUS]: setSpeed() Focuser setSpeed %f"), speedDegsPerSec);
+        INFO(DEBUG_MOUNT | DEBUG_FOCUS, "[FOCUS]: setSpeed() Focuser setSpeed %f", speedDegsPerSec);
         if (speedDegsPerSec != 0)
         {
-            LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS,
-                  F("FOCUS: Mount:setSpeed(): Enabling motor, setting speed to %f. Continuous"),
+            INFO(DEBUG_STEPPERS | DEBUG_FOCUS,
+                  "FOCUS: Mount:setSpeed(): Enabling motor, setting speed to %f. Continuous",
                   speedDegsPerSec);
             enableFocusMotor();
             _stepperFocus->setMaxSpeed(speedDegsPerSec);
@@ -1578,7 +1578,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
         }
         else
         {
-            LOGV1(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: setSpeed(): Stopping motor."));
+            INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: setSpeed(): Stopping motor.");
             _stepperFocus->stop();
         }
     }
@@ -1756,8 +1756,8 @@ void Mount::focusSetSpeedByRate(int rate)
     _focusRate          = clamp(rate, 1, 4);
     float speedFactor[] = {0, 0.05, 0.2, 0.5, 1.0};
     _maxFocusRateSpeed  = speedFactor[_focusRate] * _maxFocusSpeed;
-    LOGV5(DEBUG_FOCUS,
-          F("FOCUS: focusSetSpeedByRate: rate is %d, factor %f, maxspeed %f -> %f"),
+    INFO(DEBUG_FOCUS,
+          "FOCUS: focusSetSpeedByRate: rate is %d, factor %f, maxspeed %f -> %f",
           _focusRate,
           speedFactor[_focusRate],
           _maxFocusSpeed,
@@ -1766,7 +1766,7 @@ void Mount::focusSetSpeedByRate(int rate)
 
     if (_stepperFocus->isRunning())
     {
-        LOGV1(DEBUG_FOCUS, F("[FOCUS]: focusSetSpeedByRate: stepper is already running so should adjust speed?"));
+        INFO(DEBUG_FOCUS, "[FOCUS]: focusSetSpeedByRate: stepper is already running so should adjust speed?");
         //_stepperFocus->setSpeed(speedFactor[_focusRate ] * _maxFocusSpeed);
     }
 }
@@ -1779,7 +1779,7 @@ void Mount::focusSetSpeedByRate(int rate)
 void Mount::focusContinuousMove(FocuserDirection direction)
 {
     // maxSpeed is set to what the rate dictates
-    LOGV3(DEBUG_FOCUS, F("[FOCUS]: focusContinuousMove: direction is %d, maxspeed %f"), direction, _maxFocusRateSpeed);
+    INFO(DEBUG_FOCUS, "[FOCUS]: focusContinuousMove: direction is %d, maxspeed %f", direction, _maxFocusRateSpeed);
     setSpeed(FOCUS_STEPS, static_cast<int>(direction) * _maxFocusRateSpeed);
 }
 
@@ -1791,7 +1791,7 @@ void Mount::focusContinuousMove(FocuserDirection direction)
 void Mount::focusMoveBy(long steps)
 {
     long targetPosition = _stepperFocus->currentPosition() + steps;
-    LOGV3(DEBUG_FOCUS, F("[FOCUS]: focusMoveBy: move by %l steps to %l. Target Mode."), steps, targetPosition);
+    INFO(DEBUG_FOCUS, "[FOCUS]: focusMoveBy: move by %l steps to %l. Target Mode.", steps, targetPosition);
     enableFocusMotor();
     _stepperFocus->moveTo(targetPosition);
     _focuserMode = FOCUS_TO_TARGET;
@@ -1824,7 +1824,7 @@ void Mount::focusSetStepperPosition(long steps)
 /////////////////////////////////
 void Mount::disableFocusMotor()
 {
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: disableFocusMotor: stopping motor and waiting."));
+    INFO(DEBUG_FOCUS, "[FOCUS]: disableFocusMotor: stopping motor and waiting.");
     _stepperFocus->stop();
     waitUntilStopped(FOCUSING);
 
@@ -1832,10 +1832,10 @@ void Mount::disableFocusMotor()
         #if FOCUSER_ALWAYS_ON == 0
             #if (FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
 
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: disableFocusMotor: TMC2209U disabling enable pin"));
+    INFO(DEBUG_FOCUS, "[FOCUS]: disableFocusMotor: TMC2209U disabling enable pin");
     digitalWrite(FOCUS_EN_PIN, HIGH);  // Logic HIGH to disable driver
             #else
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: disableFocusMotor: non-TMC2209U disabling enable pin"));
+    INFO(DEBUG_FOCUS, "[FOCUS]: disableFocusMotor: non-TMC2209U disabling enable pin");
     digitalWrite(FOCUS_EN_PIN, HIGH);  // Logic HIGH to disable driver
             #endif
         #endif
@@ -1849,7 +1849,7 @@ void Mount::disableFocusMotor()
 /////////////////////////////////
 void Mount::enableFocusMotor()
 {
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: enableFocusMotor: enabling driver pin."));
+    INFO(DEBUG_FOCUS, "[FOCUS]: enableFocusMotor: enabling driver pin.");
     digitalWrite(FOCUS_EN_PIN, LOW);  // Logic LOW to enable driver
 }
 
@@ -1860,7 +1860,7 @@ void Mount::enableFocusMotor()
 /////////////////////////////////
 void Mount::focusStop()
 {
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: focusStop: stopping motor."));
+    INFO(DEBUG_FOCUS, "[FOCUS]: focusStop: stopping motor.");
     _stepperFocus->stop();
 }
 
@@ -2165,8 +2165,8 @@ void Mount::startSlewing(int direction)
         {
 // Start tracking
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-            LOGV2(
-                DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: Tracking: Switching RA driver to microsteps(%d)"), RA_TRACKING_MICROSTEPPING);
+            INFO(
+                DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Tracking: Switching RA driver to microsteps(%d)", RA_TRACKING_MICROSTEPPING);
             _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
 #endif
             _stepperTRK->setSpeed(_trackingSpeed);
@@ -2186,17 +2186,17 @@ void Mount::startSlewing(int direction)
                 stopSlewing(TRACKING);
                 _trackerStoppedAt        = millis();
                 _compensateForTrackerOff = true;
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: stopped TRK at %l"), _trackerStoppedAt);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: stopped TRK at %l", _trackerStoppedAt);
             }
 
 // Change microstep mode for slewing
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: Slewing: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Slewing: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
             _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
             // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: Slewing: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Slewing: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
             _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 
@@ -2206,14 +2206,11 @@ void Mount::startSlewing(int direction)
                 if (_decUpperLimit != 0)
                 {
                     targetLocation = _decUpperLimit;
-                    LOGV3(DEBUG_STEPPERS,
-                          F("STEPPERS: startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l"),
-                          _decUpperLimit,
-                          targetLocation);
+                    INFO(DEBUG_STEPPERS, "STEPPERS: startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l", _decUpperLimit, targetLocation);
                 }
                 else
                 {
-                    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(N): initial targetMoveTo is %l"), targetLocation);
+                    INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(N): initial targetMoveTo is %l", targetLocation);
                 }
 
                 _stepperDEC->moveTo(targetLocation);
@@ -2226,14 +2223,14 @@ void Mount::startSlewing(int direction)
                 if (_decLowerLimit != 0)
                 {
                     targetLocation = _decLowerLimit;
-                    LOGV3(DEBUG_STEPPERS,
-                          F("STEPPERS: startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l"),
+                    INFO(DEBUG_STEPPERS,
+                          "STEPPERS: startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l",
                           _decLowerLimit,
                           targetLocation);
                 }
                 else
                 {
-                    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(S): initial targetMoveTo is %l"), targetLocation);
+                    INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(S): initial targetMoveTo is %l", targetLocation);
                 }
 
                 _stepperDEC->moveTo(targetLocation);
@@ -2242,13 +2239,13 @@ void Mount::startSlewing(int direction)
 
             if (direction & EAST)
             {
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(E): initial targetMoveTo is %l"), -sign * 300000);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(E): initial targetMoveTo is %l", -sign * 300000);
                 _stepperRA->moveTo(-sign * 300000);
                 _mountStatus |= STATUS_SLEWING;
             }
             if (direction & WEST)
             {
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(W): initial targetMoveTo is %l"), sign * 300000);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(W): initial targetMoveTo is %l", sign * 300000);
                 _stepperRA->moveTo(sign * 300000);
                 _mountStatus |= STATUS_SLEWING;
             }
@@ -2269,19 +2266,19 @@ void Mount::stopSlewing(int direction)
         // Turn off tracking
         _mountStatus &= ~STATUS_TRACKING;
 
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopSlewing: TRK stepper stop()"));
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: stopSlewing: TRK stepper stop()");
         _stepperTRK->stop();
     }
 
     if ((direction & (NORTH | SOUTH)) != 0)
     {
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopSlewing: DEC stepper stop()"));
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: stopSlewing: DEC stepper stop()");
         _stepperDEC->stop();
     }
 
     if ((direction & (WEST | EAST)) != 0)
     {
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopSlewing: RA stepper stop()"));
+        INFO(DEBUG_STEPPERS, "[STEPPERS]: stopSlewing: RA stepper stop()");
         _stepperRA->stop();
         if (isFindingHome())
         {
@@ -2345,7 +2342,7 @@ void Mount::setHomingOffset(StepperAxis axis, long offset)
         _homing.offsetRA = offset;
 #endif
         EEPROMStore::storeRAHomingOffset(offset);
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: setHomingOffset(RA): Offset: %l"), offset);
+        INFO(DEBUG_MOUNT, "[MOUNT]: setHomingOffset(RA): Offset: %l", offset);
     }
 }
 
@@ -2383,7 +2380,7 @@ void Mount::processRAHomingProgress()
             {
                 if (millis() > _homing.stopAt)
                 {
-                    LOGV1(DEBUG_STEPPERS, F("[HOMING]: Initiating stop at requested time."));
+                    INFO(DEBUG_STEPPERS, "[HOMING]: Initiating stop at requested time.");
                     _stepperRA->stop();
                     _homing.state = HomingState::HOMING_WAIT_FOR_STOP;
                 }
@@ -2394,7 +2391,7 @@ void Mount::processRAHomingProgress()
             {
                 if (!_stepperRA->isRunning())
                 {
-                    LOGV2(DEBUG_STEPPERS, F("[HOMING]: Stepper has stopped as expected, advancing to next state %d"), _homing.nextState);
+                    INFO(DEBUG_STEPPERS, "[HOMING]: Stepper has stopped as expected, advancing to next state %d", _homing.nextState);
                     _homing.state     = _homing.nextState;
                     _homing.nextState = HomingState::HOMING_NOT_ACTIVE;
                 }
@@ -2403,7 +2400,7 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_MOVE_OFF:
             {
-                LOGV2(DEBUG_STEPPERS,
+                INFO(DEBUG_STEPPERS,
                       "HOMING: Currently over Sensor, so moving off of it by reverse 1h. (%l steps)",
                       (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour));
                 moveStepperBy(StepperAxis::RA_STEPS, -_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour);
@@ -2418,7 +2415,7 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (homingPinState == HIGH)
                     {
-                        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Stepper has moved off sensor... stopping in 2s"));
+                        INFO(DEBUG_STEPPERS, "[HOMING]: Stepper has moved off sensor... stopping in 2s");
                         _homing.stopAt    = millis() + 2000;
                         _homing.state     = HomingState::HOMING_STOP_AT_TIME;
                         _homing.nextState = HomingState::HOMING_START_FIND_START;
@@ -2426,7 +2423,7 @@ void Mount::processRAHomingProgress()
                 }
                 else
                 {
-                    LOGV1(DEBUG_STEPPERS, F("[HOMING]: Stepper was unable to move off sensor... homing failed!"));
+                    INFO(DEBUG_STEPPERS, "[HOMING]: Stepper was unable to move off sensor... homing failed!");
                     _homing.state = HomingState::HOMING_FAILED;
                 }
             }
@@ -2435,7 +2432,7 @@ void Mount::processRAHomingProgress()
         case HomingState::HOMING_START_FIND_START:
             {
                 long distance = (long) (_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour * _homing.searchDistance);
-                LOGV3(DEBUG_STEPPERS,
+                INFO(DEBUG_STEPPERS,
                       "HOMING: Finding start on forward pass by moving RA by %dh (%l steps)",
                       _homing.searchDistance,
                       distance);
@@ -2457,7 +2454,7 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (_homing.lastPinState != homingPinState)
                     {
-                        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Found start of sensor, continuing until end is found."));
+                        INFO(DEBUG_STEPPERS, "[HOMING]: Found start of sensor, continuing until end is found.");
                         // Found the start of the sensor, keep going until we find the end
                         _homing.position[HOMING_START_PIN_POSITION] = _stepperRA->currentPosition();
                         _homing.lastPinState                        = homingPinState;
@@ -2468,8 +2465,8 @@ void Mount::processRAHomingProgress()
                 {
                     // Did not find start. Go reverse direction for twice the distance
                     long distance = (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour * _homing.searchDistance * 2);
-                    LOGV3(DEBUG_STEPPERS,
-                          F("HOMING: Hall not found on forward pass. Moving RA reverse by %dh (%l steps)"),
+                    INFO(DEBUG_STEPPERS,
+                          "HOMING: Hall not found on forward pass. Moving RA reverse by %dh (%l steps)",
                           2 * _homing.searchDistance,
                           distance);
                     moveStepperBy(StepperAxis::RA_STEPS, distance);
@@ -2485,7 +2482,7 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (_homing.lastPinState != homingPinState)
                     {
-                        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Found start of sensor reverse, continuing until end is found."));
+                        INFO(DEBUG_STEPPERS, "[HOMING]: Found start of sensor reverse, continuing until end is found.");
                         _homing.position[HOMING_START_PIN_POSITION] = _stepperRA->currentPosition();
                         _homing.lastPinState                        = homingPinState;
                         _homing.state                               = HomingState::HOMING_FINDING_END;
@@ -2494,7 +2491,7 @@ void Mount::processRAHomingProgress()
                 else
                 {
                     // Did not find start in either direction, abort.
-                    LOGV1(DEBUG_STEPPERS, F("[HOMING]: Sensor not found on reverse pass either. Homing Failed."));
+                    INFO(DEBUG_STEPPERS, "[HOMING]: Sensor not found on reverse pass either. Homing Failed.");
                     _homing.state = HomingState::HOMING_FAILED;
                 }
             }
@@ -2507,7 +2504,7 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (_homing.lastPinState != homingPinState)
                     {
-                        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Found end of sensor, stopping..."));
+                        INFO(DEBUG_STEPPERS, "[HOMING]: Found end of sensor, stopping...");
                         _homing.position[HOMING_END_PIN_POSITION] = _stepperRA->currentPosition();
                         _homing.lastPinState                      = homingPinState;
                         _stepperRA->stop();
@@ -2524,16 +2521,16 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_RANGE_FOUND:
             {
-                LOGV4(DEBUG_STEPPERS,
-                      "HOMING: Stepper stopped, Hall sensor found! Range: [%l to %l] size: %l",
+                INFO(DEBUG_STEPPERS,
+                      "[HOMING]: Stepper stopped, Hall sensor found! Range: [%l to %l] size: %l",
                       _homing.position[HOMING_START_PIN_POSITION],
                       _homing.position[HOMING_END_PIN_POSITION],
                       _homing.position[HOMING_START_PIN_POSITION] - _homing.position[HOMING_END_PIN_POSITION]);
 
                 long midPos = (_homing.position[HOMING_START_PIN_POSITION] + _homing.position[HOMING_END_PIN_POSITION]) / 2;
 
-                LOGV4(DEBUG_STEPPERS,
-                      "HOMING: Moving RA to home by %l - (%l) - (%l) steps",
+                INFO(DEBUG_STEPPERS,
+                      "[HOMING]: Moving RA to home by %l - (%l) - (%l) steps",
                       midPos,
                       _stepperRA->currentPosition(),
                       _homing.offsetRA);
@@ -2545,7 +2542,7 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_SUCCESSFUL:
             {
-                LOGV1(DEBUG_STEPPERS, F("[HOMING]: Successfully homed! Setting home and restoring Rate setting."));
+                INFO(DEBUG_STEPPERS, "[HOMING]: Successfully homed! Setting home and restoring Rate setting.");
                 setHome(false);
                 setSlewRate(_homing.savedRate);
                 _homing.state = HomingState::HOMING_NOT_ACTIVE;
@@ -2555,7 +2552,7 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_FAILED:
             {
-                LOGV1(DEBUG_STEPPERS, F("[HOMING]: Failed to home! Restoring Rate setting and slewing to start position."));
+                INFO(DEBUG_STEPPERS, "[HOMING]: Failed to home! Restoring Rate setting and slewing to start position.");
                 setSlewRate(_homing.savedRate);
                 _homing.state = HomingState::HOMING_NOT_ACTIVE;
                 _mountStatus &= ~STATUS_FINDING_HOME;
@@ -2565,7 +2562,7 @@ void Mount::processRAHomingProgress()
             break;
 
         default:
-            LOGV2(DEBUG_STEPPERS, F("[HOMING]: Unhandled state (%d)! "), _homing.state);
+            INFO(DEBUG_STEPPERS, "[HOMING]: Unhandled state (%d)! ", _homing.state);
             break;
     }
 }
@@ -2590,12 +2587,12 @@ bool Mount::findRAHomeByHallSensor(int initialDirection, int searchDistance)
     if (digitalRead(RA_HOMING_SENSOR_PIN) == LOW)
     {
         _homing.state = HomingState::HOMING_MOVE_OFF;
-        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Sensor is signalled, move off sensor started"));
+        INFO(DEBUG_STEPPERS, "[HOMING]: Sensor is signalled, move off sensor started");
     }
     else
     {
         _homing.state = HomingState::HOMING_START_FIND_START;
-        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Sensor is not signalled, find start of range"));
+        INFO(DEBUG_STEPPERS, "[HOMING]: Sensor is not signalled, find start of range");
     }
 
     return true;
@@ -2697,7 +2694,7 @@ void Mount::loop()
 #if (DEBUG_LEVEL & DEBUG_MOUNT) && (DEBUG_LEVEL & DEBUG_VERBOSE)
     if (now - _lastMountPrint > 2000)
     {
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: Status -> %s"), getStatusString().c_str());
+        INFO(DEBUG_MOUNT, "[MOUNT]: Status -> %s", getStatusString().c_str());
         _lastMountPrint = now;
     }
 #endif
@@ -2733,21 +2730,21 @@ void Mount::loop()
 #endif
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    // LOGV2(DEBUG_MOUNT, F("[MOUNT]: Focuser running:  %d"), _stepperFocus->isRunning());
+    // INFO(DEBUG_MOUNT, "[MOUNT]: Focuser running:  %d", _stepperFocus->isRunning());
 
     if (_stepperFocus->isRunning())
     {
-        LOGV2(DEBUG_FOCUS, F("[MOUNT]: Loop: Focuser running at speed %f"), _stepperFocus->speed());
+        INFO(DEBUG_FOCUS, "[MOUNT]: Loop: Focuser running at speed %f", _stepperFocus->speed());
         _focuserWasRunning = true;
     }
     else if (_focuserWasRunning)
     {
-        LOGV1(DEBUG_FOCUS, F("[MOUNT]: Loop: Focuser is stopped, but was running "));
+        INFO(DEBUG_FOCUS, "[MOUNT]: Loop: Focuser is stopped, but was running ");
         // If focuser was running last time through the loop, but not this time, it has
         // either been stopped, or reached the target.
         _focuserMode       = FOCUS_IDLE;
         _focuserWasRunning = false;
-        LOGV1(DEBUG_FOCUS, F("[MOUNT]: Loop: Focuser is stopped, but was running, disabling"));
+        INFO(DEBUG_FOCUS, "[MOUNT]: Loop: Focuser is stopped, but was running, disabling");
         disableFocusMotor();
     }
 
@@ -2798,8 +2795,8 @@ void Mount::loop()
 
             if (_stepperWasRunning)
             {
-                LOGV3(DEBUG_MOUNT | DEBUG_STEPPERS,
-                      F("MOUNT: Loop: Reached target. RA:%l, DEC:%l"),
+                INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
+                      "[MOUNT]: Loop: Reached target. RA:%l, DEC:%l",
                       _stepperRA->currentPosition(),
                       _stepperDEC->currentPosition());
                 // Mount is at Target!
@@ -2810,19 +2807,19 @@ void Mount::loop()
                     // If we're on the second part of the slew to parking, don't set home here
                     if (!_slewingToPark)
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Was Parking, stop tracking and set home."));
+                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was Parking, stop tracking and set home.");
                         setHome(false);
                     }
                     else
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Was Parking, stop tracking."));
+                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was Parking, stop tracking.");
                     }
                 }
 
                 _currentDECStepperPosition = _stepperDEC->currentPosition();
                 _currentRAStepperPosition  = _stepperRA->currentPosition();
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: Loop: Arrived. RA driver setMicrosteps(%d)"), RA_TRACKING_MICROSTEPPING);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: Loop: Arrived. RA driver setMicrosteps(%d)", RA_TRACKING_MICROSTEPPING);
                 _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
 #endif
                 if (!isParking())
@@ -2832,8 +2829,8 @@ void Mount::loop()
                         now                             = millis();
                         unsigned long elapsed           = now - _trackerStoppedAt;
                         unsigned long compensationSteps = _trackingSpeed * elapsed / 1000.0f;
-                        LOGV4(DEBUG_STEPPERS,
-                              F("STEPPERS: loop: Arrived at %lms. Tracking was off for %lms (%l steps), compensating."),
+                        INFO(DEBUG_STEPPERS,
+                              "STEPPERS: loop: Arrived at %lms. Tracking was off for %lms (%l steps), compensating.",
                               now,
                               elapsed,
                               compensationSteps);
@@ -2845,33 +2842,33 @@ void Mount::loop()
 
 // Reset DEC to guide microstepping so that guiding is always ready and no switch is neccessary on guide pulses.
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: Loop: Arrived. DEC driver setMicrosteps(%d)"), DEC_GUIDE_MICROSTEPPING);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: Loop: Arrived. DEC driver setMicrosteps(%d)", DEC_GUIDE_MICROSTEPPING);
                 _driverDEC->microsteps(DEC_GUIDE_MICROSTEPPING == 1 ? 0 : DEC_GUIDE_MICROSTEPPING);
 #endif
 
                 if (_correctForBacklash)
                 {
-                    LOGV3(DEBUG_MOUNT | DEBUG_STEPPERS,
-                          F("MOUNT: Loop:   Reached target at %d. Compensating by %d"),
+                    INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
+                          "MOUNT: Loop:   Reached target at %d. Compensating by %d",
                           (int) _currentRAStepperPosition,
                           _backlashCorrectionSteps);
                     _currentRAStepperPosition += _backlashCorrectionSteps;
                     _stepperRA->runToNewPosition(_currentRAStepperPosition);
                     _correctForBacklash = false;
-                    LOGV2(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Backlash correction done. Pos: %d"), _currentRAStepperPosition);
+                    INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Backlash correction done. Pos: %d", _currentRAStepperPosition);
                 }
                 else
                 {
-                    LOGV2(DEBUG_MOUNT | DEBUG_STEPPERS,
-                          F("MOUNT: Loop:   Reached target at %d, no backlash compensation needed"),
+                    INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
+                          "MOUNT: Loop:   Reached target at %d, no backlash compensation needed",
                           _currentRAStepperPosition);
                 }
 
                 if (_slewingToHome)
                 {
-                    LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Was Slewing home, so setting stepper RA and TRK to zero."));
+                    INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was Slewing home, so setting stepper RA and TRK to zero.");
                     _stepperRA->setCurrentPosition(0);
-                    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Loop:  TRK.setCurrentPos(0)"));
+                    INFO(DEBUG_STEPPERS, "[STEPPERS]: Loop:  TRK.setCurrentPos(0)");
                     _stepperTRK->setCurrentPosition(0);
                     _stepperGUIDE->setCurrentPosition(0);
                     _homeOffsetRA  = 0;
@@ -2880,16 +2877,16 @@ void Mount::loop()
                     _targetRA = currentRA();
                     if (isParking())
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS,
-                              F("MOUNT: Loop:   Was parking, so no tracking. Proceeding to park position..."));
+                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
+                              "[MOUNT]: Loop:   Was parking, so no tracking. Proceeding to park position...");
                         _mountStatus &= ~STATUS_PARKING;
                         _slewingToPark = true;
                         _stepperRA->moveTo(_raParkingPos);
                         _stepperDEC->moveTo(_decParkingPos);
                         _totalDECMove = 1.0f * _stepperDEC->distanceToGo();
                         _totalRAMove  = 1.0f * _stepperRA->distanceToGo();
-                        LOGV5(DEBUG_MOUNT | DEBUG_STEPPERS,
-                              F("MOUNT: Loop:   Park Position is R:%l  D:%l, TotalMove is R:%f, D:%f"),
+                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
+                              "[MOUNT]: Loop:   Park Position is R:%l  D:%l, TotalMove is R:%f, D:%f",
                               _raParkingPos,
                               _decParkingPos,
                               _totalRAMove,
@@ -2901,14 +2898,14 @@ void Mount::loop()
                     }
                     else
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Restart tracking."));
+                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Restart tracking.");
                         startSlewing(TRACKING);
                     }
                     _slewingToHome = false;
                 }
                 else if (_slewingToPark)
                 {
-                    LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Arrived at park position..."));
+                    INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Arrived at park position...");
                     _mountStatus &= ~(STATUS_PARKING_POS | STATUS_SLEWING_TO_TARGET);
                     _slewingToPark = false;
                 }
@@ -2960,7 +2957,7 @@ void Mount::setParkingPosition()
     // TODO: Take guide pulses on DEC into account
     _decParkingPos = _stepperDEC->currentPosition();
 
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: setParkingPos: parking RA: %l  DEC:%l"), _raParkingPos, _decParkingPos);
+    INFO(DEBUG_MOUNT, "[MOUNT]: setParkingPos: parking RA: %l  DEC:%l", _raParkingPos, _decParkingPos);
 
     EEPROMStore::storeRAParkingPos(_raParkingPos);
     EEPROMStore::storeDECParkingPos(_decParkingPos);
@@ -3007,13 +3004,13 @@ void Mount::setDecLimitPositionAbs(bool upper, long stepperPos)
     {
         _decUpperLimit = stepperPos;
         EEPROMStore::storeDECUpperLimit(_decUpperLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: setDecLimitPosition(Upper): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        INFO(DEBUG_MOUNT, "[MOUNT]: setDecLimitPosition(Upper): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
     else
     {
         _decLowerLimit = stepperPos;
         EEPROMStore::storeDECLowerLimit(_decLowerLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: setDecLimitPosition(Lower): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        INFO(DEBUG_MOUNT, "[MOUNT]: setDecLimitPosition(Lower): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
 }
 
@@ -3028,13 +3025,13 @@ void Mount::clearDecLimitPosition(bool upper)
     {
         _decUpperLimit = 0;
         EEPROMStore::storeDECUpperLimit(_decUpperLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: clearDecLimitPosition(Upper): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        INFO(DEBUG_MOUNT, "[MOUNT]: clearDecLimitPosition(Upper): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
     else
     {
         _decLowerLimit = 0;
         EEPROMStore::storeDECLowerLimit(_decLowerLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: clearDecLimitPosition(Lower): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        INFO(DEBUG_MOUNT, "[MOUNT]: clearDecLimitPosition(Lower): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
 }
 
@@ -3056,10 +3053,10 @@ void Mount::getDecLimitPositions(long &lowerLimit, long &upperLimit)
 /////////////////////////////////
 void Mount::setHome(bool clearZeroPos)
 {
-    LOGV1(DEBUG_MOUNT, F("[MOUNT]: setHome() called"));
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePre: currentRA is %s"), currentRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePre: targetRA is %s"), targetRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePre: zeroPos is %s"), _zeroPosRA.ToString());
+    INFO(DEBUG_MOUNT, "[MOUNT]: setHome() called");
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePre: currentRA is %s", currentRA().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePre: targetRA is %s", targetRA().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePre: zeroPos is %s", _zeroPosRA.ToString());
     _zeroPosRA = clearZeroPos ? DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND) : calculateLst();
 #ifdef OAM
     _zeroPosRA.addHours(6);  // shift allcoordinates by 90° for EQ mount movement
@@ -3072,9 +3069,9 @@ void Mount::setHome(bool clearZeroPos)
 
     _targetRA = currentRA();
 
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePost: currentRA is %s"), currentRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePost: zeroPos is %s"), _zeroPosRA.ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePost: targetRA is %s"), targetRA().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePost: currentRA is %s", currentRA().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePost: zeroPos is %s", _zeroPosRA.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePost: targetRA is %s", targetRA().ToString());
 }
 
 /////////////////////////////////
@@ -3087,31 +3084,31 @@ void Mount::setTargetToHome()
 {
     float trackedSeconds = _stepperTRK->currentPosition() / _trackingSpeed;  // steps / steps/s = seconds
 
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: setTargetToHome() called with %fs elapsed tracking"), trackedSeconds);
+    INFO(DEBUG_MOUNT, "[MOUNT]: setTargetToHome() called with %fs elapsed tracking", trackedSeconds);
 
     // In order for RA coordinates to work correctly, we need to
     // offset HATime by elapsed time since last HA set and also
     // adjust RA by the elapsed time and set it to zero.
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePre:  currentRA is %s"), currentRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePre:  ZeroPosRA is %s"), _zeroPosRA.ToString());
-    //LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePre:  TrackedSeconds is %f, TRK Stepper: %l"), trackedSeconds, _stepperTRK->currentPosition());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePre:  LST is %s"), _LST.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePre:  currentRA is %s", currentRA().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePre:  ZeroPosRA is %s", _zeroPosRA.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePre:  TrackedSeconds is %f, TRK Stepper: %l", trackedSeconds, _stepperTRK->currentPosition());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePre:  LST is %s", _LST.ToString());
     DayTime lst(_LST);
     lst.addSeconds(trackedSeconds);
     setLST(lst);
     _targetRA = _zeroPosRA;
     _targetRA.addSeconds(trackedSeconds);
 
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePost:  currentRA is %s"), currentRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePost: ZeroPosRA is %s"), _zeroPosRA.ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePost: LST is %s"), _LST.ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setTargetToHomePost: TargetRA is %s"), _targetRA.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePost:  currentRA is %s", currentRA().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePost: ZeroPosRA is %s", _zeroPosRA.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePost: LST is %s", _LST.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setTargetToHomePost: TargetRA is %s", _targetRA.ToString());
 
     // Set DEC to pole
     _targetDEC.set(0, 0, 0);
     _slewingToHome = true;
     // Stop the tracking stepper
-    LOGV1(DEBUG_MOUNT, F("[MOUNT]: setTargetToHome() stop tracking"));
+    INFO(DEBUG_MOUNT, "[MOUNT]: setTargetToHome() stop tracking");
     stopSlewing(TRACKING);
 }
 
@@ -3163,14 +3160,14 @@ void Mount::calculateStepperPositions(float raCoord, float decCoord, long &raPos
 /////////////////////////////////
 void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps, long pSolutions[6]) const
 {
-    //LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersPre: Current: RA: %s, DEC: %s"), currentRA().ToString(), currentDEC().ToString());
-    //LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersPre: Target : RA: %s, DEC: %s"), _targetRA.ToString(), _targetDEC.ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersPre: ZeroRA : %s"), _zeroPosRA.ToString());
-    //LOGV4(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersPre: Stepper: RA: %l, DEC: %l, TRK: %l"), _stepperRA->currentPosition(), _stepperDEC->currentPosition(), _stepperTRK->currentPosition());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersPre: Current: RA: %s, DEC: %s", currentRA().ToString(), currentDEC().ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersPre: Target : RA: %s, DEC: %s", _targetRA.ToString(), _targetDEC.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersPre: ZeroRA : %s", _zeroPosRA.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersPre: Stepper: RA: %l, DEC: %l, TRK: %l", _stepperRA->currentPosition(), _stepperDEC->currentPosition(), _stepperTRK->currentPosition());
     DayTime raTarget = _targetRA;
 
     raTarget.subtractTime(_zeroPosRA);
-    //LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: Adjust RA by Zeropos. New Target RA: %s, DEC: %s"), raTarget.ToString(), _targetDEC.ToString());
+    //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: Adjust RA by Zeropos. New Target RA: %s, DEC: %s", raTarget.ToString(), _targetDEC.ToString());
 
     float hourPos = raTarget.getTotalHours();
     if (!NORTHERN_HEMISPHERE)
@@ -3181,7 +3178,7 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
     while (hourPos > 12)
     {
         hourPos = hourPos - 24;
-        //LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: RA>12 so -24. New Target RA: %s, DEC: %s"), DayTime(hourPos).ToString(), _targetDEC.ToString());
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: RA>12 so -24. New Target RA: %s, DEC: %s", DayTime(hourPos).ToString(), _targetDEC.ToString());
     }
 
     // How many u-steps moves the RA ring one sidereal hour along when slewing. One sidereal hour moves just shy of 15 degrees
@@ -3194,8 +3191,8 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
     // the variable targetDEC 0deg for the celestial pole (90deg), and goes negative only.
     float moveDEC = -_targetDEC.getTotalDegrees() * _stepsPerDECDegree;  // deg * u-steps/deg = u-steps
 
-//LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: RA Steps/deg: %d   Steps/srhour: %f"), _stepsPerRADegree, stepsPerSiderealHour);
-//LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: Target Step pos RA: %f, DEC: %f"), moveRA, moveDEC);
+//INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: RA Steps/deg: %d   Steps/srhour: %f", _stepsPerRADegree, stepsPerSiderealHour);
+//INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: Target Step pos RA: %f, DEC: %f", moveRA, moveDEC);
 
 /*
   * Current RA wheel has a rotation limit of around 7 hours in each direction from home position.
@@ -3227,26 +3224,26 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
     // If we reach the limit in the positive direction ...
     if (moveRA > RALimitR)
     {
-        //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: RA is past +limit: %f, DEC: %f"), RALimit);
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: RA is past +limit: %f, DEC: %f", RALimit);
 
         // ... turn both RA and DEC axis around
 
         moveRA -= long(12.0f * stepsPerSiderealHour);
         moveDEC = -moveDEC;
-        //LOGV3(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: Adjusted Target Step pos RA: %f, DEC: %f"), moveRA, moveDEC);
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: Adjusted Target Step pos RA: %f, DEC: %f", moveRA, moveDEC);
     }
     // If we reach the limit in the negative direction...
     else if (moveRA < -RALimitL)
     {
-        //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersIn: RA is past -limit: %f, DEC: %f"), -RALimit);
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersIn: RA is past -limit: %f, DEC: %f", -RALimit);
         // ... turn both RA and DEC axis around
 
         moveRA += long(12.0f * stepsPerSiderealHour);
         moveDEC = -moveDEC;
-        //LOGV1(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: CalcSteppersPost: Adjusted Target. Moved RA, inverted DEC"));
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CalcSteppersPost: Adjusted Target. Moved RA, inverted DEC");
     }
 
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: CalcSteppersPost: Target Steps RA: %f, DEC: %f"), -moveRA, moveDEC);
+    INFO(DEBUG_MOUNT, "[MOUNT]: CalcSteppersPost: Target Steps RA: %f, DEC: %f", -moveRA, moveDEC);
     //    float targetRA = clamp(-moveRA, -RAStepperLimit, RAStepperLimit);
     //    float targetDEC = clamp(moveDEC, DECStepperUpLimit, DECStepperDownLimit);
     targetRASteps  = -moveRA;
@@ -3272,12 +3269,12 @@ void Mount::moveSteppersTo(float targetRASteps, float targetDECSteps)
 {  // Units are u-steps (in slew mode)
     // Show time: tell the steppers where to go!
     _correctForBacklash = false;
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: MoveSteppersTo: RA  From: %l  To: %f"), _stepperRA->currentPosition(), targetRASteps);
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: MoveSteppersTo: DEC From: %l  To: %f"), _stepperDEC->currentPosition(), targetDECSteps);
+    INFO(DEBUG_MOUNT, "[MOUNT]: MoveSteppersTo: RA  From: %l  To: %f", _stepperRA->currentPosition(), targetRASteps);
+    INFO(DEBUG_MOUNT, "[MOUNT]: MoveSteppersTo: DEC From: %l  To: %f", _stepperDEC->currentPosition(), targetDECSteps);
 
     if ((_backlashCorrectionSteps != 0) && ((_stepperRA->currentPosition() - targetRASteps) > 0))
     {
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: MoveSteppersTo: Needs backlash correction of %d!"), _backlashCorrectionSteps);
+        INFO(DEBUG_MOUNT, "[MOUNT]: MoveSteppersTo: Needs backlash correction of %d!", _backlashCorrectionSteps);
         targetRASteps -= _backlashCorrectionSteps;
         _correctForBacklash = true;
     }
@@ -3287,12 +3284,12 @@ void Mount::moveSteppersTo(float targetRASteps, float targetDECSteps)
     if (_decUpperLimit != 0)
     {
         targetDECSteps = min(targetDECSteps, (float) _decUpperLimit);
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: MoveSteppersTo: DEC Upper Limit enforced. To: %f"), targetDECSteps);
+        INFO(DEBUG_MOUNT, "[MOUNT]: MoveSteppersTo: DEC Upper Limit enforced. To: %f", targetDECSteps);
     }
     if (_decLowerLimit != 0)
     {
         targetDECSteps = max(targetDECSteps, (float) _decLowerLimit);
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: MoveSteppersTo: DEC Lower Limit enforced. To: %f"), targetDECSteps);
+        INFO(DEBUG_MOUNT, "[MOUNT]: MoveSteppersTo: DEC Lower Limit enforced. To: %f", targetDECSteps);
     }
 
     _stepperDEC->moveTo(targetDECSteps);
@@ -3305,7 +3302,7 @@ void Mount::moveSteppersTo(float targetRASteps, float targetDECSteps)
 /////////////////////////////////
 void Mount::moveStepperBy(StepperAxis direction, long steps)
 {
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: %l"), steps);
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: %l", steps);
     switch (direction)
     {
         case RA_STEPS:
@@ -3316,18 +3313,18 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
             {
                 // Only stop tracking if we're actually going to slew somewhere else, otherwise the
                 // mount::loop() code won't detect the end of the slewing operation...
-                LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: Stop tracking (NEMA steppers)"));
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: Stop tracking (NEMA steppers)");
                 stopSlewing(TRACKING);
                 _trackerStoppedAt        = millis();
                 _compensateForTrackerOff = true;
 
 // set Slew microsteps for TMC2209 UART once the TRK stepper has stopped
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
                 _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: TRK stopped at %lms"), _trackerStoppedAt);
+                INFO(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: TRK stopped at %lms", _trackerStoppedAt);
             }
             break;
         case DEC_STEPS:
@@ -3337,7 +3334,7 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
 
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
             // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
             _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 
@@ -3350,8 +3347,8 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
         case AZIMUTH_STEPS:
 #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
             enableAzAltMotors();
-            LOGV3(DEBUG_STEPPERS,
-                  "STEPPERS: moveStepperBy: AZ from %l to %l",
+            INFO(DEBUG_STEPPERS,
+                  "[STEPPERS]: moveStepperBy: AZ from %l to %l",
                   _stepperAZ->currentPosition(),
                   _stepperAZ->currentPosition() + steps);
             _stepperAZ->moveTo(_stepperAZ->currentPosition() + steps);
@@ -3471,17 +3468,17 @@ String Mount::DECString(byte type, byte active)
     Declination dec;
     if ((type & TARGET_STRING) == TARGET_STRING)
     {
-        //LOGV1(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: DECString: TARGET!"));
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: DECString: TARGET!");
         dec = _targetDEC;
     }
     else
     {
-        //LOGV1(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: DECString: CURRENT!"));
+        //INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: DECString: CURRENT!");
         dec = currentDEC();
     }
-    //LOGV5(DEBUG_INFO,F("[MOUNT]: DECString: Precheck  : %s   %s  %dm %ds"), dec.ToString(), dec.getDegreesDisplay().c_str(), dec.getMinutes(), dec.getSeconds());
+    //INFO(DEBUG_INFO, "[MOUNT]: DECString: Precheck  : %s   %s  %dm %ds", dec.ToString(), dec.getDegreesDisplay().c_str(), dec.getMinutes(), dec.getSeconds());
     // dec.checkHours();
-    // LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: DECString: Postcheck : %s"), dec.ToString());
+    // INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: DECString: Postcheck : %s", dec.ToString());
 
     dec.formatString(scratchBuffer, formatStringsDEC[type & FORMAT_STRING_MASK]);
 

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1180,10 +1180,10 @@ const DayTime Mount::currentRA() const
     float hourPos              = -_stepperRA->currentPosition() / stepsPerSiderealHour;  // u-steps / u-steps/hr = hr
 
     INFO(DEBUG_MOUNT_VERBOSE,
-          "MOUNT: CurrentRA: Steps/h    : %s (%f x %s)",
-          String(stepsPerSiderealHour, 2).c_str(),
-          _stepsPerRADegree,
-          String(siderealDegreesInHour, 5).c_str());
+         "MOUNT: CurrentRA: Steps/h    : %s (%f x %s)",
+         String(stepsPerSiderealHour, 2).c_str(),
+         _stepsPerRADegree,
+         String(siderealDegreesInHour, 5).c_str());
     INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: RA Steps   : %d", _stepperRA->currentPosition());
     INFO(DEBUG_MOUNT_VERBOSE, "[MOUNT]: CurrentRA: POS        : %s", String(hourPos).c_str());
     hourPos += _zeroPosRA.getTotalHours();
@@ -1568,9 +1568,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
         INFO(DEBUG_MOUNT | DEBUG_FOCUS, "[FOCUS]: setSpeed() Focuser setSpeed %f", speedDegsPerSec);
         if (speedDegsPerSec != 0)
         {
-            INFO(DEBUG_STEPPERS | DEBUG_FOCUS,
-                  "FOCUS: Mount:setSpeed(): Enabling motor, setting speed to %f. Continuous",
-                  speedDegsPerSec);
+            INFO(DEBUG_STEPPERS | DEBUG_FOCUS, "FOCUS: Mount:setSpeed(): Enabling motor, setting speed to %f. Continuous", speedDegsPerSec);
             enableFocusMotor();
             _stepperFocus->setMaxSpeed(speedDegsPerSec);
             _stepperFocus->moveTo(sign(speedDegsPerSec) * 300000);
@@ -1757,11 +1755,11 @@ void Mount::focusSetSpeedByRate(int rate)
     float speedFactor[] = {0, 0.05, 0.2, 0.5, 1.0};
     _maxFocusRateSpeed  = speedFactor[_focusRate] * _maxFocusSpeed;
     INFO(DEBUG_FOCUS,
-          "FOCUS: focusSetSpeedByRate: rate is %d, factor %f, maxspeed %f -> %f",
-          _focusRate,
-          speedFactor[_focusRate],
-          _maxFocusSpeed,
-          _maxFocusRateSpeed);
+         "FOCUS: focusSetSpeedByRate: rate is %d, factor %f, maxspeed %f -> %f",
+         _focusRate,
+         speedFactor[_focusRate],
+         _maxFocusSpeed,
+         _maxFocusRateSpeed);
     _stepperFocus->setMaxSpeed(_maxFocusRateSpeed);
 
     if (_stepperFocus->isRunning())
@@ -2165,8 +2163,7 @@ void Mount::startSlewing(int direction)
         {
 // Start tracking
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-            INFO(
-                DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Tracking: Switching RA driver to microsteps(%d)", RA_TRACKING_MICROSTEPPING);
+            INFO(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Tracking: Switching RA driver to microsteps(%d)", RA_TRACKING_MICROSTEPPING);
             _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
 #endif
             _stepperTRK->setSpeed(_trackingSpeed);
@@ -2206,7 +2203,10 @@ void Mount::startSlewing(int direction)
                 if (_decUpperLimit != 0)
                 {
                     targetLocation = _decUpperLimit;
-                    INFO(DEBUG_STEPPERS, "STEPPERS: startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l", _decUpperLimit, targetLocation);
+                    INFO(DEBUG_STEPPERS,
+                         "STEPPERS: startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l",
+                         _decUpperLimit,
+                         targetLocation);
                 }
                 else
                 {
@@ -2224,9 +2224,9 @@ void Mount::startSlewing(int direction)
                 {
                     targetLocation = _decLowerLimit;
                     INFO(DEBUG_STEPPERS,
-                          "STEPPERS: startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l",
-                          _decLowerLimit,
-                          targetLocation);
+                         "STEPPERS: startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l",
+                         _decLowerLimit,
+                         targetLocation);
                 }
                 else
                 {
@@ -2401,8 +2401,8 @@ void Mount::processRAHomingProgress()
         case HomingState::HOMING_MOVE_OFF:
             {
                 INFO(DEBUG_STEPPERS,
-                      "HOMING: Currently over Sensor, so moving off of it by reverse 1h. (%l steps)",
-                      (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour));
+                     "HOMING: Currently over Sensor, so moving off of it by reverse 1h. (%l steps)",
+                     (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour));
                 moveStepperBy(StepperAxis::RA_STEPS, -_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour);
                 _homing.state = HomingState::HOMING_MOVING_OFF;
             }
@@ -2433,9 +2433,9 @@ void Mount::processRAHomingProgress()
             {
                 long distance = (long) (_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour * _homing.searchDistance);
                 INFO(DEBUG_STEPPERS,
-                      "HOMING: Finding start on forward pass by moving RA by %dh (%l steps)",
-                      _homing.searchDistance,
-                      distance);
+                     "HOMING: Finding start on forward pass by moving RA by %dh (%l steps)",
+                     _homing.searchDistance,
+                     distance);
                 _homing.pinState = _homing.lastPinState     = digitalRead(RA_HOMING_SENSOR_PIN);
                 _homing.position[HOMING_START_PIN_POSITION] = 0;
                 _homing.position[HOMING_END_PIN_POSITION]   = 0;
@@ -2466,9 +2466,9 @@ void Mount::processRAHomingProgress()
                     // Did not find start. Go reverse direction for twice the distance
                     long distance = (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour * _homing.searchDistance * 2);
                     INFO(DEBUG_STEPPERS,
-                          "HOMING: Hall not found on forward pass. Moving RA reverse by %dh (%l steps)",
-                          2 * _homing.searchDistance,
-                          distance);
+                         "HOMING: Hall not found on forward pass. Moving RA reverse by %dh (%l steps)",
+                         2 * _homing.searchDistance,
+                         distance);
                     moveStepperBy(StepperAxis::RA_STEPS, distance);
                     _homing.state = HomingState::HOMING_FINDING_START_REVERSE;
                 }
@@ -2522,18 +2522,18 @@ void Mount::processRAHomingProgress()
         case HomingState::HOMING_RANGE_FOUND:
             {
                 INFO(DEBUG_STEPPERS,
-                      "[HOMING]: Stepper stopped, Hall sensor found! Range: [%l to %l] size: %l",
-                      _homing.position[HOMING_START_PIN_POSITION],
-                      _homing.position[HOMING_END_PIN_POSITION],
-                      _homing.position[HOMING_START_PIN_POSITION] - _homing.position[HOMING_END_PIN_POSITION]);
+                     "[HOMING]: Stepper stopped, Hall sensor found! Range: [%l to %l] size: %l",
+                     _homing.position[HOMING_START_PIN_POSITION],
+                     _homing.position[HOMING_END_PIN_POSITION],
+                     _homing.position[HOMING_START_PIN_POSITION] - _homing.position[HOMING_END_PIN_POSITION]);
 
                 long midPos = (_homing.position[HOMING_START_PIN_POSITION] + _homing.position[HOMING_END_PIN_POSITION]) / 2;
 
                 INFO(DEBUG_STEPPERS,
-                      "[HOMING]: Moving RA to home by %l - (%l) - (%l) steps",
-                      midPos,
-                      _stepperRA->currentPosition(),
-                      _homing.offsetRA);
+                     "[HOMING]: Moving RA to home by %l - (%l) - (%l) steps",
+                     midPos,
+                     _stepperRA->currentPosition(),
+                     _homing.offsetRA);
                 moveStepperBy(StepperAxis::RA_STEPS, midPos - _stepperRA->currentPosition() - _homing.offsetRA);
                 _homing.state     = HomingState::HOMING_WAIT_FOR_STOP;
                 _homing.nextState = HomingState::HOMING_SUCCESSFUL;
@@ -2796,9 +2796,9 @@ void Mount::loop()
             if (_stepperWasRunning)
             {
                 INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
-                      "[MOUNT]: Loop: Reached target. RA:%l, DEC:%l",
-                      _stepperRA->currentPosition(),
-                      _stepperDEC->currentPosition());
+                     "[MOUNT]: Loop: Reached target. RA:%l, DEC:%l",
+                     _stepperRA->currentPosition(),
+                     _stepperDEC->currentPosition());
                 // Mount is at Target!
                 // If we we're parking, we just reached home. Clear the flag, reset the motors and stop tracking.
                 if (isParking())
@@ -2830,10 +2830,10 @@ void Mount::loop()
                         unsigned long elapsed           = now - _trackerStoppedAt;
                         unsigned long compensationSteps = _trackingSpeed * elapsed / 1000.0f;
                         INFO(DEBUG_STEPPERS,
-                              "STEPPERS: loop: Arrived at %lms. Tracking was off for %lms (%l steps), compensating.",
-                              now,
-                              elapsed,
-                              compensationSteps);
+                             "STEPPERS: loop: Arrived at %lms. Tracking was off for %lms (%l steps), compensating.",
+                             now,
+                             elapsed,
+                             compensationSteps);
                         _stepperTRK->runToNewPosition(_stepperTRK->currentPosition() + compensationSteps);
                         _compensateForTrackerOff = false;
                     }
@@ -2849,9 +2849,9 @@ void Mount::loop()
                 if (_correctForBacklash)
                 {
                     INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
-                          "MOUNT: Loop:   Reached target at %d. Compensating by %d",
-                          (int) _currentRAStepperPosition,
-                          _backlashCorrectionSteps);
+                         "MOUNT: Loop:   Reached target at %d. Compensating by %d",
+                         (int) _currentRAStepperPosition,
+                         _backlashCorrectionSteps);
                     _currentRAStepperPosition += _backlashCorrectionSteps;
                     _stepperRA->runToNewPosition(_currentRAStepperPosition);
                     _correctForBacklash = false;
@@ -2860,8 +2860,8 @@ void Mount::loop()
                 else
                 {
                     INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
-                          "MOUNT: Loop:   Reached target at %d, no backlash compensation needed",
-                          _currentRAStepperPosition);
+                         "MOUNT: Loop:   Reached target at %d, no backlash compensation needed",
+                         _currentRAStepperPosition);
                 }
 
                 if (_slewingToHome)
@@ -2877,8 +2877,7 @@ void Mount::loop()
                     _targetRA = currentRA();
                     if (isParking())
                     {
-                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
-                              "[MOUNT]: Loop:   Was parking, so no tracking. Proceeding to park position...");
+                        INFO(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was parking, so no tracking. Proceeding to park position...");
                         _mountStatus &= ~STATUS_PARKING;
                         _slewingToPark = true;
                         _stepperRA->moveTo(_raParkingPos);
@@ -2886,11 +2885,11 @@ void Mount::loop()
                         _totalDECMove = 1.0f * _stepperDEC->distanceToGo();
                         _totalRAMove  = 1.0f * _stepperRA->distanceToGo();
                         INFO(DEBUG_MOUNT | DEBUG_STEPPERS,
-                              "[MOUNT]: Loop:   Park Position is R:%l  D:%l, TotalMove is R:%f, D:%f",
-                              _raParkingPos,
-                              _decParkingPos,
-                              _totalRAMove,
-                              _totalDECMove);
+                             "[MOUNT]: Loop:   Park Position is R:%l  D:%l, TotalMove is R:%f, D:%f",
+                             _raParkingPos,
+                             _decParkingPos,
+                             _totalRAMove,
+                             _totalDECMove);
                         if ((_stepperDEC->distanceToGo() != 0) || (_stepperRA->distanceToGo() != 0))
                         {
                             _mountStatus |= STATUS_PARKING_POS | STATUS_SLEWING;
@@ -3348,9 +3347,9 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
 #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
             enableAzAltMotors();
             INFO(DEBUG_STEPPERS,
-                  "[STEPPERS]: moveStepperBy: AZ from %l to %l",
-                  _stepperAZ->currentPosition(),
-                  _stepperAZ->currentPosition() + steps);
+                 "[STEPPERS]: moveStepperBy: AZ from %l to %l",
+                 _stepperAZ->currentPosition(),
+                 _stepperAZ->currentPosition() + steps);
             _stepperAZ->moveTo(_stepperAZ->currentPosition() + steps);
 #endif
             break;

--- a/src/Utility.hpp
+++ b/src/Utility.hpp
@@ -12,7 +12,7 @@ int freeMemory();
 
 #if DEBUG_LEVEL > 0
     // note that the GCC version of pio doesn't support __VA_ARGS__ directly, hence this fix.
-    #define INFO(level, format, ...) logv((level), F(format), ##__VA_ARGS__)
+    #define INFO(level, format, ...)  logv((level), F(format), ##__VA_ARGS__)
     #define DEBUG(level, format, ...) logv((level), (F(format)), ##__VA_ARGS__)
 // Realtime timer class using microseconds to time stuff
 class RealTime

--- a/src/Utility.hpp
+++ b/src/Utility.hpp
@@ -11,16 +11,9 @@ String getLogBuffer();
 int freeMemory();
 
 #if DEBUG_LEVEL > 0
-
-    #define LOGV1(level, a)                      logv((level), (a))
-    #define LOGV2(level, a, b)                   logv((level), (a), (b))
-    #define LOGV3(level, a, b, c)                logv((level), (a), (b), (c))
-    #define LOGV4(level, a, b, c, d)             logv((level), (a), (b), (c), (d))
-    #define LOGV5(level, a, b, c, d, e)          logv((level), (a), (b), (c), (d), (e))
-    #define LOGV6(level, a, b, c, d, e, f)       logv((level), (a), (b), (c), (d), (e), (f))
-    #define LOGV7(level, a, b, c, d, e, f, g)    logv((level), (a), (b), (c), (d), (e), (f), (g))
-    #define LOGV8(level, a, b, c, d, e, f, g, h) logv((level), (a), (b), (c), (d), (e), (f), (g), (h))
-
+    // note that the GCC version of pio doesn't support __VA_ARGS__ directly, hence this fix.
+    #define INFO(level, format, ...) logv((level), F(format), ##__VA_ARGS__)
+    #define DEBUG(level, format, ...) logv((level), (F(format)), ##__VA_ARGS__)
 // Realtime timer class using microseconds to time stuff
 class RealTime
 {
@@ -138,14 +131,8 @@ String format(const char *input, ...);
 void logv(int levelFlags, String input, ...);
 
 #else  // DEBUG_LEVEL>0
-
-    #define LOGV1(level, a)
-    #define LOGV2(level, a, b)
-    #define LOGV3(level, a, b, c)
-    #define LOGV4(level, a, b, c, d)
-    #define LOGV5(level, a, b, c, d, e)
-    #define LOGV6(level, a, b, c, d, e, f)
-    #define LOGV7(level, a, b, c, d, e, f, g)
+    #define INFO(level, format, ...)
+    #define DEBUG(level, format, ...)
 
 #endif  // DEBUG_LEVEL>0
 

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -137,10 +137,10 @@ void WifiControl::loop()
             _udp->begin(4031);
 
             INFO(DEBUG_WIFI,
-                  "WIFI: Connecting to SSID %s at %s:%d",
-                  WIFI_INFRASTRUCTURE_MODE_SSID,
-                  WiFi.localIP().toString().c_str(),
-                  WIFI_PORT);
+                 "WIFI: Connecting to SSID %s at %s:%d",
+                 WIFI_INFRASTRUCTURE_MODE_SSID,
+                 WiFi.localIP().toString().c_str(),
+                 WIFI_PORT);
         }
     }
 
@@ -222,10 +222,10 @@ void WifiControl::udpLoop()
         reply += "@";
         reply += WiFi.localIP().toString();
         INFO(DEBUG_WIFI,
-              "[WIFIUDP]: Received %d bytes from %s, port %d",
-              packetSize,
-              _udp->remoteIP().toString().c_str(),
-              _udp->remotePort());
+             "[WIFIUDP]: Received %d bytes from %s, port %d",
+             packetSize,
+             _udp->remoteIP().toString().c_str(),
+             _udp->remotePort());
         char incomingPacket[255];
         int len             = _udp->read(incomingPacket, 255);
         incomingPacket[len] = 0;

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -14,7 +14,7 @@ WifiControl::WifiControl(Mount *mount, LcdMenu *lcdMenu)
 
 void WifiControl::setup()
 {
-    LOGV2(DEBUG_WIFI, F("[WIFI]: Starting up Wifi As Mode %d\n"), WIFI_MODE);
+    INFO(DEBUG_WIFI, "[WIFI]: Starting up Wifi As Mode %d\n", WIFI_MODE);
 
     _cmdProcessor = MeadeCommandProcessor::instance();
 
@@ -39,10 +39,10 @@ void WifiControl::setup()
 
 void WifiControl::startInfrastructureMode()
 {
-    LOGV1(DEBUG_WIFI, F("[WIFI]: Starting Infrastructure Mode Wifi"));
-    LOGV2(DEBUG_WIFI, F("[WIFI]:    with host name: %s"), String(WIFI_HOSTNAME).c_str());
-    LOGV2(DEBUG_WIFI, F("[WIFI]:          for SSID: %s"), String(WIFI_INFRASTRUCTURE_MODE_SSID).c_str());
-    LOGV2(DEBUG_WIFI, F("[WIFI]:       and WPA key: %s"), String(WIFI_INFRASTRUCTURE_MODE_WPAKEY).c_str());
+    INFO(DEBUG_WIFI, "[WIFI]: Starting Infrastructure Mode Wifi");
+    INFO(DEBUG_WIFI, "[WIFI]:    with host name: %s", String(WIFI_HOSTNAME).c_str());
+    INFO(DEBUG_WIFI, "[WIFI]:          for SSID: %s", String(WIFI_INFRASTRUCTURE_MODE_SSID).c_str());
+    INFO(DEBUG_WIFI, "[WIFI]:       and WPA key: %s", String(WIFI_INFRASTRUCTURE_MODE_WPAKEY).c_str());
 
     #if defined(ESP32)
     WiFi.setHostname(WIFI_HOSTNAME);
@@ -52,7 +52,7 @@ void WifiControl::startInfrastructureMode()
 
 void WifiControl::startAccessPointMode()
 {
-    LOGV1(DEBUG_WIFI, F("[WIFI]: Starting AP Mode Wifi"));
+    INFO(DEBUG_WIFI, "[WIFI]: Starting AP Mode Wifi");
     IPAddress local_ip(192, 168, 1, 1);
     IPAddress gateway(192, 168, 1, 1);
     IPAddress subnet(255, 255, 255, 0);
@@ -126,7 +126,7 @@ void WifiControl::loop()
     if (_status != WiFi.status())
     {
         _status = WiFi.status();
-        LOGV2(DEBUG_WIFI, F("[WIFI]: Connected status changed to %s"), wifiStatus(_status).c_str());
+        INFO(DEBUG_WIFI, "[WIFI]: Connected status changed to %s", wifiStatus(_status).c_str());
         if (_status == WL_CONNECTED)
         {
             _tcpServer = new WiFiServer(WIFI_PORT);
@@ -136,8 +136,8 @@ void WifiControl::loop()
             _udp = new WiFiUDP();
             _udp->begin(4031);
 
-            LOGV4(DEBUG_WIFI,
-                  F("WIFI: Connecting to SSID %s at %s:%d"),
+            INFO(DEBUG_WIFI,
+                  "WIFI: Connecting to SSID %s at %s:%d",
                   WIFI_INFRASTRUCTURE_MODE_SSID,
                   WiFi.localIP().toString().c_str(),
                   WIFI_PORT);
@@ -164,7 +164,7 @@ void WifiControl::infraToAPFailover()
         startAccessPointMode();
         _infraStart = 0;
 
-        LOGV1(DEBUG_WIFI, F("[WIFI]: Could not connect to Infra, Starting AP."));
+        INFO(DEBUG_WIFI, "[WIFI]: Could not connect to Infra, Starting AP.");
     }
 }
 
@@ -174,31 +174,31 @@ void WifiControl::tcpLoop()
     {
         while (client.available())
         {
-            LOGV2(DEBUG_WIFI, F("[WIFITCP]: Available bytes %d. Peeking."), client.available());
+            INFO(DEBUG_WIFI, "[WIFITCP]: Available bytes %d. Peeking.", client.available());
 
             // Peek first byte and check for ACK (0x06) handshake
-            LOGV2(DEBUG_WIFI, F("[WIFITCP]: First byte is %x"), client.peek());
+            INFO(DEBUG_WIFI, "[WIFITCP]: First byte is %x", client.peek());
             if (client.peek() == 0x06)
             {
                 client.read();
-                LOGV1(DEBUG_WIFI, F("[WIFITCP]: Query <-- Handshake request"));
+                INFO(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
                 client.write("1");
-                LOGV1(DEBUG_WIFI, F("[WIFITCP]: Reply --> 1"));
+                INFO(DEBUG_WIFI, "[WIFITCP]: Reply --> 1");
             }
             else
             {
                 String cmd = client.readStringUntil('#');
-                LOGV2(DEBUG_WIFI, F("[WIFITCP]: Query <-- %s#"), cmd.c_str());
+                INFO(DEBUG_WIFI, "[WIFITCP]: Query <-- %s#", cmd.c_str());
                 String retVal = _cmdProcessor->processCommand(cmd);
 
                 if (retVal != "")
                 {
                     client.write(retVal.c_str());
-                    LOGV2(DEBUG_WIFI, F("[WIFITCP]: Reply --> %s"), retVal.c_str());
+                    INFO(DEBUG_WIFI, "[WIFITCP]: Reply --> %s", retVal.c_str());
                 }
                 else
                 {
-                    LOGV1(DEBUG_WIFI, F("[WIFITCP]: No Reply"));
+                    INFO(DEBUG_WIFI, "[WIFITCP]: No Reply");
                 }
             }
 
@@ -221,15 +221,15 @@ void WifiControl::udpLoop()
         reply += WIFI_HOSTNAME;
         reply += "@";
         reply += WiFi.localIP().toString();
-        LOGV4(DEBUG_WIFI,
-              F("WIFIUDP: Received %d bytes from %s, port %d"),
+        INFO(DEBUG_WIFI,
+              "[WIFIUDP]: Received %d bytes from %s, port %d",
               packetSize,
               _udp->remoteIP().toString().c_str(),
               _udp->remotePort());
         char incomingPacket[255];
         int len             = _udp->read(incomingPacket, 255);
         incomingPacket[len] = 0;
-        LOGV2(DEBUG_WIFI, F("[WIFIUDP]: Received: %s"), incomingPacket);
+        INFO(DEBUG_WIFI, "[WIFIUDP]: Received: %s", incomingPacket);
 
         incomingPacket[lookingFor.length()] = 0;
         if (lookingFor.equalsIgnoreCase(incomingPacket))
@@ -244,7 +244,7 @@ void WifiControl::udpLoop()
     #endif
 
             _udp->endPacket();
-            LOGV2(DEBUG_WIFI, F("[WIFIUDP]: Replied: %s"), reply.c_str());
+            INFO(DEBUG_WIFI, "[WIFIUDP]: Replied: %s", reply.c_str());
         }
     }
 }

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -102,7 +102,7 @@ void setup()
     Serial.begin(SERIAL_BAUDRATE);
 #endif
 
-    LOGV2(DEBUG_ANY, F("[SYSTEM]: Hello, universe, this is OAT %s!"), VERSION);
+    INFO(DEBUG_ANY, "[SYSTEM]: Hello, universe, this is OAT %s!", VERSION);
 
 #if USE_GPS == 1
     GPS_SERIAL_PORT.begin(GPS_BAUD_RATE);
@@ -183,13 +183,13 @@ void setup()
 #endif
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: setup(): focus disabling enable pin"));
+    INFO(DEBUG_FOCUS, "[FOCUS]: setup(): focus disabling enable pin");
     pinMode(FOCUS_EN_PIN, OUTPUT);
     digitalWrite(FOCUS_EN_PIN, HIGH);  // Logic HIGH to disable the driver initally
     #if FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         // include TMC2209 UART pins
         #ifdef FOCUS_SERIAL_PORT
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: setup(): focus TMC2209U starting comms"));
+    INFO(DEBUG_FOCUS, "[FOCUS]: setup(): focus TMC2209U starting comms");
     FOCUS_SERIAL_PORT.begin(57600);  // Start HardwareSerial comms with driver
         #endif
     #endif
@@ -200,12 +200,12 @@ void setup()
     pinMode(RA_HOMING_SENSOR_PIN, INPUT);
 #endif
 
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Get EEPROM store ready..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Get EEPROM store ready...");
     EEPROMStore::initialize();
 
 // Calling the LCD startup here, I2C can't be found if called earlier
 #if DISPLAY_TYPE != DISPLAY_TYPE_NONE
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Get LCD ready..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Get LCD ready...");
     lcdMenu.startup();
 
     // Show a splash screen
@@ -222,17 +222,17 @@ void setup()
     // Check for EEPROM reset (Button down during boot)
     if (lcdButtons.currentState() == btnDOWN)
     {
-        LOGV1(DEBUG_INFO, F("[SYSTEM]: Erasing configuration in EEPROM!"));
+        INFO(DEBUG_INFO, "[SYSTEM]: Erasing configuration in EEPROM!");
         mount.clearConfiguration();
         // Wait for button release
         lcdMenu.setCursor(13, 1);
         lcdMenu.printMenu("CLR");
-        LOGV1(DEBUG_INFO, F("[SYSTEM]: Waiting for button release!"));
+        INFO(DEBUG_INFO, "[SYSTEM]: Waiting for button release!");
         while (lcdButtons.currentState() != btnNONE)
         {
             delay(10);
         }
-        LOGV1(DEBUG_INFO, F("[SYSTEM]: Button released, continuing"));
+        INFO(DEBUG_INFO, "[SYSTEM]: Button released, continuing");
     }
 
     // Create the LCD top-level menu items
@@ -265,14 +265,14 @@ void setup()
 
 #endif  // DISPLAY_TYPE > 0
 
-    LOGV2(DEBUG_ANY, F("[SYSTEM]: Hardware: %s"), mount.getMountHardwareInfo().c_str());
+    INFO(DEBUG_ANY, "[SYSTEM]: Hardware: %s", mount.getMountHardwareInfo().c_str());
 
     // Create the command processor singleton
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Initialize LX200 handler..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Initialize LX200 handler...");
     MeadeCommandProcessor::createProcessor(&mount, &lcdMenu);
 
 #if (WIFI_ENABLED == 1)
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Setup Wifi..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Setup Wifi...");
     wifiControl.setup();
 #endif
 
@@ -280,25 +280,25 @@ void setup()
     // Delay for a while to get UARTs booted...
     delay(1000);
 
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Configure steppers..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Configure steppers...");
 
 // Set the stepper motor parameters
 #if (RA_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure RA stepper NEMA..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure RA stepper NEMA...");
     mount.configureRAStepper(RAmotorPin1, RAmotorPin2, RA_STEPPER_SPEED, RA_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.
 #endif
 
 #if (DEC_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure DEC stepper NEMA..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure DEC stepper NEMA...");
     mount.configureDECStepper(DECmotorPin1, DECmotorPin2, DEC_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.
 #endif
 
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure RA driver TMC2209 UART..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure RA driver TMC2209 UART...");
     #if SW_SERIAL_UART == 0
     mount.configureRAdriver(&RA_SERIAL_PORT, R_SENSE, RA_DRIVER_ADDRESS, RA_RMSCURRENT, RA_STALL_VALUE);
     #elif SW_SERIAL_UART == 1
@@ -306,7 +306,7 @@ void setup()
     #endif
 #endif
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure DEC driver TMC2209 UART..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure DEC driver TMC2209 UART...");
     #if SW_SERIAL_UART == 0
     mount.configureDECdriver(&DEC_SERIAL_PORT, R_SENSE, DEC_DRIVER_ADDRESS, DEC_RMSCURRENT, DEC_STALL_VALUE);
     #elif SW_SERIAL_UART == 1
@@ -315,10 +315,10 @@ void setup()
 #endif
 
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure AZ stepper..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure AZ stepper...");
     mount.configureAZStepper(AZmotorPin1, AZmotorPin2, AZ_STEPPER_SPEED, AZ_STEPPER_ACCELERATION);
     #if AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure AZ driver..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure AZ driver...");
         #if SW_SERIAL_UART == 0
     mount.configureAZdriver(&AZ_SERIAL_PORT, R_SENSE, AZ_DRIVER_ADDRESS, AZ_RMSCURRENT, AZ_STALL_VALUE);
         #elif SW_SERIAL_UART == 1
@@ -327,10 +327,10 @@ void setup()
     #endif
 #endif
 #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure Alt stepper..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure Alt stepper...");
     mount.configureALTStepper(ALTmotorPin1, ALTmotorPin2, ALT_STEPPER_SPEED, ALT_STEPPER_ACCELERATION);
     #if ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure ALT driver..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: Configure ALT driver...");
         #if SW_SERIAL_UART == 0
     mount.configureALTdriver(&ALT_SERIAL_PORT, R_SENSE, ALT_DRIVER_ADDRESS, ALT_RMSCURRENT, ALT_STALL_VALUE);
         #elif SW_SERIAL_UART == 1
@@ -340,11 +340,11 @@ void setup()
 #endif
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: setup(): Configure Focus stepper..."));
+    INFO(DEBUG_ANY, "[STEPPERS]: setup(): Configure Focus stepper...");
     mount.configureFocusStepper(FOCUSmotorPin1, FOCUSmotorPin2, FOCUS_STEPPER_SPEED, FOCUS_STEPPER_ACCELERATION);
     #if FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: setup(): Configure Focus driver..."));
-    LOGV3(DEBUG_FOCUS, F("[FOCUS]: setup(): RSense %f, RMS Current %fmA"), R_SENSE, FOCUS_RMSCURRENT);
+    INFO(DEBUG_ANY, "[STEPPERS]: setup(): Configure Focus driver...");
+    INFO(DEBUG_FOCUS, "[FOCUS]: setup(): RSense %f, RMS Current %fmA", R_SENSE, FOCUS_RMSCURRENT);
         #if SW_SERIAL_UART == 0
     mount.configureFocusDriver(&FOCUS_SERIAL_PORT, R_SENSE, FOCUS_DRIVER_ADDRESS, FOCUS_RMSCURRENT, FOCUS_STALL_VALUE);
         #elif SW_SERIAL_UART == 1
@@ -354,7 +354,7 @@ void setup()
     #endif
 #endif
 
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Read Configuration..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Read Configuration...");
 
     // The mount uses EEPROM storage locations 0-10 that it reads during construction
     // The LCD uses EEPROM storage location 11
@@ -363,8 +363,8 @@ void setup()
     // Read other persisted values and set in mount
     DayTime haTime = EEPROMStore::getHATime();
 
-    LOGV2(DEBUG_INFO, F("[SYSTEM]: SpeedCal: %s"), String(mount.getSpeedCalibration(), 5).c_str());
-    LOGV2(DEBUG_INFO, F("[SYSTEM]: TRKSpeed: %s"), String(mount.getSpeed(TRACKING), 5).c_str());
+    INFO(DEBUG_INFO, "[SYSTEM]: SpeedCal: %s", String(mount.getSpeedCalibration(), 5).c_str());
+    INFO(DEBUG_INFO, "[SYSTEM]: TRKSpeed: %s", String(mount.getSpeed(TRACKING), 5).c_str());
 
     mount.setHA(haTime);
 
@@ -387,30 +387,30 @@ void setup()
     // 2 kHz updates (higher frequency interferes with serial communications and complete messes up OATControl communications)
     if (!InterruptCallback::setInterval(0.5f, stepperControlTimerCallback, &mount))
     {
-        LOGV1(DEBUG_MOUNT, F("[SYSTEM]: CANNOT setup interrupt timer!"));
+        INFO(DEBUG_MOUNT, "[SYSTEM]: CANNOT setup interrupt timer!");
     }
 #endif
 
 #if UART_CONNECTION_TEST_TX == 1
     #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Moving RA axis using UART commands..."));
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: Moving RA axis using UART commands...");
     mount.testRA_UART_TX();
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Finished moving RA axis using UART commands."));
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: Finished moving RA axis using UART commands.");
     #endif
 
     #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Moving DEC axis using UART commands..."));
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: Moving DEC axis using UART commands...");
     mount.testDEC_UART_TX();
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Finished moving DEC axis using UART commands."));
+    INFO(DEBUG_STEPPERS, "[STEPPERS]: Finished moving DEC axis using UART commands.");
     #endif
 #endif
 
 #if TRACK_ON_BOOT == 1
     // Start the tracker.
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Start Tracking..."));
+    INFO(DEBUG_ANY, "[SYSTEM]: Start Tracking...");
     mount.startSlewing(TRACKING);
 #endif
 
     mount.bootComplete();
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Boot complete!"));
+    INFO(DEBUG_ANY, "[SYSTEM]: Boot complete!");
 }

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -38,7 +38,7 @@ int isInHomePosition        = NO;
 
 void startupIsCompleted()
 {
-    LOGV1(DEBUG_INFO, F("[STARTUP]: Completed!"));
+    INFO(DEBUG_INFO, "[STARTUP]: Completed!");
 
     startupState   = StartupCompleted;
     inStartup      = false;
@@ -72,7 +72,7 @@ bool processStartupKeys()
                         {
         #if USE_GYRO_LEVEL == 1
                             startupState = StartupSetRoll;
-                            LOGV1(DEBUG_INFO, F("[STARTUP]: State is set roll!"));
+                            INFO(DEBUG_INFO, "[STARTUP]: State is set roll!");
         #else
                             startupState = StartupSetHATime;
         #endif
@@ -102,7 +102,7 @@ bool processStartupKeys()
         case StartupSetRoll:
             {
                 inStartup = false;
-                LOGV1(DEBUG_INFO, F("[STARTUP]: Switching to CAL menu!"));
+                INFO(DEBUG_INFO, "[STARTUP]: Switching to CAL menu!");
 
                 lcdMenu.setCursor(0, 0);
                 lcdMenu.printMenu("Level front");
@@ -114,7 +114,7 @@ bool processStartupKeys()
 
         case StartupRollConfirmed:
             {
-                LOGV1(DEBUG_INFO, F("[STARTUP]: Roll confirmed!"));
+                INFO(DEBUG_INFO, "[STARTUP]: Roll confirmed!");
                 startupState = StartupSetHATime;
             }
             break;
@@ -123,7 +123,7 @@ bool processStartupKeys()
         case StartupSetHATime:
             {
                 inStartup = false;
-                LOGV1(DEBUG_INFO, F("[STARTUP]: Switching to HA menu!"));
+                INFO(DEBUG_INFO, "[STARTUP]: Switching to HA menu!");
 
         #if USE_GPS == 0
                 // Jump to the HA menu

--- a/src/c722_menuPOI.hpp
+++ b/src/c722_menuPOI.hpp
@@ -86,9 +86,9 @@ bool processPOIKeys()
                         mount.targetDEC() = Declination::FromSeconds(targetSeconds);
                         INFO(DEBUG_INFO, "[POI]: Target RA  is %s. %ls", mount.targetRA().ToString(), targetSeconds);
                         INFO(DEBUG_INFO,
-                              "[POI]: mount target DEC is %s. %ls",
-                              mount.targetDEC().ToString(),
-                              mount.targetDEC().getTotalSeconds());
+                             "[POI]: mount target DEC is %s. %ls",
+                             mount.targetDEC().ToString(),
+                             mount.targetDEC().getTotalSeconds());
                         mount.startSlewingToTarget();
                     }
                 }

--- a/src/c722_menuPOI.hpp
+++ b/src/c722_menuPOI.hpp
@@ -78,15 +78,15 @@ bool processPOIKeys()
                     else
                     {
                         PointOfInterest *poi = &pointOfInterest[currentPOI];
-                        LOGV5(DEBUG_INFO, F("[POI]: Selected %s.  RA: %d %d %d"), poi->pDisplay, poi->hourRA, poi->minRA, poi->secRA);
-                        LOGV5(DEBUG_INFO, F("[POI]: Selected %s. DEC: %d %d %d"), poi->pDisplay, poi->degreeDEC, poi->minDEC, poi->secDEC);
+                        INFO(DEBUG_INFO, "[POI]: Selected %s.  RA: %d %d %d", poi->pDisplay, poi->hourRA, poi->minRA, poi->secRA);
+                        INFO(DEBUG_INFO, "[POI]: Selected %s. DEC: %d %d %d", poi->pDisplay, poi->degreeDEC, poi->minDEC, poi->secDEC);
                         long targetSeconds = (60L * abs(poi->degreeDEC) + poi->minDEC) * 60L + poi->secDEC;
                         targetSeconds *= (poi->degreeDEC < 0 ? -1 : 1);
                         mount.targetRA().set(poi->hourRA, poi->minRA, poi->secRA);
                         mount.targetDEC() = Declination::FromSeconds(targetSeconds);
-                        LOGV3(DEBUG_INFO, F("[POI]: Target RA  is %s. %ls"), mount.targetRA().ToString(), targetSeconds);
-                        LOGV3(DEBUG_INFO,
-                              F("POI: mount target DEC is %s. %ls"),
+                        INFO(DEBUG_INFO, "[POI]: Target RA  is %s. %ls", mount.targetRA().ToString(), targetSeconds);
+                        INFO(DEBUG_INFO,
+                              "[POI]: mount target DEC is %s. %ls",
                               mount.targetDEC().ToString(),
                               mount.targetDEC().getTotalSeconds());
                         mount.startSlewingToTarget();

--- a/src/c72_menuHA_GPS.hpp
+++ b/src/c72_menuHA_GPS.hpp
@@ -36,21 +36,21 @@ bool gpsAqcuisitionComplete(int &indicator)
         {
     #if DEBUG_LEVEL & DEBUG_GPS
             gpsBuf[gpsBufPos++] = 0;
-            LOGV2(DEBUG_GPS, F("[GPS]: Sentence: [%s]"), gpsBuf);
+            INFO(DEBUG_GPS, "[GPS]: Sentence: [%s]", gpsBuf);
             gpsBufPos = 0;
     #endif
 
-            LOGV4(DEBUG_GPS,
-                  F("GPS: Encoded. %l sats, Location is%svalid, age is %lms"),
+            INFO(DEBUG_GPS,
+                  "GPS: Encoded. %l sats, Location is%svalid, age is %lms",
                   gps.satellites.value(),
                   (gps.location.isValid() ? " " : " NOT "),
                   gps.location.age());
             // Make sure we got a fix in the last 30 seconds
             if ((gps.location.lng() != 0) && (gps.location.age() < 30000UL))
             {
-                LOGV2(DEBUG_INFO, F("[GPS]: Sync'd GPS location. Age is %d secs"), gps.location.age() / 1000);
-                LOGV3(DEBUG_INFO, F("[GPS]: Location: %f  %f"), gps.location.lat(), gps.location.lng());
-                LOGV4(DEBUG_INFO, F("[GPS]: UTC time is %dh%dm%ds"), gps.time.hour(), gps.time.minute(), gps.time.second());
+                INFO(DEBUG_INFO, "[GPS]: Sync'd GPS location. Age is %d secs", gps.location.age() / 1000);
+                INFO(DEBUG_INFO, "[GPS]: Location: %f  %f", gps.location.lat(), gps.location.lng());
+                INFO(DEBUG_INFO, "[GPS]: UTC time is %dh%dm%ds", gps.time.hour(), gps.time.minute(), gps.time.second());
                 lcdMenu.printMenu("GPS sync'd....");
 
                 DayTime utcNow = DayTime(gps.time.hour(), gps.time.minute(), gps.time.second());
@@ -92,13 +92,13 @@ bool processHAKeys()
     {
         if (gpsAqcuisitionComplete(indicator))
         {
-            LOGV1(DEBUG_INFO, F("[HA]: GPS acquired"));
+            INFO(DEBUG_INFO, "[HA]: GPS acquired");
             GPS_SERIAL_PORT.end();
             haState = SHOWING_HA_SYNC;
         #if SUPPORT_GUIDED_STARTUP == 1
             if (startupState == StartupWaitForHACompletion)
             {
-                LOGV1(DEBUG_INFO, F("[HA]: We were in startup, so confirm HA"));
+                INFO(DEBUG_INFO, "[HA]: We were in startup, so confirm HA");
                 startupState = StartupHAConfirmed;
                 inStartup    = true;
             }
@@ -109,7 +109,7 @@ bool processHAKeys()
     if (lcdButtons.keyChanged(&key))
     {
         waitForRelease = true;
-        LOGV3(DEBUG_INFO, F("[HA]: Key %d was pressed in state %d"), key, haState);
+        INFO(DEBUG_INFO, "[HA]: Key %d was pressed in state %d", key, haState);
         if (haState == SHOWING_HA_SYNC)
         {
             if (key == btnSELECT)
@@ -176,24 +176,24 @@ bool processHAKeys()
 
         if (key == btnRIGHT)
         {
-            LOGV1(DEBUG_INFO, F("[HA]: Right Key was pressed"));
+            INFO(DEBUG_INFO, "[HA]: Right Key was pressed");
             if (haState == STARTING_GPS)
             {
-                LOGV1(DEBUG_INFO, F("[HA]: In GPS Start mode, switching to manual"));
+                INFO(DEBUG_INFO, "[HA]: In GPS Start mode, switching to manual");
                 GPS_SERIAL_PORT.end();
                 haState = SHOWING_HA_SYNC;
             }
         #if SUPPORT_GUIDED_STARTUP == 1
             else if (startupState == StartupWaitForHACompletion)
             {
-                LOGV1(DEBUG_INFO, F("[HA]: In Startup, not in GPS Start mode, leaving"));
+                INFO(DEBUG_INFO, "[HA]: In Startup, not in GPS Start mode, leaving");
                 startupState = StartupHAConfirmed;
                 inStartup    = true;
             }
         #endif
             else
             {
-                LOGV1(DEBUG_INFO, F("[HA]: leaving HA"));
+                INFO(DEBUG_INFO, "[HA]: leaving HA");
                 lcdMenu.setNextActive();
             }
         }

--- a/src/c72_menuHA_GPS.hpp
+++ b/src/c72_menuHA_GPS.hpp
@@ -41,10 +41,10 @@ bool gpsAqcuisitionComplete(int &indicator)
     #endif
 
             INFO(DEBUG_GPS,
-                  "GPS: Encoded. %l sats, Location is%svalid, age is %lms",
-                  gps.satellites.value(),
-                  (gps.location.isValid() ? " " : " NOT "),
-                  gps.location.age());
+                 "GPS: Encoded. %l sats, Location is%svalid, age is %lms",
+                 gps.satellites.value(),
+                 (gps.location.isValid() ? " " : " NOT "),
+                 gps.location.age());
             // Make sure we got a fix in the last 30 seconds
             if ((gps.location.lng() != 0) && (gps.location.age() < 30000UL))
             {

--- a/src/c75_menuCTRL.hpp
+++ b/src/c75_menuCTRL.hpp
@@ -87,7 +87,7 @@ void processManualSlew(lcdButton_t key)
     const bool directionInTable = directionLookup.tryGet(key, &slewDirection);
     if (!directionInTable)
     {
-        LOGV2(DEBUG_MOUNT, F("[SYSTEM]: Unknown LCD button value: %i"), key);
+        INFO(DEBUG_MOUNT, "[SYSTEM]: Unknown LCD button value: %i", key);
         return;
     }
 
@@ -152,10 +152,10 @@ bool processControlKeys()
                     if (setZeroPoint)
                     {
                         // Leaving Control Menu, so set stepper motor positions to zero.
-                        LOGV1(DEBUG_GENERAL, F("[CTRL]: Calling setHome(true)!"));
+                        INFO(DEBUG_GENERAL, "[CTRL]: Calling setHome(true)!");
                         mount.setHome(true);
-                        LOGV3(DEBUG_GENERAL,
-                              F("CTRL: setHome(true) returned: RA Current %s, Target: %f"),
+                        INFO(DEBUG_GENERAL,
+                              "[CTRL]: setHome(true) returned: RA Current %s, Target: %f",
                               mount.RAString(CURRENT_STRING | COMPACT_STRING).c_str(),
                               mount.RAString(TARGET_STRING | COMPACT_STRING).c_str());
                         mount.startSlewing(TRACKING);

--- a/src/c75_menuCTRL.hpp
+++ b/src/c75_menuCTRL.hpp
@@ -155,9 +155,9 @@ bool processControlKeys()
                         INFO(DEBUG_GENERAL, "[CTRL]: Calling setHome(true)!");
                         mount.setHome(true);
                         INFO(DEBUG_GENERAL,
-                              "[CTRL]: setHome(true) returned: RA Current %s, Target: %f",
-                              mount.RAString(CURRENT_STRING | COMPACT_STRING).c_str(),
-                              mount.RAString(TARGET_STRING | COMPACT_STRING).c_str());
+                             "[CTRL]: setHome(true) returned: RA Current %s, Target: %f",
+                             mount.RAString(CURRENT_STRING | COMPACT_STRING).c_str(),
+                             mount.RAString(TARGET_STRING | COMPACT_STRING).c_str());
                         mount.startSlewing(TRACKING);
                     }
 

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -223,14 +223,14 @@ bool processCalibrationKeys()
         #if USE_GYRO_LEVEL == 1
     if (!gyroStarted)
     {
-        LOGV1(DEBUG_INFO, F("[CAL]: Starting Gyro!"));
+        INFO(DEBUG_INFO, "[CAL]: Starting Gyro!");
         Gyro::startup();
         gyroStarted = true;
     }
 
     if ((startupState == StartupWaitForRollCompletion) && (calState != ROLL_OFFSET_CALIBRATION))
     {
-        LOGV1(DEBUG_INFO, F("[CAL]: In Startup, so going to Roll confirm!"));
+        INFO(DEBUG_INFO, "[CAL]: In Startup, so going to Roll confirm!");
         calState = ROLL_OFFSET_CALIBRATION;
     }
         #endif
@@ -310,7 +310,7 @@ bool processCalibrationKeys()
             lcdMenu.getBacklightBrightnessRange(&minBrightness, &maxBrightness);
             Brightness = clamp(Brightness, minBrightness, maxBrightness);
             lcdMenu.setBacklightBrightness(Brightness, false);
-            LOGV2(DEBUG_INFO, F("[CAL]: Brightness set %i"), lcdMenu.getBacklightBrightness());
+            INFO(DEBUG_INFO, "[CAL]: Brightness set %i", lcdMenu.getBacklightBrightness());
         }
     }
     else if (calState == POLAR_CALIBRATION_WAIT_HOME)
@@ -540,7 +540,7 @@ bool processCalibrationKeys()
                     {
                         if (startupState == StartupWaitForRollCompletion)
                         {
-                            LOGV1(DEBUG_INFO, F("[CAL]: Confirmed roll. Going back to Startup, Roll confirmed!"));
+                            INFO(DEBUG_INFO, "[CAL]: Confirmed roll. Going back to Startup, Roll confirmed!");
                             gotoNextMenu();  // Turns of Gyro
                             inStartup    = true;
                             startupState = StartupRollConfirmed;
@@ -579,13 +579,13 @@ bool processCalibrationKeys()
                         auto angles = Gyro::getCurrentAngles();
                         if (setRollZeroPoint)
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Confirmed Roll offset is %f"), angles.rollAngle);
+                            INFO(DEBUG_GYRO, "[CAL]: Confirmed Roll offset is %f", angles.rollAngle);
                             mount.setRollCalibrationAngle(angles.rollAngle);
-                            LOGV2(DEBUG_GYRO, F("[CAL]: New Roll offset is %f"), mount.getRollCalibrationAngle());
+                            INFO(DEBUG_GYRO, "[CAL]: New Roll offset is %f", mount.getRollCalibrationAngle());
                         }
                         else
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Did not confirm, Roll offset was %f"), angles.rollAngle);
+                            INFO(DEBUG_GYRO, "[CAL]: Did not confirm, Roll offset was %f", angles.rollAngle);
                         }
                         calState       = HIGHLIGHT_ROLL_LEVEL;
                         okToUpdateMenu = true;
@@ -625,12 +625,12 @@ bool processCalibrationKeys()
                         auto angles = Gyro::getCurrentAngles();
                         if (setPitchZeroPoint)
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Confirmed Pitch offset is %f"), angles.pitchAngle);
+                            INFO(DEBUG_GYRO, "[CAL]: Confirmed Pitch offset is %f", angles.pitchAngle);
                             mount.setPitchCalibrationAngle(angles.pitchAngle);
                         }
                         else
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Did not confirm, Pitch offset was %f"), angles.pitchAngle);
+                            INFO(DEBUG_GYRO, "[CAL]: Did not confirm, Pitch offset was %f", angles.pitchAngle);
                         }
                         calState       = HIGHLIGHT_PITCH_LEVEL;
                         okToUpdateMenu = true;
@@ -649,7 +649,7 @@ bool processCalibrationKeys()
                     // UP and DOWN are handled above
                     if (key == btnSELECT)
                     {
-                        LOGV2(DEBUG_GENERAL, F("[CAL]: Set brightness to %d"), Brightness);
+                        INFO(DEBUG_GENERAL, "[CAL]: Set brightness to %d", Brightness);
                         lcdMenu.setBacklightBrightness(Brightness);
                         lcdMenu.printMenu("Level stored.");
                         mount.delay(500);

--- a/src/f_serial.hpp
+++ b/src/f_serial.hpp
@@ -42,7 +42,7 @@ void processSerialData()
         {
             if (buffer[0] == 0x06)
             {
-                LOGV1(DEBUG_SERIAL, F("[SERIAL]: Received: ACK request, replying 1"));
+                INFO(DEBUG_SERIAL, "[SERIAL]: Received: ACK request, replying 1");
     #if DEBUG_LEVEL == DEBUG_NONE
                 Serial.print('1');
     #endif
@@ -50,19 +50,19 @@ void processSerialData()
             else
             {
                 String inCmd = String(buffer[0]) + Serial.readStringUntil('#');
-                LOGV3(DEBUG_SERIAL, F("[SERIAL]: ReceivedCommand(%d chars): [%s]"), inCmd.length(), inCmd.c_str());
+                INFO(DEBUG_SERIAL, "[SERIAL]: ReceivedCommand(%d chars): [%s]", inCmd.length(), inCmd.c_str());
 
                 String retVal = MeadeCommandProcessor::instance()->processCommand(inCmd);
                 if (retVal != "")
                 {
-                    LOGV2(DEBUG_SERIAL, F("[SERIAL]: RepliedWith:  [%s]"), retVal.c_str());
+                    INFO(DEBUG_SERIAL, "[SERIAL]: RepliedWith:  [%s]", retVal.c_str());
     #if DEBUG_LEVEL == DEBUG_NONE
                     Serial.print(retVal);
     #endif
                 }
                 else
                 {
-                    LOGV1(DEBUG_SERIAL, F("[SERIAL]: NoReply"));
+                    INFO(DEBUG_SERIAL, "[SERIAL]: NoReply");
                 }
             }
         }


### PR DESCRIPTION
This is basically `LOGV.\(([^,]+), *F\(("[^"]+")\)([^;]+);` -> `INFO($1, $2$3;` with a few hand edits for multiline and special cases.

```
NO debug:
RAM:   [=====     ]  50.4% (used 4132 bytes from 8192 bytes)
Flash: [===       ]  32.5% (used 84892 bytes from 261120 bytes)

INFO debug:
RAM:   [=====     ]  54.1% (used 4430 bytes from 8192 bytes)
Flash: [=====     ]  45.3% (used 118414 bytes from 261120 bytes)

INFO debug, no using F(fmt) (jikes!):
RAM:   [==========]  202.6% (used 16600 bytes from 8192 bytes)
Flash: [=====     ]  45.2% (used 118086 bytes from 261120 bytes)
```