### PR TITLE
Change LOGVx to LOG

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -29,7 +29,7 @@ BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: Always
-  AfterEnum:       false
+  AfterEnum:       true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.11.3 - Updates**
+- Change logging macro LOGVx to LOG
+
 **V1.11.2 - Updates**
 - Cache build files by default
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.11.2"
+#define VERSION "V1.11.3"

--- a/src/DayTime.cpp
+++ b/src/DayTime.cpp
@@ -17,7 +17,7 @@ DayTime DayTime::ParseFromMeade(String const &s)
     DayTime result;
     int i    = 0;
     long sgn = 1;
-    LOGV2(DEBUG_MEADE, F("[DAYTIME]: Parse Coord from [%s]"), s.c_str());
+    LOG(DEBUG_MEADE, "[DAYTIME]: Parse Coord from [%s]", s.c_str());
     // Check whether we have a sign. This should be able to parse RA and DEC strings (RA never has a sign, and DEC should always have one).
     if ((s[i] == '-') || (s[i] == '+'))
     {
@@ -27,34 +27,34 @@ DayTime DayTime::ParseFromMeade(String const &s)
 
     // Degs can be 2 or 3 digits
     long degs = s[i++] - '0';
-    LOGV3(DEBUG_MEADE, F("[DAYTIME]: 1st digit [%c] -> degs=%l"), s[i - 1], degs);
+    LOG(DEBUG_MEADE, "[DAYTIME]: 1st digit [%c] -> degs=%l", s[i - 1], degs);
     degs = degs * 10 + s[i++] - '0';
-    LOGV3(DEBUG_MEADE, F("[DAYTIME]: 2nd digit [%c] -> degs=%l"), s[i - 1], degs);
+    LOG(DEBUG_MEADE, "[DAYTIME]: 2nd digit [%c] -> degs=%l", s[i - 1], degs);
 
     // Third digit?
     if ((s[i] >= '0') && (s[i] <= '9'))
     {
         degs = degs * 10 + s[i++] - '0';
-        LOGV3(DEBUG_MEADE, F("[DAYTIME]: 3rd digit [%c] -> degs=%d"), s[i - 1], degs);
+        LOG(DEBUG_MEADE, "[DAYTIME]: 3rd digit [%c] -> degs=%d", s[i - 1], degs);
     }
     i++;  // Skip seperator
 
     int mins = s.substring(i, i + 2).toInt();
-    LOGV3(DEBUG_MEADE, F("[DAYTIME]: Minutes are [%s] -> mins=%d"), s.substring(i, i + 2).c_str(), mins);
+    LOG(DEBUG_MEADE, "[DAYTIME]: Minutes are [%s] -> mins=%d", s.substring(i, i + 2).c_str(), mins);
     int secs = 0;
     if (int(s.length()) > i + 4)
     {
         secs = s.substring(i + 3, i + 5).toInt();
-        LOGV3(DEBUG_MEADE, F("[DAYTIME]: Seconds are [%s] -> secs=%d"), s.substring(i + 3, i + 5).c_str(), secs);
+        LOG(DEBUG_MEADE, "[DAYTIME]: Seconds are [%s] -> secs=%d", s.substring(i + 3, i + 5).c_str(), secs);
     }
     else
     {
-        LOGV3(DEBUG_MEADE, F("[DAYTIME]: No Seconds. slen %d is not > %d"), s.length(), i + 4);
+        LOG(DEBUG_MEADE, "[DAYTIME]: No Seconds. slen %d is not > %d", s.length(), i + 4);
     }
     // Get the signed total seconds specified....
     result.totalSeconds = sgn * (((degs * 60L + mins) * 60L) + secs);
 
-    LOGV5(DEBUG_MEADE, F("[DAYTIME]: TotalSeconds are %l from %lh %dm %ds"), result.totalSeconds, degs, mins, secs);
+    LOG(DEBUG_MEADE, "[DAYTIME]: TotalSeconds are %l from %lh %dm %ds", result.totalSeconds, degs, mins, secs);
 
     return result;
 }

--- a/src/Declination.cpp
+++ b/src/Declination.cpp
@@ -59,12 +59,12 @@ void Declination::checkHours()
 {
     if (totalSeconds > arcSecondsPerHemisphere)
     {
-        LOGV1(DEBUG_GENERAL, F("[DECLINATION]: CheckHours: Degrees is more than 180, clamping"));
+        LOG(DEBUG_GENERAL, "[DECLINATION]: CheckHours: Degrees is more than 180, clamping");
         totalSeconds = arcSecondsPerHemisphere;
     }
     if (totalSeconds < -arcSecondsPerHemisphere)
     {
-        LOGV1(DEBUG_GENERAL, F("[DECLINATION]: CheckHours: Degrees is less than -180, clamping"));
+        LOG(DEBUG_GENERAL, "[DECLINATION]: CheckHours: Degrees is less than -180, clamping");
         totalSeconds = -arcSecondsPerHemisphere;
     }
 }
@@ -96,7 +96,7 @@ const char *Declination::ToString() const
 Declination Declination::ParseFromMeade(String const &s)
 {
     Declination result;
-    LOGV2(DEBUG_GENERAL, F("[DECLINATION]: Declination.Parse(%s)"), s.c_str());
+    LOG(DEBUG_GENERAL, "[DECLINATION]: Declination.Parse(%s)", s.c_str());
 
     // Use the DayTime code to parse it...
     DayTime dt = DayTime::ParseFromMeade(s);
@@ -104,7 +104,7 @@ Declination Declination::ParseFromMeade(String const &s)
     // ...and then correct for hemisphere
     result.totalSeconds = NORTHERN_HEMISPHERE ? (arcSecondsPerHemisphere / 2) - dt.getTotalSeconds()
                                               : -(arcSecondsPerHemisphere / 2) + dt.getTotalSeconds();
-    LOGV4(DEBUG_GENERAL, F("[DECLINATION]: Declination.Parse(%s) -> %s (%l)"), s.c_str(), result.ToString(), result.totalSeconds);
+    LOG(DEBUG_GENERAL, "[DECLINATION]: Declination.Parse(%s) -> %s (%l)", s.c_str(), result.ToString(), result.totalSeconds);
     return result;
 }
 

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -19,7 +19,7 @@ static uint8_t dummyEepromStorage[EEPROMStore::STORE_SIZE];
 // Initialize the EEPROM object for ESP boards, setting aside storage
 void EEPROMStore::initialize()
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Dummy: Startup with %d bytes"), EEPROMStore::STORE_SIZE);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Dummy: Startup with %d bytes", EEPROMStore::STORE_SIZE);
     memset(dummyEepromStorage, 0, sizeof(dummyEepromStorage));
 
     displayContents();  // Will always be empty at restart
@@ -28,7 +28,7 @@ void EEPROMStore::initialize()
 // Update the given location with the given value
 void EEPROMStore::update(uint8_t location, uint8_t value)
 {
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Dummy: Writing %x to %d"), value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Dummy: Writing %x to %d", value, location);
     dummyEepromStorage[location] = value;
 }
 
@@ -43,7 +43,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 {
     uint8_t value;
     value = dummyEepromStorage[location];
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Dummy: Read %x from %d"), value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Dummy: Read %x from %d", value, location);
     return value;
 }
 
@@ -52,7 +52,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 // Initialize the EEPROM object for ESP boards, setting aside space for storage
 void EEPROMStore::initialize()
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: ESP32: Startup with %d bytes"), STORE_SIZE);
+    LOG(DEBUG_EEPROM, "[EEPROM]: ESP32: Startup with %d bytes", STORE_SIZE);
     EEPROM.begin(STORE_SIZE);
 
     displayContents();
@@ -61,14 +61,14 @@ void EEPROMStore::initialize()
 // Update the given location with the given value
 void EEPROMStore::update(uint8_t location, uint8_t value)
 {
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ESP32: Writing %x to %d"), value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: ESP32: Writing %x to %d", value, location);
     EEPROM.write(location, value);
 }
 
 // Complete the transaction
 void EEPROMStore::commit()
 {
-    LOGV1(DEBUG_EEPROM, F("[EEPROM]: ESP32: Committing"));
+    LOG(DEBUG_EEPROM, "[EEPROM]: ESP32: Committing");
     EEPROM.commit();
 }
 
@@ -77,7 +77,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 {
     uint8_t value;
     value = EEPROM.read(location);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ESP32: Read %x from %d"), value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: ESP32: Read %x from %d", value, location);
     return value;
 }
 
@@ -86,7 +86,7 @@ uint8_t EEPROMStore::read(uint8_t location)
 // Initialize the EEPROM storage in a platform-independent abstraction
 void EEPROMStore::initialize()
 {
-    LOGV1(DEBUG_EEPROM, F("[EEPROM]: ATMega: Startup"));
+    LOG(DEBUG_EEPROM, "[EEPROM]: ATMega: Startup");
 
     displayContents();
 }
@@ -94,7 +94,7 @@ void EEPROMStore::initialize()
 // Update the given location with the given value
 void EEPROMStore::update(uint8_t location, uint8_t value)
 {
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ATMega: Writing8 %x to %d"), value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: ATMega: Writing8 %x to %d", value, location);
     EEPROM.write(location, value);
 }
 
@@ -108,7 +108,7 @@ void EEPROMStore::commit()
 uint8_t EEPROMStore::read(uint8_t location)
 {
     uint8_t value = EEPROM.read(location);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: ATMega: Read8 %x from %d"), value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: ATMega: Read8 %x from %d", value, location);
     return value;
 }
 
@@ -119,35 +119,34 @@ void EEPROMStore::displayContents()
 #if (DEBUG_LEVEL & (DEBUG_INFO | DEBUG_EEPROM))
     // Read the magic marker byte and state
     uint16_t marker = readUint16(MAGIC_MARKER_AND_FLAGS_ADDR);
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Magic Marker: %x"), marker);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Magic Marker: %x", marker);
 
-    LOGV1(DEBUG_INFO,
-          ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? F("[EEPROM]: Has values") : F("[EEPROM]: Does NOT have values"));
-    LOGV1(DEBUG_INFO,
-          ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? F("[EEPROM]: Has extended values") : F("[EEPROM]: Does NOT have extended values"));
+    LOG(DEBUG_INFO, ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? F("[EEPROM]: Has values") : F("[EEPROM]: Does NOT have values"));
+    LOG(DEBUG_INFO,
+        ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? F("[EEPROM]: Has extended values") : F("[EEPROM]: Does NOT have extended values"));
     if (EEPROMStore::isPresent(EXTENDED_FLAG))
     {
-        LOGV1(DEBUG_INFO, F("[EEPROM]: IsPresent(EXTENDED): Yes"));
+        LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED): Yes");
     }
     else
     {
-        LOGV1(DEBUG_INFO, F("[EEPROM]: IsPresent(EXTENDED): No"));
+        LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED): No");
     }
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored HATime: %s"), getHATime().ToString());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored UTC Offset: %d"), getUtcOffset());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Brightness: %d"), getBrightness());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored RA Steps per Degree: %f"), getRAStepsPerDegree());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Steps per Degree: %f"), getDECStepsPerDegree());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Speed Factor: %f"), getSpeedFactor());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Backlash Correction Steps: %d"), getBacklashCorrectionSteps());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Latitude: %s"), getLatitude().ToString());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Longitude: %s"), getLongitude().ToString());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Pitch Calibration Angle: %f"), getPitchCalibrationAngle());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored Roll Calibration Angle: %f"), getRollCalibrationAngle());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored RA Parking Position: %l"), getRAParkingPos());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Parking Position: %l"), getDECParkingPos());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Lower Limit: %l"), getDECLowerLimit());
-    LOGV2(DEBUG_INFO, F("[EEPROM]: Stored DEC Upper Limit: %l"), getDECUpperLimit());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored HATime: %s", getHATime().ToString());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored UTC Offset: %d", getUtcOffset());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Brightness: %d", getBrightness());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored RA Steps per Degree: %f", getRAStepsPerDegree());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Steps per Degree: %f", getDECStepsPerDegree());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Speed Factor: %f", getSpeedFactor());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Backlash Correction Steps: %d", getBacklashCorrectionSteps());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Latitude: %s", getLatitude().ToString());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Longitude: %s", getLongitude().ToString());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Pitch Calibration Angle: %f", getPitchCalibrationAngle());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Roll Calibration Angle: %f", getRollCalibrationAngle());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored RA Parking Position: %l", getRAParkingPos());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Parking Position: %l", getDECParkingPos());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Lower Limit: %l", getDECLowerLimit());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Upper Limit: %l", getDECUpperLimit());
 #endif
 }
 
@@ -157,7 +156,7 @@ void EEPROMStore::displayContents()
 // Helper to update the given location with the given 8-bit value
 void EEPROMStore::updateUint8(EEPROMStore::ItemAddress location, uint8_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing8 %x (%d) to %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Writing8 %x (%d) to %d", value, value, location);
     update(location, value);
 }
 
@@ -166,14 +165,14 @@ uint8_t EEPROMStore::readUint8(EEPROMStore::ItemAddress location)
 {
     uint8_t value;
     value = read(location);
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read8 %x (%d) from %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Read8 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 8-bit value
 void EEPROMStore::updateInt8(EEPROMStore::ItemAddress location, int8_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing8 %x (%d) to %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Writing8 %x (%d) to %d", value, value, location);
     update(location, static_cast<uint8_t>(value));
 }
 
@@ -182,14 +181,14 @@ int8_t EEPROMStore::readInt8(EEPROMStore::ItemAddress location)
 {
     int8_t value;
     value = static_cast<int8_t>(read(location));
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read8 %x (%d) from %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Read8 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 16-bit value
 void EEPROMStore::updateInt16(EEPROMStore::ItemAddress location, int16_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing16 %x (%d) to %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Writing16 %x (%d) to %d", value, value, location);
     update(location, value & 0x00FF);
     update(location + 1, (value >> 8) & 0x00FF);
 }
@@ -201,14 +200,14 @@ int16_t EEPROMStore::readInt16(EEPROMStore::ItemAddress location)
     uint8_t valHi   = read(location + 1);
     uint16_t uValue = (uint16_t) valLo + (uint16_t) valHi * 256;
     int16_t value   = static_cast<int16_t>(uValue);
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read16 %x (%d) from %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Read16 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 16-bit value
 void EEPROMStore::updateUint16(EEPROMStore::ItemAddress location, uint16_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing16 %x (%d) to %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Writing16 %x (%d) to %d", value, value, location);
     update(location, value & 0x00FF);
     update(location + 1, (value >> 8) & 0x00FF);
 }
@@ -219,14 +218,14 @@ uint16_t EEPROMStore::readUint16(EEPROMStore::ItemAddress location)
     uint8_t valLo  = read(location);
     uint8_t valHi  = read(location + 1);
     uint16_t value = (uint16_t) valLo + (uint16_t) valHi * 256;
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read16 %x (%d) from %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Read16 %x (%d) from %d", value, value, location);
     return value;
 }
 
 // Helper to update the given location with the given 32-bit value
 void EEPROMStore::updateInt32(EEPROMStore::ItemAddress location, int32_t value)
 {
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Writing32 %x (%l) to %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Writing32 %x (%l) to %d", value, value, location);
     update(location, value & 0x00FF);
     update(location + 1, (value >> 8) & 0x00FF);
     update(location + 2, (value >> 16) & 0x00FF);
@@ -242,7 +241,7 @@ int32_t EEPROMStore::readInt32(EEPROMStore::ItemAddress location)
     uint8_t val4    = read(location + 3);
     uint32_t uValue = (uint32_t) val1 + (uint32_t) val2 * 256 + (uint32_t) val3 * 256 * 256 + (uint32_t) val4 * 256 * 256 * 256;
     int32_t value   = static_cast<int32_t>(uValue);
-    LOGV4(DEBUG_EEPROM, F("[EEPROM]: Read32 %x (%l) from %d"), value, value, location);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Read32 %x (%l) from %d", value, value, location);
     return value;
 }
 
@@ -256,7 +255,7 @@ bool EEPROMStore::isPresent(ItemFlag item)
     unsigned check  = (MAGIC_MARKER_MASK | item);
     unsigned result = (MAGIC_MARKER_VALUE | item);
     bool res        = ((marker & check) == result);
-    LOGV6(DEBUG_EEPROM, F("[EEPROM]: IsDataPresent (%x). Checking (%x & %x) == %x => %d"), item, marker, check, result, res);
+    LOG(DEBUG_EEPROM, "[EEPROM]: IsDataPresent (%x). Checking (%x & %x) == %x => %d", item, marker, check, result, res);
 
     // Data is only present if both magic marker and item flag are present
     //return ((marker & (MAGIC_MARKER_MASK | item)) == (MAGIC_MARKER_VALUE | item));
@@ -276,7 +275,7 @@ bool EEPROMStore::isPresentExtended(ExtendedItemFlag item)
     uint16_t marker = readUint16(EXTENDED_FLAGS_ADDR);
 
     bool result = (marker & item);
-    LOGV5(DEBUG_EEPROM, F("[EEPROM]: IsExtendedDataPresent (%x). Checking (%x & %x) => %d"), item, marker, item, result);
+    LOG(DEBUG_EEPROM, "[EEPROM]: IsExtendedDataPresent (%x). Checking (%x & %x) => %d", item, marker, item, result);
 
     return result;
 }
@@ -295,7 +294,7 @@ void EEPROMStore::updateFlags(ItemFlag item)
     updateUint16(MAGIC_MARKER_AND_FLAGS_ADDR, newMarkerAndFlags);
     // We will not commit until the actual item value has been written
 
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Marker & flags updated from %x to %x"), existingMarkerAndFlags, newMarkerAndFlags);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Marker & flags updated from %x to %x", existingMarkerAndFlags, newMarkerAndFlags);
 }
 
 // Updates the core & extended flags for the specified extended item to indicate it is present.
@@ -311,7 +310,7 @@ void EEPROMStore::updateFlagsExtended(ExtendedItemFlag item)
     updateUint16(EXTENDED_FLAGS_ADDR, extendedFlags | item);
     // We will not commit until the actual item value has been written
 
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Extended flags updated from %x to %x"), extendedFlags, extendedFlags | item);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Extended flags updated from %x to %x", extendedFlags, extendedFlags | item);
 }
 
 ///////////////////////////////////////
@@ -349,11 +348,11 @@ int EEPROMStore::getUtcOffset()
     if (isPresentExtended(UTC_OFFSET_MARKER_FLAG))
     {
         utcOffset = readInt8(UTC_OFFSET_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: UTC OFfset Marker OK! UTC Offset is %d"), utcOffset);
+        LOG(DEBUG_EEPROM, "[EEPROM]: UTC OFfset Marker OK! UTC Offset is %d", utcOffset);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for UTC Offset"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for UTC Offset");
     }
 
     return utcOffset;
@@ -395,11 +394,11 @@ float EEPROMStore::getRAStepsPerDegree()
     if (isPresent(RA_STEPS_FLAG))
     {
         raStepsPerDegree = 0.1 * readInt16(RA_STEPS_DEGREE_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: RA Marker OK! RA steps/deg is %f"), raStepsPerDegree);
+        LOG(DEBUG_EEPROM, "[EEPROM]: RA Marker OK! RA steps/deg is %f", raStepsPerDegree);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for RA steps"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for RA steps");
     }
 
     return raStepsPerDegree;  // microsteps per degree
@@ -410,7 +409,7 @@ void EEPROMStore::storeRAStepsPerDegree(float raStepsPerDegree)
 {
     int32_t val = raStepsPerDegree * 10;  // Store as tenths of degree
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing RA steps to %d (%f)"), val, raStepsPerDegree);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing RA steps to %d (%f)", val, raStepsPerDegree);
 
     updateInt16(RA_STEPS_DEGREE_ADDR, val);
     updateFlags(RA_STEPS_FLAG);
@@ -426,11 +425,11 @@ float EEPROMStore::getDECStepsPerDegree()
     if (isPresent(DEC_STEPS_FLAG))
     {
         decStepsPerDegree = 0.1 * readInt16(DEC_STEPS_DEGREE_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC Marker OK! DEC steps/deg is %f"), decStepsPerDegree);
+        LOG(DEBUG_EEPROM, "[EEPROM]: DEC Marker OK! DEC steps/deg is %f", decStepsPerDegree);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for DEC steps"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for DEC steps");
     }
 
     return decStepsPerDegree;  // microsteps per degree
@@ -441,7 +440,7 @@ void EEPROMStore::storeDECStepsPerDegree(float decStepsPerDegree)
 {
     int32_t val = decStepsPerDegree * 10;  // Store as tenths of degree
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing DEC steps to %d (%f)"), val, decStepsPerDegree);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing DEC steps to %d (%f)", val, decStepsPerDegree);
 
     updateInt16(DEC_STEPS_DEGREE_ADDR, val);
     updateFlags(DEC_STEPS_FLAG);
@@ -459,11 +458,11 @@ float EEPROMStore::getSpeedFactor()
         // Speed factor bytes are in split locations :-(
         int val     = readUint8(SPEED_FACTOR_LOW_ADDR) + (int) readUint8(SPEED_FACTOR_HIGH_ADDR) * 256;
         speedFactor = 1.0 + val / 10000.0;
-        LOGV3(DEBUG_EEPROM, F("[EEPROM]: Speed Marker OK! Speed adjust is %d, speedFactor is %f"), val, speedFactor);
+        LOG(DEBUG_EEPROM, "[EEPROM]: Speed Marker OK! Speed adjust is %d, speedFactor is %f", val, speedFactor);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for speed factor"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for speed factor");
     }
 
     return speedFactor;
@@ -475,7 +474,7 @@ void EEPROMStore::storeSpeedFactor(float speedFactor)
     // Store the fractional speed factor since it is a number very close to 1
     int32_t val = (speedFactor - 1.0f) * 10000.0f;
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Speed Factor to %d (%f)"), val, speedFactor);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing Speed Factor to %d (%f)", val, speedFactor);
 
     // Speed factor bytes are in split locations :-(
     updateUint8(SPEED_FACTOR_LOW_ADDR, val & 0xFF);
@@ -494,11 +493,11 @@ int16_t EEPROMStore::getBacklashCorrectionSteps()
     if (isPresent(BACKLASH_STEPS_FLAG))
     {
         backlashCorrectionSteps = readInt16(BACKLASH_STEPS_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: Backlash Steps Marker OK! Backlash correction is %d"), backlashCorrectionSteps);
+        LOG(DEBUG_EEPROM, "[EEPROM]: Backlash Steps Marker OK! Backlash correction is %d", backlashCorrectionSteps);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for backlash correction"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for backlash correction");
     }
 
     return backlashCorrectionSteps;  // Microsteps (slew)
@@ -507,7 +506,7 @@ int16_t EEPROMStore::getBacklashCorrectionSteps()
 // Store the Backlash Correction step count (microsteps).
 void EEPROMStore::storeBacklashCorrectionSteps(int16_t backlashCorrectionSteps)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Write: Updating Backlash to %d"), backlashCorrectionSteps);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Write: Updating Backlash to %d", backlashCorrectionSteps);
 
     updateInt16(BACKLASH_STEPS_ADDR, backlashCorrectionSteps);
     updateFlags(BACKLASH_STEPS_FLAG);
@@ -523,11 +522,11 @@ Latitude EEPROMStore::getLatitude()
     if (isPresent(LATITUDE_FLAG))
     {
         latitude = Latitude(1.0f * readInt16(LATITUDE_ADDR) / 100.0f);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: Latitude Marker OK! Latitude is %s"), latitude.ToString());
+        LOG(DEBUG_EEPROM, "[EEPROM]: Latitude Marker OK! Latitude is %s", latitude.ToString());
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for latitude"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for latitude");
     }
 
     return latitude;  // Object
@@ -538,7 +537,7 @@ void EEPROMStore::storeLatitude(Latitude const &latitude)
 {
     int32_t val = static_cast<int32_t>(roundf(latitude.getTotalHours() * 100.0f));
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Latitude as %d (%f)"), val, latitude.getTotalHours());
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing Latitude as %d (%f)", val, latitude.getTotalHours());
 
     updateInt16(LATITUDE_ADDR, val);
     updateFlags(LATITUDE_FLAG);
@@ -554,11 +553,11 @@ Longitude EEPROMStore::getLongitude()
     if (isPresent(LONGITUDE_FLAG))
     {
         longitude = Longitude(1.0f * readInt16(LONGITUDE_ADDR) / 100.0f);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: Longitude Marker OK! Longitude is %s"), longitude.ToString());
+        LOG(DEBUG_EEPROM, "[EEPROM]: Longitude Marker OK! Longitude is %s", longitude.ToString());
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for longitude"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for longitude");
     }
 
     return longitude;  // Object
@@ -569,7 +568,7 @@ void EEPROMStore::storeLongitude(Longitude const &longitude)
 {
     int32_t val = static_cast<int32_t>(roundf(longitude.getTotalHours() * 100.0f));
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Longitude as %d (%f)"), val, longitude.getTotalHours());
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing Longitude as %d (%f)", val, longitude.getTotalHours());
 
     updateInt16(LONGITUDE_ADDR, val);
     updateFlags(LONGITUDE_FLAG);
@@ -586,11 +585,11 @@ float EEPROMStore::getPitchCalibrationAngle()
     {
         int32_t val           = readUint16(PITCH_OFFSET_ADDR);
         pitchCalibrationAngle = (val - 16384) / 100.0;
-        LOGV3(DEBUG_EEPROM, F("[EEPROM]: Pitch Offset Marker OK! Pitch Offset is %d (%f)"), val, pitchCalibrationAngle);
+        LOG(DEBUG_EEPROM, "[EEPROM]: Pitch Offset Marker OK! Pitch Offset is %d (%f)", val, pitchCalibrationAngle);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Pitch Offset"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Pitch Offset");
     }
 
     return pitchCalibrationAngle;  // degrees
@@ -601,7 +600,7 @@ void EEPROMStore::storePitchCalibrationAngle(float pitchCalibrationAngle)
 {
     int32_t val = (pitchCalibrationAngle * 100) + 16384;
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Pitch calibration %d (%f)"), val, pitchCalibrationAngle);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing Pitch calibration %d (%f)", val, pitchCalibrationAngle);
 
     updateInt16(PITCH_OFFSET_ADDR, val);
     updateFlags(PITCH_OFFSET_FLAG);
@@ -618,11 +617,11 @@ float EEPROMStore::getRollCalibrationAngle()
     {
         int32_t val          = readUint16(ROLL_OFFSET_ADDR);
         rollCalibrationAngle = (val - 16384) / 100.0;
-        LOGV3(DEBUG_EEPROM, F("[EEPROM]: Roll Offset Marker OK! Roll Offset is %d (%f)"), val, rollCalibrationAngle);
+        LOG(DEBUG_EEPROM, "[EEPROM]: Roll Offset Marker OK! Roll Offset is %d (%f)", val, rollCalibrationAngle);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Roll Offset"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Roll Offset");
     }
 
     return rollCalibrationAngle;  // degrees
@@ -633,7 +632,7 @@ void EEPROMStore::storeRollCalibrationAngle(float rollCalibrationAngle)
 {
     int32_t val = (rollCalibrationAngle * 100) + 16384;
     val         = clamp(val, (int32_t) INT16_MIN, (int32_t) INT16_MAX);
-    LOGV3(DEBUG_EEPROM, F("[EEPROM]: Storing Roll calibration %d (%f)"), val, rollCalibrationAngle);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing Roll calibration %d (%f)", val, rollCalibrationAngle);
 
     updateInt16(ROLL_OFFSET_ADDR, val);
     updateFlags(ROLL_OFFSET_FLAG);
@@ -650,11 +649,11 @@ int32_t EEPROMStore::getRAParkingPos()
     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
     {
         raParkingPos = readInt32(RA_PARKING_POS_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: RA Parking position read as %l"), raParkingPos);
+        LOG(DEBUG_EEPROM, "[EEPROM]: RA Parking position read as %l", raParkingPos);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Parking position"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
     }
 
     return raParkingPos;  // microsteps (slew)
@@ -663,7 +662,7 @@ int32_t EEPROMStore::getRAParkingPos()
 // Store the configured RA Parking Pos (slew microsteps relative to home).
 void EEPROMStore::storeRAParkingPos(int32_t raParkingPos)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Updating RA Parking Pos to %l"), raParkingPos);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Updating RA Parking Pos to %l", raParkingPos);
 
     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
     updateInt32(RA_PARKING_POS_ADDR, raParkingPos);
@@ -681,11 +680,11 @@ int32_t EEPROMStore::getDECParkingPos()
     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
     {
         decParkingPos = readInt32(DEC_PARKING_POS_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC Parking position read as %l"), decParkingPos);
+        LOG(DEBUG_EEPROM, "[EEPROM]: DEC Parking position read as %l", decParkingPos);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored value for Parking position"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
     }
 
     return decParkingPos;  // microsteps (slew)
@@ -694,7 +693,7 @@ int32_t EEPROMStore::getDECParkingPos()
 // Store the configured DEC Parking Pos (slew microsteps relative to home).
 void EEPROMStore::storeDECParkingPos(int32_t decParkingPos)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Updating DEC Parking Pos to %l"), decParkingPos);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Updating DEC Parking Pos to %l", decParkingPos);
 
     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
     updateInt32(DEC_PARKING_POS_ADDR, decParkingPos);
@@ -712,11 +711,11 @@ int32_t EEPROMStore::getDECLowerLimit()
     if (isPresentExtended(DEC_LIMIT_MARKER_FLAG))
     {
         decLowerLimit = readInt32(DEC_LOWER_LIMIT_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC lower limit read as %l"), decLowerLimit);
+        LOG(DEBUG_EEPROM, "[EEPROM]: DEC lower limit read as %l", decLowerLimit);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored values for DEC limits"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored values for DEC limits");
     }
 
     return decLowerLimit;  // microsteps (slew)
@@ -725,7 +724,7 @@ int32_t EEPROMStore::getDECLowerLimit()
 // Store the configured DEC Lower Limit Pos (slew microsteps relative to home).
 void EEPROMStore::storeDECLowerLimit(int32_t decLowerLimit)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Write: Updating DEC Lower Limit to %l"), decLowerLimit);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Write: Updating DEC Lower Limit to %l", decLowerLimit);
 
     // Note that flags doesn't verify that _both_ DEC limits have been written - these should always be stored as a pair
     updateInt32(DEC_LOWER_LIMIT_ADDR, decLowerLimit);
@@ -743,11 +742,11 @@ int32_t EEPROMStore::getDECUpperLimit()
     if (isPresentExtended(DEC_LIMIT_MARKER_FLAG))
     {
         decUpperLimit = readInt32(DEC_UPPER_LIMIT_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: DEC upper limit read as %l"), decUpperLimit);
+        LOG(DEBUG_EEPROM, "[EEPROM]: DEC upper limit read as %l", decUpperLimit);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored values for DEC limits"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored values for DEC limits");
     }
 
     return decUpperLimit;  // microsteps (slew)
@@ -756,7 +755,7 @@ int32_t EEPROMStore::getDECUpperLimit()
 // Store the configured DEC Upper Limit Pos (slew microsteps relative to home).
 void EEPROMStore::storeDECUpperLimit(int32_t decUpperLimit)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Write: Updating DEC Upper Limit to %l"), decUpperLimit);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Write: Updating DEC Upper Limit to %l", decUpperLimit);
 
     // Note that flags doesn't verify that _both_ DEC limits have been written - these should always be stored as a pair
     updateInt32(DEC_UPPER_LIMIT_ADDR, decUpperLimit);
@@ -772,11 +771,11 @@ int32_t EEPROMStore::getRAHomingOffset()
     if (isPresentExtended(RA_HOMING_MARKER_FLAG))
     {
         raHomingOffset = readInt32(RA_HOMING_OFFSET_ADDR);
-        LOGV2(DEBUG_EEPROM, F("[EEPROM]: RA Homing offset read as %l"), raHomingOffset);
+        LOG(DEBUG_EEPROM, "[EEPROM]: RA Homing offset read as %l", raHomingOffset);
     }
     else
     {
-        LOGV1(DEBUG_EEPROM, F("[EEPROM]: No stored values for RA Homing offset"));
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored values for RA Homing offset");
     }
 
     return raHomingOffset;  // microsteps (slew)
@@ -785,7 +784,7 @@ int32_t EEPROMStore::getRAHomingOffset()
 // Store the configured RA Homing offset for Hall sensor homing (slew microsteps relative to home).
 void EEPROMStore::storeRAHomingOffset(int32_t raHomingOffset)
 {
-    LOGV2(DEBUG_EEPROM, F("[EEPROM]: Write: Updating RA Homing offset to %l"), raHomingOffset);
+    LOG(DEBUG_EEPROM, "[EEPROM]: Write: Updating RA Homing offset to %l", raHomingOffset);
 
     updateInt32(RA_HOMING_OFFSET_ADDR, raHomingOffset);
     updateFlagsExtended(RA_HOMING_MARKER_FLAG);

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -121,17 +121,9 @@ void EEPROMStore::displayContents()
     uint16_t marker = readUint16(MAGIC_MARKER_AND_FLAGS_ADDR);
     LOG(DEBUG_EEPROM, "[EEPROM]: Magic Marker: %x", marker);
 
-    LOG(DEBUG_INFO, ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? F("[EEPROM]: Has values") : F("[EEPROM]: Does NOT have values"));
-    LOG(DEBUG_INFO,
-        ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? F("[EEPROM]: Has extended values") : F("[EEPROM]: Does NOT have extended values"));
-    if (EEPROMStore::isPresent(EXTENDED_FLAG))
-    {
-        LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED): Yes");
-    }
-    else
-    {
-        LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED): No");
-    }
+    LOG(DEBUG_INFO, "[EEPROM]: Values? %s", ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? F("Yes") : F("No"));
+    LOG(DEBUG_INFO, "[EEPROM]: Extended values? %s", ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? F("Yes") : F("No"));
+    LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED)? %s", (EEPROMStore::isPresent(EXTENDED_FLAG) ? F("Yes") : F("No")));
     LOG(DEBUG_INFO, "[EEPROM]: Stored HATime: %s", getHATime().ToString());
     LOG(DEBUG_INFO, "[EEPROM]: Stored UTC Offset: %d", getUtcOffset());
     LOG(DEBUG_INFO, "[EEPROM]: Stored Brightness: %d", getBrightness());

--- a/src/Gyro.cpp
+++ b/src/Gyro.cpp
@@ -25,7 +25,7 @@ void Gyro::startup()
 */
 {
     // Initialize interface to the MPU6050
-    LOGV1(DEBUG_INFO, F("[GYRO]:: Starting"));
+    LOG(DEBUG_INFO, "[GYRO]:: Starting");
     Wire.begin();
 
     // Execute 1 byte read from MPU6050_REG_WHO_AM_I
@@ -38,7 +38,7 @@ void Gyro::startup()
     isPresent = (id == 0x34);
     if (!isPresent)
     {
-        LOGV1(DEBUG_INFO, F("[GYRO]:: Not found!"));
+        LOG(DEBUG_INFO, "[GYRO]:: Not found!");
         return;
     }
 
@@ -54,7 +54,7 @@ void Gyro::startup()
     Wire.write(6);  // 5Hz bandwidth (lowest) for smoothing
     Wire.endTransmission(true);
 
-    LOGV1(DEBUG_INFO, F("[GYRO]:: Started"));
+    LOG(DEBUG_INFO, "[GYRO]:: Started");
 }
 
 void Gyro::shutdown()
@@ -62,7 +62,7 @@ void Gyro::shutdown()
    Currently does nothing.
 */
 {
-    LOGV1(DEBUG_INFO, F("[GYRO]: Shutdown"));
+    LOG(DEBUG_INFO, "[GYRO]: Shutdown");
     // Nothing to do
 }
 

--- a/src/Latitude.cpp
+++ b/src/Latitude.cpp
@@ -21,12 +21,12 @@ void Latitude::checkHours()
 {
     if (totalSeconds > 90L * 3600L)
     {
-        LOGV1(DEBUG_GENERAL, F("[LATITUDE]: CheckHours: Degrees is more than 90, clamping"));
+        LOG(DEBUG_GENERAL, "[LATITUDE]: CheckHours: Degrees is more than 90, clamping");
         totalSeconds = 90L * 3600L;
     }
     if (totalSeconds < (-90L * 3600L))
     {
-        LOGV1(DEBUG_GENERAL, F("[LATITUDE]: CheckHours: Degrees is less than -90, clamping"));
+        LOG(DEBUG_GENERAL, "[LATITUDE]: CheckHours: Degrees is less than -90, clamping");
         totalSeconds = -90L * 3600L;
     }
 }
@@ -35,11 +35,11 @@ Latitude Latitude::ParseFromMeade(String const &s)
 {
     Latitude result(0.0);
 
-    LOGV2(DEBUG_GENERAL, F("[LATITUDE]: Latitude.Parse(%s)"), s.c_str());
+    LOG(DEBUG_GENERAL, "[LATITUDE]: Latitude.Parse(%s)", s.c_str());
     // Use the DayTime code to parse it.
     DayTime dt          = DayTime::ParseFromMeade(s);
     result.totalSeconds = dt.getTotalSeconds();
     result.checkHours();
-    LOGV3(DEBUG_GENERAL, F("[LATITUDE]: Latitude.Parse(%s) -> %s"), s.c_str(), result.ToString());
+    LOG(DEBUG_GENERAL, "[LATITUDE]: Latitude.Parse(%s) -> %s", s.c_str(), result.ToString());
     return result;
 }

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -35,7 +35,7 @@ LcdMenu::LcdMenu(byte cols, byte rows, int maxItems)
 
 void LcdMenu::startup()
 {
-    LOGV1(DEBUG_INFO, F("[LCD]: LcdMenu startup"));
+    LOG(DEBUG_INFO, "[LCD]: LcdMenu startup");
 
     #if DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD
     _lcd.begin(_cols, _rows);
@@ -55,7 +55,7 @@ void LcdMenu::startup()
     #endif
 
     _brightness = EEPROMStore::getBrightness();
-    LOGV2(DEBUG_INFO, F("[LCD]: Brightness from EEPROM is %d"), _brightness);
+    LOG(DEBUG_INFO, "[LCD]: Brightness from EEPROM is %d", _brightness);
     setBacklightBrightness(_brightness, false);
 
     _numMenuItems    = 0;
@@ -129,7 +129,7 @@ bool LcdMenu::testIfLcdIsBad()
      * pin is being driven HIGH by the AVR.
      */
     const bool lcdIsBad = (pinValue != HIGH);
-    LOGV2(DEBUG_INFO, F("[LCD]: HW is bad? %s"), lcdIsBad ? "YES" : "NO");
+    LOG(DEBUG_INFO, "[LCD]: HW is bad? %s", lcdIsBad ? "YES" : "NO");
     return lcdIsBad;
 }
     #endif
@@ -217,7 +217,7 @@ void LcdMenu::setBacklightBrightness(int level, bool persist)
 
     if (persist)
     {
-        LOGV2(DEBUG_INFO, F("[LCD]: Saving %d as brightness"), _brightness);
+        LOG(DEBUG_INFO, "[LCD]: Saving %d as brightness", _brightness);
         EEPROMStore::storeBrightness(_brightness);
     }
 }

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -22,12 +22,12 @@ void Longitude::checkHours()
 {
     while (totalSeconds > 180L * 3600L)
     {
-        LOGV1(DEBUG_GENERAL, F("[LONGITUDE]: CheckHours: Degrees is more than 180, wrapping"));
+        LOG(DEBUG_GENERAL, "[LONGITUDE]: CheckHours: Degrees is more than 180, wrapping");
         totalSeconds -= 360L * 3600L;
     }
     while (totalSeconds < (-180L * 3600L))
     {
-        LOGV1(DEBUG_GENERAL, F("[LONGITUDE]: CheckHours: Degrees is less than -180, wrapping"));
+        LOG(DEBUG_GENERAL, "[LONGITUDE]: CheckHours: Degrees is less than -180, wrapping");
         totalSeconds += 360L * 3600L;
     }
 }
@@ -35,7 +35,7 @@ void Longitude::checkHours()
 Longitude Longitude::ParseFromMeade(String const &s)
 {
     Longitude result(0.0);
-    LOGV2(DEBUG_GENERAL, F("[LONGITUDE]: Parse(%s)"), s.c_str());
+    LOG(DEBUG_GENERAL, "[LONGITUDE]: Parse(%s)", s.c_str());
 
     // Use the DayTime code to parse it.
     DayTime dt = DayTime::ParseFromMeade(s);
@@ -44,7 +44,7 @@ Longitude Longitude::ParseFromMeade(String const &s)
     result.totalSeconds = 180L * 3600L - dt.getTotalSeconds();
     result.checkHours();
 
-    LOGV4(DEBUG_GENERAL, F("[LONGITUDE]: Parse(%s) -> %s = %ls"), s.c_str(), result.ToString(), result.getTotalSeconds());
+    LOG(DEBUG_GENERAL, "[LONGITUDE]: Parse(%s) -> %s = %ls", s.c_str(), result.ToString(), result.getTotalSeconds());
     return result;
 }
 

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1210,13 +1210,13 @@ String MeadeCommandProcessor::handleMeadeGPSCommands(String inCmd)
         {
             if (gpsAqcuisitionComplete(indicator))
             {
-                LOGV1(DEBUG_MEADE, F("[MEADE]: GPS startup, GPS acquired"));
+                LOG(DEBUG_MEADE, "[MEADE]: GPS startup, GPS acquired");
                 return "1";
             }
         }
     }
 #endif
-    LOGV1(DEBUG_MEADE, F("[MEADE]: GPS startup, no GPS signal"));
+    LOG(DEBUG_MEADE, "[MEADE]: GPS startup, no GPS signal");
     return "0";
 }
 
@@ -1248,7 +1248,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
         {
             Declination dec     = Declination::ParseFromMeade(inCmd.substring(1));
             _mount->targetDEC() = dec;
-            LOGV2(DEBUG_MEADE, F("[MEADE]: SetInfo: Received Target DEC: %s"), _mount->targetDEC().ToString());
+            LOG(DEBUG_MEADE, "[MEADE]: SetInfo: Received Target DEC: %s", _mount->targetDEC().ToString());
             return "1";
         }
         else
@@ -1266,7 +1266,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
         if ((inCmd[3] == ':') && (inCmd[6] == ':'))
         {
             _mount->targetRA().set(inCmd.substring(1, 3).toInt(), inCmd.substring(4, 6).toInt(), inCmd.substring(7, 9).toInt());
-            LOGV2(DEBUG_MEADE, F("[MEADE]: SetInfo: Received Target RA: %s"), _mount->targetRA().ToString());
+            LOG(DEBUG_MEADE, "[MEADE]: SetInfo: Received Target RA: %s", _mount->targetRA().ToString());
             return "1";
         }
         else
@@ -1289,7 +1289,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
             }
 
             DayTime lst(hLST, minLST, secLST);
-            LOGV4(DEBUG_MEADE, F("[MEADE]: SetInfo: Received LST: %d:%d:%d"), hLST, minLST, secLST);
+            LOG(DEBUG_MEADE, "[MEADE]: SetInfo: Received LST: %d:%d:%d", hLST, minLST, secLST);
             _mount->setLST(lst);
         }
         else if (inCmd[1] == 'P')
@@ -1302,7 +1302,7 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
             // Set HA
             int hHA   = inCmd.substring(1, 3).toInt();
             int minHA = inCmd.substring(4, 6).toInt();
-            LOGV4(DEBUG_MEADE, F("[MEADE]: SetInfo: Received HA: %d:%d:%d"), hHA, minHA, 0);
+            LOG(DEBUG_MEADE, "[MEADE]: SetInfo: Received HA: %d:%d:%d", hHA, minHA, 0);
             _mount->setHA(DayTime(hHA, minHA, 0));
         }
 
@@ -1422,7 +1422,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     }
     else if (inCmd[0] == 'A')
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Move Az/Alt"));
+        LOG(DEBUG_MEADE, "[MEADE]: Move Az/Alt");
 
         // Move Azimuth or Altitude by given arcminutes
         // :MAZ+32.1# or :MAL-32.1#
@@ -1430,7 +1430,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         if (inCmd[1] == 'Z')  // :MAZ
         {
             float arcMinute = inCmd.substring(2).toFloat();
-            LOGV2(DEBUG_MEADE, F("[MEADE]: Move AZ by %f arcmins"), arcMinute);
+            LOG(DEBUG_MEADE, "[MEADE]: Move AZ by %f arcmins", arcMinute);
             _mount->moveBy(AZIMUTH_STEPS, arcMinute);
         }
 #endif
@@ -1466,7 +1466,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
     else if (inCmd[0] == 'X')  // :MX
     {
         long steps = inCmd.substring(2).toInt();
-        LOGV3(DEBUG_MEADE, F("[MEADE]: Move: %l in %d"), steps, inCmd[1]);
+        LOG(DEBUG_MEADE, "[MEADE]: Move: %l in %d", steps, inCmd[1]);
         if (inCmd[1] == 'r')
             _mount->moveStepperBy(RA_STEPS, steps);
         else if (inCmd[1] == 'd')
@@ -1488,7 +1488,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         if (inCmd.length() > 3)
         {
             distance = clamp((int) inCmd.substring(3).toInt(), 1, 5);
-            LOGV2(DEBUG_MEADE, F("[MEADE]: RA AutoHome by %dh"), distance);
+            LOG(DEBUG_MEADE, "[MEADE]: RA AutoHome by %dh", distance);
         }
 
         if (inCmd[2] == 'R')  // :MHRR
@@ -1885,57 +1885,57 @@ String MeadeCommandProcessor::handleMeadeFocusCommands(String inCmd)
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
     if (inCmd[0] == '+')  // :F+
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus focusContinuousMove IN"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus focusContinuousMove IN");
         _mount->focusContinuousMove(FOCUS_BACKWARD);
     }
     else if (inCmd[0] == '-')  // :F-
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus focusContinuousMove OUT"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus focusContinuousMove OUT");
         _mount->focusContinuousMove(FOCUS_FORWARD);
     }
     else if (inCmd[0] == 'M')  // :FMnnnn
     {
         long steps = inCmd.substring(1).toInt();
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Focus move by %l steps"), steps);
+        LOG(DEBUG_MEADE, "[MEADE]: Focus move by %l steps", steps);
         _mount->focusMoveBy(steps);
     }
     else if ((inCmd[0] >= '1') && (inCmd[0] <= '4'))  // :F1 - Slowest, F4 fastest
     {
         int speed = inCmd[0] - '0';
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Focus setSpeed %d"), speed);
+        LOG(DEBUG_MEADE, "[MEADE]: Focus setSpeed %d", speed);
         _mount->focusSetSpeedByRate(speed);
     }
     else if (inCmd[0] == 'F')  // :FF
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus setSpeed fastest"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus setSpeed fastest");
         _mount->focusSetSpeedByRate(4);
     }
     else if (inCmd[0] == 'S')  // :FS
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus setSpeed slowest"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus setSpeed slowest");
         _mount->focusSetSpeedByRate(1);
     }
     else if (inCmd[0] == 'p')  // :Fp
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus get stepperPosition"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus get stepperPosition");
         long focusPos = _mount->focusGetStepperPosition();
         return String(focusPos) + "#";
     }
     else if (inCmd[0] == 'P')  // :FPnnn
     {
         long steps = inCmd.substring(1).toInt();
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Focus set stepperPosition %d"), steps);
+        LOG(DEBUG_MEADE, "[MEADE]: Focus set stepperPosition %d", steps);
         _mount->focusSetStepperPosition(steps);
         return "1";
     }
     else if (inCmd[0] == 'B')  // :FB
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus isRunningFocus"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus isRunningFocus");
         return _mount->isRunningFocus() ? "1" : "0";
     }
     else if (inCmd[0] == 'Q')  // :FQ
     {
-        LOGV1(DEBUG_MEADE, F("[MEADE]: Focus stop"));
+        LOG(DEBUG_MEADE, "[MEADE]: Focus stop");
         _mount->focusStop();
     }
 #else
@@ -1956,7 +1956,7 @@ String MeadeCommandProcessor::processCommand(String inCmd)
 {
     if (inCmd[0] == ':')
     {
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Received command '%s'"), inCmd.c_str());
+        LOG(DEBUG_MEADE, "[MEADE]: Received command '%s'", inCmd.c_str());
 
         // Apparently some LX200 implementations put spaces in their commands..... remove them with impunity.
         int spacePos;
@@ -1965,7 +1965,7 @@ String MeadeCommandProcessor::processCommand(String inCmd)
             inCmd.remove(spacePos, 1);
         }
 
-        LOGV2(DEBUG_MEADE, F("[MEADE]: Processing command '%s'"), inCmd.c_str());
+        LOG(DEBUG_MEADE, "[MEADE]: Processing command '%s'", inCmd.c_str());
         char command = inCmd[1];
         inCmd        = inCmd.substring(2);
         switch (command)
@@ -1995,7 +1995,7 @@ String MeadeCommandProcessor::processCommand(String inCmd)
             case 'F':
                 return handleMeadeFocusCommands(inCmd);
             default:
-                LOGV2(DEBUG_MEADE, F("[MEADE]: Received unknown command '%s'"), inCmd.c_str());
+                LOG(DEBUG_MEADE, "[MEADE]: Received unknown command '%s'", inCmd.c_str());
                 break;
         }
     }

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -159,9 +159,9 @@ void Mount::clearConfiguration()
 /////////////////////////////////
 void Mount::readConfiguration()
 {
-    LOGV1(DEBUG_INFO, F("[MOUNT]: Reading configuration data from EEPROM"));
+    LOG(DEBUG_INFO, "[MOUNT]: Reading configuration data from EEPROM");
     readPersistentData();
-    LOGV1(DEBUG_INFO, F("[MOUNT]: Done reading configuration data from EEPROM"));
+    LOG(DEBUG_INFO, "[MOUNT]: Done reading configuration data from EEPROM");
 }
 
 /////////////////////////////////
@@ -174,38 +174,38 @@ void Mount::readPersistentData()
     // EEPROMStore will always return valid data, even if no data is present in the store
 
     _stepsPerRADegree = EEPROMStore::getRAStepsPerDegree();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: RA steps/deg is %f"), _stepsPerRADegree);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: RA steps/deg is %f", _stepsPerRADegree);
 
     _stepsPerDECDegree = EEPROMStore::getDECStepsPerDegree();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: DEC steps/deg is %f"), _stepsPerDECDegree);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: DEC steps/deg is %f", _stepsPerDECDegree);
 
     float speed = EEPROMStore::getSpeedFactor();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Speed factor is %f"), speed);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Speed factor is %f", speed);
     setSpeedCalibration(speed, false);
 
     _backlashCorrectionSteps = EEPROMStore::getBacklashCorrectionSteps();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Backlash correction is %d"), _backlashCorrectionSteps);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Backlash correction is %d", _backlashCorrectionSteps);
 
     _latitude = EEPROMStore::getLatitude();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Latitude is %s"), _latitude.ToString());
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Latitude is %s", _latitude.ToString());
 
     _longitude = EEPROMStore::getLongitude();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Longitude is %s"), _longitude.ToString());
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Longitude is %s", _longitude.ToString());
 
     _localUtcOffset = EEPROMStore::getUtcOffset();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: UTC offset is %d"), _localUtcOffset);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: UTC offset is %d", _localUtcOffset);
 
 #if USE_GYRO_LEVEL == 1
     _pitchCalibrationAngle = EEPROMStore::getPitchCalibrationAngle();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Pitch Offset is %f"), _pitchCalibrationAngle);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Pitch Offset is %f", _pitchCalibrationAngle);
 
     _rollCalibrationAngle = EEPROMStore::getRollCalibrationAngle();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: Roll Offset is %f"), _rollCalibrationAngle);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Roll Offset is %f", _rollCalibrationAngle);
 #endif
 
     _raParkingPos  = EEPROMStore::getRAParkingPos();
     _decParkingPos = EEPROMStore::getDECParkingPos();
-    LOGV3(DEBUG_INFO, F("[MOUNT]: EEPROM: Parking position read as R:%l, D:%l"), _raParkingPos, _decParkingPos);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: Parking position read as R:%l, D:%l", _raParkingPos, _decParkingPos);
 
     _decLowerLimit = EEPROMStore::getDECLowerLimit();
     if (_decLowerLimit == 0 && DEC_LIMIT_DOWN != 0)
@@ -217,11 +217,11 @@ void Mount::readPersistentData()
     {
         _decUpperLimit = long(DEC_LIMIT_UP * _stepsPerDECDegree);
     }
-    LOGV3(DEBUG_INFO, F("[MOUNT]: EEPROM: DEC limits read as %l -> %l"), _decLowerLimit, _decUpperLimit);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: DEC limits read as %l -> %l", _decLowerLimit, _decUpperLimit);
 
 #if USE_HALL_SENSOR_RA_AUTOHOME == 1
     _homing.offsetRA = EEPROMStore::getRAHomingOffset();
-    LOGV2(DEBUG_INFO, F("[MOUNT]: EEPROM: RA Homing offset read as %l"), _homing.offsetRA);
+    LOG(DEBUG_INFO, "[MOUNT]: EEPROM: RA Homing offset read as %l", _homing.offsetRA);
 #endif
 }
 
@@ -330,12 +330,12 @@ void Mount::configureFocusStepper(byte pin1, byte pin2, int maxSpeed, int maxAcc
     #if UART_CONNECTION_TEST_TXRX == 1
 bool Mount::connectToDriver(TMC2209Stepper *driver, const char *driverKind)
 {
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: Testing UART Connection to %s driver..."), driverKind);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: Testing UART Connection to %s driver...", driverKind);
     for (int i = 0; i < UART_CONNECTION_TEST_RETRIES; i++)
     {
         if (driver->test_connection() == 0)
         {
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: UART connection to %s driver successful."), driverKind);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: UART connection to %s driver successful.", driverKind);
             return true;
         }
         else
@@ -343,7 +343,7 @@ bool Mount::connectToDriver(TMC2209Stepper *driver, const char *driverKind)
             delay(500);
         }
     }
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: UART connection to %s driver failed."), driverKind);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: UART connection to %s driver failed.", driverKind);
     return false;
 }
     #endif
@@ -373,7 +373,7 @@ void Mount::configureRAdriver(Stream *serial, float rsense, byte driveraddress, 
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverRA->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested RA motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested RA motor rms_current: %d mA", rmscurrent);
     _driverRA->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverRA->toff(1);
     _driverRA->en_spreadCycle(RA_UART_STEALTH_MODE == 0);
@@ -385,9 +385,9 @@ void Mount::configureRAdriver(Stream *serial, float rsense, byte driveraddress, 
     _driverRA->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA motor rms_current: %d mA"), _driverRA->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA CS value: %d"), _driverRA->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA vsense: %d"), _driverRA->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual RA motor rms_current: %d mA", _driverRA->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual RA CS value: %d", _driverRA->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual RA vsense: %d", _driverRA->vsense());
     }
 }
 
@@ -412,7 +412,7 @@ void Mount::configureRAdriver(uint16_t RA_SW_RX, uint16_t RA_SW_TX, float rsense
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverRA->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested RA motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested RA motor rms_current: %d mA", rmscurrent);
     _driverRA->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverRA->toff(1);
     _driverRA->en_spreadCycle(RA_UART_STEALTH_MODE == 0);
@@ -424,9 +424,9 @@ void Mount::configureRAdriver(uint16_t RA_SW_RX, uint16_t RA_SW_TX, float rsense
     _driverRA->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA motor rms_current: %d mA"), _driverRA->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA CS value: %d"), _driverRA->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual RA vsense: %d"), _driverRA->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual RA motor rms_current: %d mA", _driverRA->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual RA CS value: %d", _driverRA->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual RA vsense: %d", _driverRA->vsense());
     }
 }
     #endif
@@ -456,7 +456,7 @@ void Mount::configureDECdriver(Stream *serial, float rsense, byte driveraddress,
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverDEC->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested DEC motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested DEC motor rms_current: %d mA", rmscurrent);
     _driverDEC->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverDEC->toff(1);
     _driverDEC->en_spreadCycle(DEC_UART_STEALTH_MODE == 0);
@@ -468,9 +468,9 @@ void Mount::configureDECdriver(Stream *serial, float rsense, byte driveraddress,
     _driverDEC->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC motor rms_current: %d mA"), _driverDEC->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC CS value: %d"), _driverDEC->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC vsense: %d"), _driverDEC->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual DEC motor rms_current: %d mA", _driverDEC->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual DEC CS value: %d", _driverDEC->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual DEC vsense: %d", _driverDEC->vsense());
     }
 }
 
@@ -495,7 +495,7 @@ void Mount::configureDECdriver(uint16_t DEC_SW_RX, uint16_t DEC_SW_TX, float rse
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverDEC->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested DEC motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested DEC motor rms_current: %d mA", rmscurrent);
     _driverDEC->rms_current(rmscurrent, 1.0f);  //holdMultiplier = 1 to set ihold = irun
     _driverDEC->toff(1);
     _driverDEC->en_spreadCycle(DEC_UART_STEALTH_MODE == 0);
@@ -507,9 +507,9 @@ void Mount::configureDECdriver(uint16_t DEC_SW_RX, uint16_t DEC_SW_TX, float rse
     _driverDEC->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC motor rms_current: %d mA"), _driverDEC->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC CS value: %d"), _driverDEC->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual DEC vsense: %d"), _driverDEC->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual DEC motor rms_current: %d mA", _driverDEC->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual DEC CS value: %d", _driverDEC->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual DEC vsense: %d", _driverDEC->vsense());
     }
 }
     #endif
@@ -539,7 +539,7 @@ void Mount::configureAZdriver(Stream *serial, float rsense, byte driveraddress, 
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverAZ->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested AZ motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested AZ motor rms_current: %d mA", rmscurrent);
     _driverAZ->rms_current(rmscurrent, AZ_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverAZ->toff(1);
     _driverAZ->en_spreadCycle(0);
@@ -550,9 +550,9 @@ void Mount::configureAZdriver(Stream *serial, float rsense, byte driveraddress, 
     _driverAZ->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ motor rms_current: %d mA"), _driverAZ->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ CS value: %d"), _driverAZ->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ vsense: %d"), _driverAZ->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual AZ motor rms_current: %d mA", _driverAZ->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual AZ CS value: %d", _driverAZ->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual AZ vsense: %d", _driverAZ->vsense());
     }
 }
 
@@ -577,7 +577,7 @@ void Mount::configureAZdriver(uint16_t AZ_SW_RX, uint16_t AZ_SW_TX, float rsense
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverAZ->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested AZ motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested AZ motor rms_current: %d mA", rmscurrent);
     _driverAZ->rms_current(rmscurrent, AZ_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverAZ->toff(1);
     _driverAZ->en_spreadCycle(0);
@@ -588,9 +588,9 @@ void Mount::configureAZdriver(uint16_t AZ_SW_RX, uint16_t AZ_SW_TX, float rsense
     _driverAZ->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ motor rms_current: %d mA"), _driverAZ->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ CS value: %d"), _driverAZ->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual AZ vsense: %d"), _driverAZ->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual AZ motor rms_current: %d mA", _driverAZ->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual AZ CS value: %d", _driverAZ->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual AZ vsense: %d", _driverAZ->vsense());
     }
 }
     #endif
@@ -620,7 +620,7 @@ void Mount::configureALTdriver(Stream *serial, float rsense, byte driveraddress,
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverALT->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested ALT motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested ALT motor rms_current: %d mA", rmscurrent);
     _driverALT->rms_current(rmscurrent, ALT_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverALT->toff(1);
     _driverALT->en_spreadCycle(0);
@@ -631,9 +631,9 @@ void Mount::configureALTdriver(Stream *serial, float rsense, byte driveraddress,
     _driverALT->SGTHRS(stallvalue);
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT motor rms_current: %d mA"), _driverALT->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT CS value: %d"), _driverALT->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT vsense: %d"), _driverALT->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual ALT motor rms_current: %d mA", _driverALT->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual ALT CS value: %d", _driverALT->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual ALT vsense: %d", _driverALT->vsense());
     }
 }
 
@@ -658,7 +658,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverALT->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Requested ALT motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS, "[MOUNT]: Requested ALT motor rms_current: %d mA", rmscurrent);
     _driverALT->rms_current(rmscurrent, ALT_MOTOR_HOLD_SETTING / 100.0);  //holdMultiplier = 1 to set ihold = irun
     _driverALT->toff(1);
     _driverALT->en_spreadCycle(0);
@@ -670,9 +670,9 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
         #if UART_CONNECTION_TEST_TXRX == 1
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT motor rms_current: %d mA"), _driverALT->rms_current());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT CS value: %d"), _driverALT->cs_actual());
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: Actual ALT vsense: %d"), _driverALT->vsense());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual ALT motor rms_current: %d mA", _driverALT->rms_current());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual ALT CS value: %d", _driverALT->cs_actual());
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Actual ALT vsense: %d", _driverALT->vsense());
     }
         #endif
 }
@@ -703,7 +703,7 @@ void Mount::configureFocusDriver(Stream *serial, float rsense, byte driveraddres
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverFocus->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Requested Focus motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Requested Focus motor rms_current: %d mA", rmscurrent);
     _driverFocus->rms_current(rmscurrent, FOCUSER_MOTOR_HOLD_SETTING / 100.f);  //holdMultiplier = 1 to set ihold = irun
     _driverFocus->toff(1);
     _driverFocus->en_spreadCycle(FOCUS_UART_STEALTH_MODE == 0);
@@ -715,14 +715,14 @@ void Mount::configureFocusDriver(Stream *serial, float rsense, byte driveraddres
         #if UART_CONNECTION_TEST_TXRX == 1
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus motor rms_current: %d mA"), _driverFocus->rms_current());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus CS value: %d"), _driverFocus->cs_actual());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus vsense: %d"), _driverFocus->vsense());
+        LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus motor rms_current: %d mA", _driverFocus->rms_current());
+        LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus CS value: %d", _driverFocus->cs_actual());
+        LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus vsense: %d", _driverFocus->vsense());
     }
         #endif
 
         #if FOCUSER_ALWAYS_ON == 1
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: Always on -> TMC2209U enabling driver pin."));
+    LOG(DEBUG_FOCUS, "[FOCUS]: Always on -> TMC2209U enabling driver pin.");
     digitalWrite(FOCUS_EN_PIN, LOW);  // Logic LOW to enable driver
         #endif
 }
@@ -749,7 +749,7 @@ void Mount::configureFocusDriver(
         #if USE_VREF == 0  //By default, Vref is ignored when using UART to specify rms current.
     _driverFocus->I_scale_analog(false);
         #endif
-    LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Requested Focus motor rms_current: %d mA"), rmscurrent);
+    LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Requested Focus motor rms_current: %d mA", rmscurrent);
     _driverFocus->rms_current(rmscurrent, FOCUSER_MOTOR_HOLD_SETTING / 100.f);  //holdMultiplier = 1 to set ihold = irun
     _driverFocus->toff(1);
     _driverFocus->en_spreadCycle(FOCUS_UART_STEALTH_MODE == 0);
@@ -761,13 +761,13 @@ void Mount::configureFocusDriver(
         #if UART_CONNECTION_TEST_TXRX == 1
     if (UART_Rx_connected)
     {
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus motor rms_current: %d mA"), _driverFocus->rms_current());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus CS value: %d"), _driverFocus->cs_actual());
-        LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: Actual Focus vsense: %d"), _driverFocus->vsense());
+        LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus motor rms_current: %d mA", _driverFocus->rms_current());
+        LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus CS value: %d", _driverFocus->cs_actual());
+        LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: Actual Focus vsense: %d", _driverFocus->vsense());
     }
         #endif
         #if FOCUSER_ALWAYS_ON == 1
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: Always on -> TMC2209U enabling driver pin."));
+    LOG(DEBUG_FOCUS, "[FOCUS]: Always on -> TMC2209U enabling driver pin.");
     digitalWrite(FOCUS_EN_PIN, LOW);  // Logic LOW to enable driver
         #endif
 }
@@ -791,20 +791,20 @@ float Mount::getSpeedCalibration()
 /////////////////////////////////
 void Mount::setSpeedCalibration(float val, bool saveToStorage)
 {
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: Updating speed calibration from %f to %f"), _trackingSpeedCalibration, val);
+    LOG(DEBUG_MOUNT, "[MOUNT]: Updating speed calibration from %f to %f", _trackingSpeedCalibration, val);
     _trackingSpeedCalibration = val;
 
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: Current tracking speed is %f steps/sec"), _trackingSpeed);
+    LOG(DEBUG_MOUNT, "[MOUNT]: Current tracking speed is %f steps/sec", _trackingSpeed);
 
     // Tracking speed has to be exactly the rotation speed of the earth. The earth rotates 360° per astronomical day.
     // This is 23h 56m 4.0905s, therefore the dimensionless _trackingSpeedCalibration = (23h 56m 4.0905s / 24 h) * mechanical calibration factor
     // Also compensate for higher precision microstepping in tracking mode
     _trackingSpeed = _trackingSpeedCalibration * _stepsPerRADegree * (RA_TRACKING_MICROSTEPPING / RA_SLEW_MICROSTEPPING) * 360.0f
                      / secondsPerDay;  // (fraction of day) * u-steps/deg * (u-steps/u-steps) * deg / (sec/day) = u-steps / sec
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: RA steps per degree is %f steps/deg"), _stepsPerRADegree);
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: New tracking speed is %f steps/sec"), _trackingSpeed);
+    LOG(DEBUG_MOUNT, "[MOUNT]: RA steps per degree is %f steps/deg", _stepsPerRADegree);
+    LOG(DEBUG_MOUNT, "[MOUNT]: New tracking speed is %f steps/sec", _trackingSpeed);
 
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: FactorToSpeed : %s, %s"), String(val, 6).c_str(), String(_trackingSpeed, 6).c_str());
+    LOG(DEBUG_MOUNT, "[MOUNT]: FactorToSpeed : %s, %s", String(val, 6).c_str(), String(_trackingSpeed, 6).c_str());
 
     if (saveToStorage)
         EEPROMStore::storeSpeedFactor(_trackingSpeedCalibration);
@@ -812,7 +812,7 @@ void Mount::setSpeedCalibration(float val, bool saveToStorage)
     // If we are currently tracking, update the speed. No need to update microstepping mode
     if (isSlewingTRK())
     {
-        LOGV2(DEBUG_STEPPERS, F("[MOUNT]: SpeedCalibration TRK.setSpeed(%f)"), _trackingSpeed);
+        LOG(DEBUG_STEPPERS, "[MOUNT]: SpeedCalibration TRK.setSpeed(%f)", _trackingSpeed);
         _stepperTRK->setSpeed(_trackingSpeed);
     }
 }
@@ -1053,10 +1053,10 @@ void Mount::setSlewRate(int rate)
 {
     _moveRate           = clamp(rate, 1, 4);
     float speedFactor[] = {0, 0.05, 0.2, 0.5, 1.0};
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: setSlewRate, rate is %d -> %f"), _moveRate, speedFactor[_moveRate]);
+    LOG(DEBUG_MOUNT, "[MOUNT]: setSlewRate, rate is %d -> %f", _moveRate, speedFactor[_moveRate]);
     _stepperDEC->setMaxSpeed(speedFactor[_moveRate] * _maxDECSpeed);
     _stepperRA->setMaxSpeed(speedFactor[_moveRate] * _maxRASpeed);
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: setSlewRate, new speeds are RA: %f  DEC: %f"), _stepperRA->maxSpeed(), _stepperDEC->maxSpeed());
+    LOG(DEBUG_MOUNT, "[MOUNT]: setSlewRate, new speeds are RA: %f  DEC: %f", _stepperRA->maxSpeed(), _stepperDEC->maxSpeed());
 }
 
 /////////////////////////////////
@@ -1066,7 +1066,7 @@ void Mount::setSlewRate(int rate)
 /////////////////////////////////
 void Mount::setHA(const DayTime &haTime)
 {
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: setHA:  HA is %s"), haTime.ToString());
+    LOG(DEBUG_MOUNT, "[MOUNT]: setHA:  HA is %s", haTime.ToString());
     DayTime lst = DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND);
     lst.addTime(haTime);
     setLST(lst);
@@ -1080,12 +1080,12 @@ void Mount::setHA(const DayTime &haTime)
 /////////////////////////////////
 const DayTime Mount::HA() const
 {
-    // LOGV1(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: Get HA."));
-    // LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: Polaris adjust: %s"), DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND).ToString());
+    // LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: Get HA.");
+    // LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: Polaris adjust: %s", DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND).ToString());
     DayTime ha = _LST;
-    // LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: LST: %s"), _LST.ToString());
+    // LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: LST: %s", _LST.ToString());
     ha.subtractTime(DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND));
-    // LOGV2(DEBUG_MOUNT, F("[MOUNT]: GetHA: LST-Polaris is HA %s"), ha.ToString());
+    // LOG(DEBUG_MOUNT, "[MOUNT]: GetHA: LST-Polaris is HA %s", ha.ToString());
     return ha;
 }
 
@@ -1111,7 +1111,7 @@ void Mount::setLST(const DayTime &lst)
 #ifdef OAM
     _zeroPosRA.addHours(6);  // shift allcoordinates by 90° for EQ mount movement
 #endif
-    LOGV2(DEBUG_MOUNT, F("[MOUNT]: Set LST and ZeroPosRA to: %s"), _LST.ToString());
+    LOG(DEBUG_MOUNT, "[MOUNT]: Set LST and ZeroPosRA to: %s", _LST.ToString());
 }
 
 /////////////////////////////////
@@ -1237,12 +1237,11 @@ void Mount::syncPosition(DayTime ra, Declination dec)
     long solutions[6];
     _targetDEC = dec;
     _targetRA  = ra;
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition( RA: %s and DEC: %s )"), _targetRA.ToString(), _targetDEC.ToString());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition( RA: %s and DEC: %s )", _targetRA.ToString(), _targetDEC.ToString());
 
     // Adjust the home RA position by the delta sync position.
     float raAdjust = ra.getTotalHours() - currentRA().getTotalHours();
-    LOGV4(
-        DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: AdjustRA is %f  (%f - %f)"), raAdjust, ra.getTotalHours(), currentRA().getTotalHours());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: AdjustRA is %f  (%f - %f)", raAdjust, ra.getTotalHours(), currentRA().getTotalHours());
     while (raAdjust > 12)
     {
         raAdjust -= 24;
@@ -1251,9 +1250,9 @@ void Mount::syncPosition(DayTime ra, Declination dec)
     {
         raAdjust += 24;
     }
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: AdjustRA is %f"), raAdjust);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: AdjustRA is %f", raAdjust);
     _zeroPosRA.addHours(raAdjust);
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: ZeroPosRA is now %f"), _zeroPosRA.getTotalHours());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: ZeroPosRA is now %f", _zeroPosRA.getTotalHours());
 
     // Adjust the home DEC position by the delta between the sync'd target and current position.
     const float degreePos = (_stepperDEC->currentPosition() / _stepsPerDECDegree) + _zeroPosDEC;  // u-steps / u-steps/deg = deg
@@ -1263,16 +1262,16 @@ void Mount::syncPosition(DayTime ra, Declination dec)
         decAdjust = -decAdjust;
     }
     _zeroPosDEC += decAdjust;
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: _zerPosDEC adjusted by: %f"), decAdjust);
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: _zerPosDEC: %f"), _zeroPosDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: _zerPosDEC adjusted by: %f", decAdjust);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: _zerPosDEC: %f", _zeroPosDEC);
 
     long targetRAPosition, targetDECPosition;
     calculateRAandDECSteppers(targetRAPosition, targetDECPosition, solutions);
 
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: Solution 1: RA %l and DEC %l"), solutions[0], solutions[1]);
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: Solution 2: RA %l and DEC %l"), solutions[2], solutions[3]);
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: Solution 3: RA %l and DEC %l"), solutions[4], solutions[5]);
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: syncPosition: Chosen    : RA %l and DEC %l"), targetRAPosition, targetDECPosition);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: Solution 1: RA %l and DEC %l", solutions[0], solutions[1]);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: Solution 2: RA %l and DEC %l", solutions[2], solutions[3]);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: Solution 3: RA %l and DEC %l", solutions[4], solutions[5]);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: syncPosition: Chosen    : RA %l and DEC %l", targetRAPosition, targetDECPosition);
 }
 
 /////////////////////////////////
@@ -1287,9 +1286,9 @@ void Mount::startSlewingToTarget()
     stopGuiding();
 
     // Make sure we're slewing at full speed on a GoTo
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Set DEC to MaxSpeed(%d)"), _maxDECSpeed);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Set DEC to MaxSpeed(%d)", _maxDECSpeed);
     _stepperDEC->setMaxSpeed(_maxDECSpeed);
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Set RA  to MaxSpeed(%d)"), _maxRASpeed);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Set RA  to MaxSpeed(%d)", _maxRASpeed);
     _stepperRA->setMaxSpeed(_maxRASpeed);
 
     // Calculate new RA stepper target (and DEC). We are never in guding mode here.
@@ -1309,28 +1308,28 @@ void Mount::startSlewingToTarget()
     _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_TO_TARGET;
     _totalDECMove = 1.0f * _stepperDEC->distanceToGo();
     _totalRAMove  = 1.0f * _stepperRA->distanceToGo();
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: RA Dist: %l,   DEC Dist: %l"), _stepperRA->distanceToGo(), _stepperDEC->distanceToGo());
+    LOG(DEBUG_MOUNT, "[MOUNT]: RA Dist: %l,   DEC Dist: %l", _stepperRA->distanceToGo(), _stepperDEC->distanceToGo());
     if ((_stepperRA->distanceToGo() != 0) || (_stepperDEC->distanceToGo() != 0))
     {
         // Only stop tracking if we're actually going to slew somewhere else, otherwise the
         // mount::loop() code won't detect the end of the slewing operation...
-        LOGV1(DEBUG_STEPPERS, F("[MOUNT]: Stop tracking (NEMA steppers)"));
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Stop tracking (NEMA steppers)");
         stopSlewing(TRACKING);
         _trackerStoppedAt        = millis();
         _compensateForTrackerOff = true;
 
 // set Slew microsteps for TMC2209 UART once the TRK stepper has stopped
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
         _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: TRK stopped at %lms"), _trackerStoppedAt);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: TRK stopped at %lms", _trackerStoppedAt);
     }
 
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToTarget: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToTarget: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
     _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 }
@@ -1347,9 +1346,9 @@ void Mount::startSlewingToHome()
     stopGuiding();
 
     // Make sure we're slewing at full speed on a GoTo
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToHome: Set DEC to MaxSpeed(%d)"), _maxDECSpeed);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToHome: Set DEC to MaxSpeed(%d)", _maxDECSpeed);
     _stepperDEC->setMaxSpeed(_maxDECSpeed);
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToHome: Set RA  to MaxSpeed(%d)"), _maxRASpeed);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToHome: Set RA  to MaxSpeed(%d)", _maxRASpeed);
     _stepperRA->setMaxSpeed(_maxRASpeed);
 
     _currentDECStepperPosition = _stepperDEC->currentPosition();
@@ -1358,45 +1357,45 @@ void Mount::startSlewingToHome()
     // Take any syncs that have happened into account
     long targetRAPosition        = -_homeOffsetRA;
     const long targetDECPosition = -_homeOffsetDEC;
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToHome: Sync op offsets: RA: %l, DEC: %l"), targetRAPosition, targetDECPosition);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToHome: Sync op offsets: RA: %l, DEC: %l", targetRAPosition, targetDECPosition);
 
     _slewingToHome = true;
     // Take tracking into account
     const long trackingOffset = _stepperTRK->currentPosition() * RA_SLEW_MICROSTEPPING / RA_TRACKING_MICROSTEPPING;
     targetRAPosition -= trackingOffset;
-    LOGV4(DEBUG_STEPPERS,
-          F("[STEPPERS]: startSlewingToHome: Adjusted with tracking distance: %l (adjusted for MS: %l), result: %l"),
-          _stepperTRK->currentPosition(),
-          trackingOffset,
-          targetRAPosition);
+    LOG(DEBUG_STEPPERS,
+        "[STEPPERS]: startSlewingToHome: Adjusted with tracking distance: %l (adjusted for MS: %l), result: %l",
+        _stepperTRK->currentPosition(),
+        trackingOffset,
+        targetRAPosition);
 
     moveSteppersTo(targetRAPosition, targetDECPosition);  // u-steps (in slew mode)
 
     _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_TO_TARGET;
     _totalDECMove = static_cast<float>(_stepperDEC->distanceToGo());
     _totalRAMove  = static_cast<float>(_stepperRA->distanceToGo());
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: RA Dist: %l,   DEC Dist: %l"), _stepperRA->distanceToGo(), _stepperDEC->distanceToGo());
+    LOG(DEBUG_MOUNT, "[MOUNT]: RA Dist: %l,   DEC Dist: %l", _stepperRA->distanceToGo(), _stepperDEC->distanceToGo());
     if ((_stepperRA->distanceToGo() != 0) || (_stepperDEC->distanceToGo() != 0))
     {
         // Only stop tracking if we're actually going to slew somewhere else, otherwise the
         // mount::loop() code won't detect the end of the slewing operation...
-        LOGV1(DEBUG_STEPPERS, F("[MOUNT]: Stop tracking (NEMA steppers)"));
+        LOG(DEBUG_STEPPERS, "[MOUNT]: Stop tracking (NEMA steppers)");
         stopSlewing(TRACKING);
         _trackerStoppedAt        = millis();
         _compensateForTrackerOff = false;
 
 // set Slew microsteps for TMC2209 UART once the TRK stepper has stopped
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToHome: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToHome: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
         _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToHome: TRK stopped at %lms"), _trackerStoppedAt);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToHome: TRK stopped at %lms", _trackerStoppedAt);
     }
 
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewingToHome: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewingToHome: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
     _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 }
@@ -1414,14 +1413,14 @@ void Mount::stopGuiding(bool ra, bool dec)
     // Stop RA guide first, since it's just a speed change back to tracking speed
     if (ra && (_mountStatus & STATUS_GUIDE_PULSE_RA))
     {
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: stopGuiding(RA): TRK.setSpeed(%f)"), _trackingSpeed);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: stopGuiding(RA): TRK.setSpeed(%f)", _trackingSpeed);
         _stepperTRK->setSpeed(_trackingSpeed);
         _mountStatus &= ~STATUS_GUIDE_PULSE_RA;
     }
 
     if (dec && (_mountStatus & STATUS_GUIDE_PULSE_DEC))
     {
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopGuiding(DEC): Stop motor"));
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: stopGuiding(DEC): Stop motor");
 
         // Stop DEC guiding and wait for it to stop.
         _stepperGUIDE->stop();
@@ -1432,7 +1431,7 @@ void Mount::stopGuiding(bool ra, bool dec)
             _stepperTRK->runSpeed();
         }
 
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: stopGuiding(DEC): GuideStepper stopped at %l"), _stepperGUIDE->currentPosition());
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: stopGuiding(DEC): GuideStepper stopped at %l", _stepperGUIDE->currentPosition());
 
         _mountStatus &= ~STATUS_GUIDE_PULSE_DEC;
     }
@@ -1451,7 +1450,7 @@ void Mount::stopGuiding(bool ra, bool dec)
 /////////////////////////////////
 void Mount::guidePulse(byte direction, int duration)
 {
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse: > Guide Pulse %d for %dms"), direction, duration);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: guidePulse: > Guide Pulse %d for %dms", direction, duration);
 
     // DEC stepper moves at sidereal rate in both directions
     // RA stepper moves at either 2.5x sidereal rate or 0.5x sidereal rate.
@@ -1470,14 +1469,14 @@ void Mount::guidePulse(byte direction, int duration)
     switch (direction)
     {
         case NORTH:
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  DEC.setSpeed(%f)"), DEC_PULSE_MULTIPLIER * decGuidingSpeed);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  DEC.setSpeed(%f)", DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _stepperGUIDE->setSpeed(DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_DEC;
             _guideDecEndTime = millis() + duration;
             break;
 
         case SOUTH:
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  DEC.setSpeed(%f)"), -DEC_PULSE_MULTIPLIER * decGuidingSpeed);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  DEC.setSpeed(%f)", -DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _stepperGUIDE->setSpeed(-DEC_PULSE_MULTIPLIER * decGuidingSpeed);
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_DEC;
             _guideDecEndTime = millis() + duration;
@@ -1485,7 +1484,7 @@ void Mount::guidePulse(byte direction, int duration)
 
         case WEST:
             // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  TRK.setSpeed(%f)"), (RA_PULSE_MULTIPLIER * raGuidingSpeed));
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  TRK.setSpeed(%f)", (RA_PULSE_MULTIPLIER * raGuidingSpeed));
             _stepperTRK->setSpeed(RA_PULSE_MULTIPLIER * raGuidingSpeed);  // Faster than siderael
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
             _guideRaEndTime = millis() + duration;
@@ -1493,14 +1492,14 @@ void Mount::guidePulse(byte direction, int duration)
 
         case EAST:
             // We were in tracking mode before guiding, so no need to update microstepping mode on RA driver
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse:  TRK.setSpeed(%f)"), (raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER)));
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: guidePulse:  TRK.setSpeed(%f)", (raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER)));
             _stepperTRK->setSpeed(raGuidingSpeed * (2.0f - RA_PULSE_MULTIPLIER));  // Slower than siderael
             _mountStatus |= STATUS_GUIDE_PULSE | STATUS_GUIDE_PULSE_RA;
             _guideRaEndTime = millis() + duration;
             break;
     }
 
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: guidePulse: < Guide Pulse"));
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: guidePulse: < Guide Pulse");
 }
 
 /////////////////////////////////
@@ -1578,7 +1577,7 @@ void Mount::setManualSlewMode(bool state)
         waitUntilStopped(ALL_DIRECTIONS);
         _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_MANUAL;
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: setManualSlewMode: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setManualSlewMode: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
         _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
     }
@@ -1587,8 +1586,8 @@ void Mount::setManualSlewMode(bool state)
         _mountStatus &= ~STATUS_SLEWING_MANUAL;
         stopSlewing(ALL_DIRECTIONS);
         waitUntilStopped(ALL_DIRECTIONS);
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setManualSlewMode: Set RA  speed/accel:  %f  / %f"), _maxRASpeed, _maxRAAcceleration);
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setManualSlewMode: Set DEC speed/accel:  %f  / %f"), _maxDECSpeed, _maxDECAcceleration);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setManualSlewMode: Set RA  speed/accel:  %f  / %f", _maxRASpeed, _maxRAAcceleration);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setManualSlewMode: Set DEC speed/accel:  %f  / %f", _maxDECSpeed, _maxDECAcceleration);
         _stepperRA->setAcceleration(_maxRAAcceleration);
         _stepperRA->setMaxSpeed(_maxRASpeed);
         _stepperDEC->setMaxSpeed(_maxDECSpeed);
@@ -1607,14 +1606,14 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
     if (which == RA_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerRADegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set RA speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set RA speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         // TODO: Are we already in slew mode?
         _stepperRA->setSpeed(stepsPerSec);
     }
     else if (which == DEC_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerDECDegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set DEC speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set DEC speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         // TODO: Are we already in slew mode?
         _stepperDEC->setSpeed(stepsPerSec);
     }
@@ -1622,7 +1621,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
     else if (which == AZIMUTH_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerAZDegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set AZ speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set AZ speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         _stepperAZ->setSpeed(stepsPerSec);
     }
 #endif
@@ -1630,7 +1629,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
     else if (which == ALTITUDE_STEPS)
     {
         float stepsPerSec = speedDegsPerSec * _stepsPerALTDegree;  // deg/sec * u-steps/deg = u-steps/sec
-        LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: setSpeed: Set ALT speed %f degs/s, which is %f steps/s"), speedDegsPerSec, stepsPerSec);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: setSpeed: Set ALT speed %f degs/s, which is %f steps/s", speedDegsPerSec, stepsPerSec);
         _stepperALT->setSpeed(stepsPerSec);
     }
 #endif
@@ -1638,12 +1637,12 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
     else if (which == FOCUS_STEPS)
     {
-        LOGV2(DEBUG_MOUNT | DEBUG_FOCUS, F("[FOCUS]: setSpeed() Focuser setSpeed %f"), speedDegsPerSec);
+        LOG(DEBUG_MOUNT | DEBUG_FOCUS, "[FOCUS]: setSpeed() Focuser setSpeed %f", speedDegsPerSec);
         if (speedDegsPerSec != 0)
         {
-            LOGV2(DEBUG_STEPPERS | DEBUG_FOCUS,
-                  F("[FOCUS]: Mount:setSpeed(): Enabling motor, setting speed to %f. Continuous"),
-                  speedDegsPerSec);
+            LOG(DEBUG_STEPPERS | DEBUG_FOCUS,
+                "[FOCUS]: Mount:setSpeed(): Enabling motor, setting speed to %f. Continuous",
+                speedDegsPerSec);
             enableFocusMotor();
             _stepperFocus->setMaxSpeed(speedDegsPerSec);
             _stepperFocus->moveTo(sign(speedDegsPerSec) * 300000);
@@ -1651,7 +1650,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
         }
         else
         {
-            LOGV1(DEBUG_STEPPERS | DEBUG_FOCUS, F("[FOCUS]: setSpeed(): Stopping motor."));
+            LOG(DEBUG_STEPPERS | DEBUG_FOCUS, "[FOCUS]: setSpeed(): Stopping motor.");
             _stepperFocus->stop();
         }
     }
@@ -1815,17 +1814,17 @@ void Mount::focusSetSpeedByRate(int rate)
     _focusRate          = clamp(rate, 1, 4);
     float speedFactor[] = {0, 0.05, 0.2, 0.5, 1.0};
     _maxFocusRateSpeed  = speedFactor[_focusRate] * _maxFocusSpeed;
-    LOGV5(DEBUG_FOCUS,
-          F("[FOCUS]: focusSetSpeedByRate: rate is %d, factor %f, maxspeed %f -> %f"),
-          _focusRate,
-          speedFactor[_focusRate],
-          _maxFocusSpeed,
-          _maxFocusRateSpeed);
+    LOG(DEBUG_FOCUS,
+        "[FOCUS]: focusSetSpeedByRate: rate is %d, factor %f, maxspeed %f -> %f",
+        _focusRate,
+        speedFactor[_focusRate],
+        _maxFocusSpeed,
+        _maxFocusRateSpeed);
     _stepperFocus->setMaxSpeed(_maxFocusRateSpeed);
 
     if (_stepperFocus->isRunning())
     {
-        LOGV1(DEBUG_FOCUS, F("[FOCUS]: focusSetSpeedByRate: stepper is already running so should adjust speed?"));
+        LOG(DEBUG_FOCUS, "[FOCUS]: focusSetSpeedByRate: stepper is already running so should adjust speed?");
         //_stepperFocus->setSpeed(speedFactor[_focusRate ] * _maxFocusSpeed);
     }
 }
@@ -1838,7 +1837,7 @@ void Mount::focusSetSpeedByRate(int rate)
 void Mount::focusContinuousMove(FocuserDirection direction)
 {
     // maxSpeed is set to what the rate dictates
-    LOGV3(DEBUG_FOCUS, F("[FOCUS]: focusContinuousMove: direction is %d, maxspeed %f"), direction, _maxFocusRateSpeed);
+    LOG(DEBUG_FOCUS, "[FOCUS]: focusContinuousMove: direction is %d, maxspeed %f", direction, _maxFocusRateSpeed);
     setSpeed(FOCUS_STEPS, static_cast<int>(direction) * _maxFocusRateSpeed);
 }
 
@@ -1850,7 +1849,7 @@ void Mount::focusContinuousMove(FocuserDirection direction)
 void Mount::focusMoveBy(long steps)
 {
     long targetPosition = _stepperFocus->currentPosition() + steps;
-    LOGV3(DEBUG_FOCUS, F("[FOCUS]: focusMoveBy: move by %l steps to %l. Target Mode."), steps, targetPosition);
+    LOG(DEBUG_FOCUS, "[FOCUS]: focusMoveBy: move by %l steps to %l. Target Mode.", steps, targetPosition);
     enableFocusMotor();
     _stepperFocus->moveTo(targetPosition);
     _focuserMode = FOCUS_TO_TARGET;
@@ -1883,7 +1882,7 @@ void Mount::focusSetStepperPosition(long steps)
 /////////////////////////////////
 void Mount::disableFocusMotor()
 {
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: disableFocusMotor: stopping motor and waiting."));
+    LOG(DEBUG_FOCUS, "[FOCUS]: disableFocusMotor: stopping motor and waiting.");
     _stepperFocus->stop();
     waitUntilStopped(FOCUSING);
 
@@ -1891,10 +1890,10 @@ void Mount::disableFocusMotor()
         #if FOCUSER_ALWAYS_ON == 0
             #if (FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART)
 
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: disableFocusMotor: TMC2209U disabling enable pin"));
+    LOG(DEBUG_FOCUS, "[FOCUS]: disableFocusMotor: TMC2209U disabling enable pin");
     digitalWrite(FOCUS_EN_PIN, HIGH);  // Logic HIGH to disable driver
             #else
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: disableFocusMotor: non-TMC2209U disabling enable pin"));
+    LOG(DEBUG_FOCUS, "[FOCUS]: disableFocusMotor: non-TMC2209U disabling enable pin");
     digitalWrite(FOCUS_EN_PIN, HIGH);  // Logic HIGH to disable driver
             #endif
         #endif
@@ -1908,7 +1907,7 @@ void Mount::disableFocusMotor()
 /////////////////////////////////
 void Mount::enableFocusMotor()
 {
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: enableFocusMotor: enabling driver pin."));
+    LOG(DEBUG_FOCUS, "[FOCUS]: enableFocusMotor: enabling driver pin.");
     digitalWrite(FOCUS_EN_PIN, LOW);  // Logic LOW to enable driver
 }
 
@@ -1919,7 +1918,7 @@ void Mount::enableFocusMotor()
 /////////////////////////////////
 void Mount::focusStop()
 {
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: focusStop: stopping motor."));
+    LOG(DEBUG_FOCUS, "[FOCUS]: focusStop: stopping motor.");
     _stepperFocus->stop();
 }
 
@@ -2231,8 +2230,7 @@ void Mount::startSlewing(int direction)
         {
 // Start tracking
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-            LOGV2(
-                DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: Tracking: Switching RA driver to microsteps(%d)"), RA_TRACKING_MICROSTEPPING);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Tracking: Switching RA driver to microsteps(%d)", RA_TRACKING_MICROSTEPPING);
             _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
 #endif
             _stepperTRK->setSpeed(_trackingSpeed);
@@ -2252,17 +2250,17 @@ void Mount::startSlewing(int direction)
                 stopSlewing(TRACKING);
                 _trackerStoppedAt        = millis();
                 _compensateForTrackerOff = true;
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: stopped TRK at %l"), _trackerStoppedAt);
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: stopped TRK at %l", _trackerStoppedAt);
             }
 
 // Change microstep mode for slewing
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: Slewing: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Slewing: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
             _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
             // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing: Slewing: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing: Slewing: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
             _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 
@@ -2272,14 +2270,14 @@ void Mount::startSlewing(int direction)
                 if (_decUpperLimit != 0)
                 {
                     targetLocation = _decUpperLimit;
-                    LOGV3(DEBUG_STEPPERS,
-                          F("[STEPPERS]: startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l"),
-                          _decUpperLimit,
-                          targetLocation);
+                    LOG(DEBUG_STEPPERS,
+                        "[STEPPERS]: startSlewing(N): DEC has upper limit of %l. targetMoveTo is now %l",
+                        _decUpperLimit,
+                        targetLocation);
                 }
                 else
                 {
-                    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(N): initial targetMoveTo is %l"), targetLocation);
+                    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(N): initial targetMoveTo is %l", targetLocation);
                 }
 
                 _stepperDEC->moveTo(targetLocation);
@@ -2292,14 +2290,14 @@ void Mount::startSlewing(int direction)
                 if (_decLowerLimit != 0)
                 {
                     targetLocation = _decLowerLimit;
-                    LOGV3(DEBUG_STEPPERS,
-                          F("[STEPPERS]: startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l"),
-                          _decLowerLimit,
-                          targetLocation);
+                    LOG(DEBUG_STEPPERS,
+                        "[STEPPERS]: startSlewing(S): DEC has lower limit of %l. targetMoveTo is now %l",
+                        _decLowerLimit,
+                        targetLocation);
                 }
                 else
                 {
-                    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(S): initial targetMoveTo is %l"), targetLocation);
+                    LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(S): initial targetMoveTo is %l", targetLocation);
                 }
 
                 _stepperDEC->moveTo(targetLocation);
@@ -2308,13 +2306,13 @@ void Mount::startSlewing(int direction)
 
             if (direction & EAST)
             {
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(E): initial targetMoveTo is %l"), -sign * 300000);
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(E): initial targetMoveTo is %l", -sign * 300000);
                 _stepperRA->moveTo(-sign * 300000);
                 _mountStatus |= STATUS_SLEWING;
             }
             if (direction & WEST)
             {
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: startSlewing(W): initial targetMoveTo is %l"), sign * 300000);
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: startSlewing(W): initial targetMoveTo is %l", sign * 300000);
                 _stepperRA->moveTo(sign * 300000);
                 _mountStatus |= STATUS_SLEWING;
             }
@@ -2335,19 +2333,19 @@ void Mount::stopSlewing(int direction)
         // Turn off tracking
         _mountStatus &= ~STATUS_TRACKING;
 
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopSlewing: TRK stepper stop()"));
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: stopSlewing: TRK stepper stop()");
         _stepperTRK->stop();
     }
 
     if ((direction & (NORTH | SOUTH)) != 0)
     {
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopSlewing: DEC stepper stop()"));
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: stopSlewing: DEC stepper stop()");
         _stepperDEC->stop();
     }
 
     if ((direction & (WEST | EAST)) != 0)
     {
-        LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: stopSlewing: RA stepper stop()"));
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: stopSlewing: RA stepper stop()");
         _stepperRA->stop();
         if (isFindingHome())
         {
@@ -2411,7 +2409,7 @@ void Mount::setHomingOffset(StepperAxis axis, long offset)
         _homing.offsetRA = offset;
 #endif
         EEPROMStore::storeRAHomingOffset(offset);
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: setHomingOffset(RA): Offset: %l"), offset);
+        LOG(DEBUG_MOUNT, "[MOUNT]: setHomingOffset(RA): Offset: %l", offset);
     }
 }
 
@@ -2475,9 +2473,9 @@ void Mount::processRAHomingProgress()
             {
                 if (millis() > _homing.stopAt)
                 {
-                    LOGV2(DEBUG_STEPPERS,
-                          F("[HOMING]: Initiating stop at requested time. Advance to state %s"),
-                          getHomingState(HomingState::HOMING_WAIT_FOR_STOP).c_str());
+                    LOG(DEBUG_STEPPERS,
+                        "[HOMING]: Initiating stop at requested time. Advance to state %s",
+                        getHomingState(HomingState::HOMING_WAIT_FOR_STOP).c_str());
                     _stepperRA->stop();
                     _homing.state = HomingState::HOMING_WAIT_FOR_STOP;
                 }
@@ -2488,9 +2486,9 @@ void Mount::processRAHomingProgress()
             {
                 if (!_stepperRA->isRunning())
                 {
-                    LOGV2(DEBUG_STEPPERS,
-                          F("[HOMING]: Stepper has stopped as expected, advancing to next state %s"),
-                          getHomingState(_homing.nextState).c_str());
+                    LOG(DEBUG_STEPPERS,
+                        "[HOMING]: Stepper has stopped as expected, advancing to next state %s",
+                        getHomingState(_homing.nextState).c_str());
                     _homing.state     = _homing.nextState;
                     _homing.nextState = HomingState::HOMING_NOT_ACTIVE;
                 }
@@ -2499,10 +2497,10 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_MOVE_OFF:
             {
-                LOGV3(DEBUG_STEPPERS,
-                      F("[HOMING]: Currently over Sensor, so moving off of it by reverse 1h. (%l steps). Advance to %s"),
-                      (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour),
-                      getHomingState(HomingState::HOMING_MOVING_OFF).c_str());
+                LOG(DEBUG_STEPPERS,
+                    "[HOMING]: Currently over Sensor, so moving off of it by reverse 1h. (%l steps). Advance to %s",
+                    (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour),
+                    getHomingState(HomingState::HOMING_MOVING_OFF).c_str());
                 moveStepperBy(StepperAxis::RA_STEPS, -_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour);
                 _homing.state = HomingState::HOMING_MOVING_OFF;
             }
@@ -2515,9 +2513,9 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (homingPinState == HIGH)
                     {
-                        LOGV2(DEBUG_STEPPERS,
-                              F("[HOMING]: Stepper has moved off sensor... stopping in 2s. Advance to %s"),
-                              getHomingState(HomingState::HOMING_STOP_AT_TIME).c_str());
+                        LOG(DEBUG_STEPPERS,
+                            "[HOMING]: Stepper has moved off sensor... stopping in 2s. Advance to %s",
+                            getHomingState(HomingState::HOMING_STOP_AT_TIME).c_str());
                         _homing.stopAt    = millis() + 2000;
                         _homing.state     = HomingState::HOMING_STOP_AT_TIME;
                         _homing.nextState = HomingState::HOMING_START_FIND_START;
@@ -2525,9 +2523,9 @@ void Mount::processRAHomingProgress()
                 }
                 else
                 {
-                    LOGV2(DEBUG_STEPPERS,
-                          F("[HOMING]: Stepper was unable to move off sensor... homing failed! Advance to %s"),
-                          getHomingState(HomingState::HOMING_FAILED).c_str());
+                    LOG(DEBUG_STEPPERS,
+                        "[HOMING]: Stepper was unable to move off sensor... homing failed! Advance to %s",
+                        getHomingState(HomingState::HOMING_FAILED).c_str());
                     _homing.state = HomingState::HOMING_FAILED;
                 }
             }
@@ -2536,11 +2534,11 @@ void Mount::processRAHomingProgress()
         case HomingState::HOMING_START_FIND_START:
             {
                 long distance = (long) (_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour * _homing.searchDistance);
-                LOGV4(DEBUG_STEPPERS,
-                      F("[HOMING]: Finding start on forward pass by moving RA by %dh (%l steps). Advance to %s"),
-                      _homing.searchDistance,
-                      distance,
-                      getHomingState(HomingState::HOMING_FINDING_START).c_str());
+                LOG(DEBUG_STEPPERS,
+                    "[HOMING]: Finding start on forward pass by moving RA by %dh (%l steps). Advance to %s",
+                    _homing.searchDistance,
+                    distance,
+                    getHomingState(HomingState::HOMING_FINDING_START).c_str());
                 _homing.pinState = _homing.lastPinState     = digitalRead(RA_HOMING_SENSOR_PIN);
                 _homing.position[HOMING_START_PIN_POSITION] = 0;
                 _homing.position[HOMING_END_PIN_POSITION]   = 0;
@@ -2559,9 +2557,9 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (_homing.lastPinState != homingPinState)
                     {
-                        LOGV2(DEBUG_STEPPERS,
-                              F("[HOMING]: Found start of sensor, continuing until end is found. Advance to %s"),
-                              getHomingState(HomingState::HOMING_FINDING_END).c_str());
+                        LOG(DEBUG_STEPPERS,
+                            "[HOMING]: Found start of sensor, continuing until end is found. Advance to %s",
+                            getHomingState(HomingState::HOMING_FINDING_END).c_str());
                         // Found the start of the sensor, keep going until we find the end
                         _homing.position[HOMING_START_PIN_POSITION] = _stepperRA->currentPosition();
                         _homing.lastPinState                        = homingPinState;
@@ -2572,11 +2570,11 @@ void Mount::processRAHomingProgress()
                 {
                     // Did not find start. Go reverse direction for twice the distance
                     long distance = (long) (-_homing.initialDir * _stepsPerRADegree * siderealDegreesInHour * _homing.searchDistance * 2);
-                    LOGV4(DEBUG_STEPPERS,
-                          F("[HOMING]: Hall not found on forward pass. Moving RA reverse by %dh (%l steps). Advance to %s"),
-                          2 * _homing.searchDistance,
-                          distance,
-                          getHomingState(HomingState::HOMING_FINDING_START_REVERSE).c_str());
+                    LOG(DEBUG_STEPPERS,
+                        "[HOMING]: Hall not found on forward pass. Moving RA reverse by %dh (%l steps). Advance to %s",
+                        2 * _homing.searchDistance,
+                        distance,
+                        getHomingState(HomingState::HOMING_FINDING_START_REVERSE).c_str());
                     moveStepperBy(StepperAxis::RA_STEPS, distance);
                     _homing.state = HomingState::HOMING_FINDING_START_REVERSE;
                 }
@@ -2590,9 +2588,9 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (_homing.lastPinState != homingPinState)
                     {
-                        LOGV2(DEBUG_STEPPERS,
-                              F("[HOMING]: Found start of sensor reverse, continuing until end is found. Advance to %s"),
-                              getHomingState(HomingState::HOMING_FINDING_END).c_str());
+                        LOG(DEBUG_STEPPERS,
+                            "[HOMING]: Found start of sensor reverse, continuing until end is found. Advance to %s",
+                            getHomingState(HomingState::HOMING_FINDING_END).c_str());
                         _homing.position[HOMING_START_PIN_POSITION] = _stepperRA->currentPosition();
                         _homing.lastPinState                        = homingPinState;
                         _homing.state                               = HomingState::HOMING_FINDING_END;
@@ -2601,9 +2599,9 @@ void Mount::processRAHomingProgress()
                 else
                 {
                     // Did not find start in either direction, abort.
-                    LOGV2(DEBUG_STEPPERS,
-                          F("[HOMING]: Sensor not found on reverse pass either. Homing Failed. Advance to %s"),
-                          getHomingState(HomingState::HOMING_FAILED).c_str());
+                    LOG(DEBUG_STEPPERS,
+                        "[HOMING]: Sensor not found on reverse pass either. Homing Failed. Advance to %s",
+                        getHomingState(HomingState::HOMING_FAILED).c_str());
                     _homing.state = HomingState::HOMING_FAILED;
                 }
             }
@@ -2616,9 +2614,9 @@ void Mount::processRAHomingProgress()
                     int homingPinState = digitalRead(RA_HOMING_SENSOR_PIN);
                     if (_homing.lastPinState != homingPinState)
                     {
-                        LOGV2(DEBUG_STEPPERS,
-                              F("[HOMING]: Found end of sensor, stopping... Advance to %s"),
-                              getHomingState(HomingState::HOMING_WAIT_FOR_STOP).c_str());
+                        LOG(DEBUG_STEPPERS,
+                            "[HOMING]: Found end of sensor, stopping... Advance to %s",
+                            getHomingState(HomingState::HOMING_WAIT_FOR_STOP).c_str());
                         _homing.position[HOMING_END_PIN_POSITION] = _stepperRA->currentPosition();
                         _homing.lastPinState                      = homingPinState;
                         _stepperRA->stop();
@@ -2628,9 +2626,9 @@ void Mount::processRAHomingProgress()
                 }
                 else
                 {
-                    LOGV2(DEBUG_STEPPERS,
-                          F("[HOMING]: End of sensor not found! Advance to %s"),
-                          getHomingState(HomingState::HOMING_FAILED).c_str());
+                    LOG(DEBUG_STEPPERS,
+                        "[HOMING]: End of sensor not found! Advance to %s",
+                        getHomingState(HomingState::HOMING_FAILED).c_str());
                     _homing.state = HomingState::HOMING_FAILED;
                 }
             }
@@ -2638,20 +2636,20 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_RANGE_FOUND:
             {
-                LOGV4(DEBUG_STEPPERS,
-                      F("[HOMING]: Stepper stopped, Hall sensor found! Range: [%l to %l] size: %l"),
-                      _homing.position[HOMING_START_PIN_POSITION],
-                      _homing.position[HOMING_END_PIN_POSITION],
-                      _homing.position[HOMING_START_PIN_POSITION] - _homing.position[HOMING_END_PIN_POSITION]);
+                LOG(DEBUG_STEPPERS,
+                    "[HOMING]: Stepper stopped, Hall sensor found! Range: [%l to %l] size: %l",
+                    _homing.position[HOMING_START_PIN_POSITION],
+                    _homing.position[HOMING_END_PIN_POSITION],
+                    _homing.position[HOMING_START_PIN_POSITION] - _homing.position[HOMING_END_PIN_POSITION]);
 
                 long midPos = (_homing.position[HOMING_START_PIN_POSITION] + _homing.position[HOMING_END_PIN_POSITION]) / 2;
 
-                LOGV5(DEBUG_STEPPERS,
-                      F("[HOMING]: Moving RA to home by %l - (%l) - (%l) steps. Advance to %s"),
-                      midPos,
-                      _stepperRA->currentPosition(),
-                      _homing.offsetRA,
-                      getHomingState(HomingState::HOMING_WAIT_FOR_STOP).c_str());
+                LOG(DEBUG_STEPPERS,
+                    "[HOMING]: Moving RA to home by %l - (%l) - (%l) steps. Advance to %s",
+                    midPos,
+                    _stepperRA->currentPosition(),
+                    _homing.offsetRA,
+                    getHomingState(HomingState::HOMING_WAIT_FOR_STOP).c_str());
 
                 moveStepperBy(StepperAxis::RA_STEPS, midPos - _stepperRA->currentPosition() - _homing.offsetRA);
 
@@ -2662,9 +2660,9 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_SUCCESSFUL:
             {
-                LOGV2(DEBUG_STEPPERS,
-                      F("[HOMING]: Successfully homed! Setting home and restoring Rate setting. Advance to %s"),
-                      getHomingState(HomingState::HOMING_NOT_ACTIVE).c_str());
+                LOG(DEBUG_STEPPERS,
+                    "[HOMING]: Successfully homed! Setting home and restoring Rate setting. Advance to %s",
+                    getHomingState(HomingState::HOMING_NOT_ACTIVE).c_str());
                 setHome(false);
                 setSlewRate(_homing.savedRate);
                 _homing.state = HomingState::HOMING_NOT_ACTIVE;
@@ -2675,9 +2673,9 @@ void Mount::processRAHomingProgress()
 
         case HomingState::HOMING_FAILED:
             {
-                LOGV2(DEBUG_STEPPERS,
-                      F("[HOMING]: Failed to home! Restoring Rate setting and slewing to start position. Advance to %s"),
-                      getHomingState(HomingState::HOMING_NOT_ACTIVE).c_str());
+                LOG(DEBUG_STEPPERS,
+                    "[HOMING]: Failed to home! Restoring Rate setting and slewing to start position. Advance to %s",
+                    getHomingState(HomingState::HOMING_NOT_ACTIVE).c_str());
                 setSlewRate(_homing.savedRate);
                 _homing.state = HomingState::HOMING_NOT_ACTIVE;
                 _mountStatus &= ~STATUS_FINDING_HOME;
@@ -2687,7 +2685,7 @@ void Mount::processRAHomingProgress()
             break;
 
         default:
-            LOGV2(DEBUG_STEPPERS, F("[HOMING]: Unhandled state (%d)! "), _homing.state);
+            LOG(DEBUG_STEPPERS, "[HOMING]: Unhandled state (%d)! ", _homing.state);
             break;
     }
 }
@@ -2712,12 +2710,12 @@ bool Mount::findRAHomeByHallSensor(int initialDirection, int searchDistance)
     if (digitalRead(RA_HOMING_SENSOR_PIN) == LOW)
     {
         _homing.state = HomingState::HOMING_MOVE_OFF;
-        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Sensor is signalled, move off sensor started"));
+        LOG(DEBUG_STEPPERS, "[HOMING]: Sensor is signalled, move off sensor started");
     }
     else
     {
         _homing.state = HomingState::HOMING_START_FIND_START;
-        LOGV1(DEBUG_STEPPERS, F("[HOMING]: Sensor is not signalled, find start of range"));
+        LOG(DEBUG_STEPPERS, "[HOMING]: Sensor is not signalled, find start of range");
     }
 
     return true;
@@ -2820,7 +2818,7 @@ void Mount::loop()
 #if (DEBUG_LEVEL & DEBUG_MOUNT) && (DEBUG_LEVEL & DEBUG_VERBOSE)
     if (now - _lastMountPrint > 2000)
     {
-        LOGV2(DEBUG_MOUNT, F("[MOUNT]: Status -> %s"), getStatusString().c_str());
+        LOG(DEBUG_MOUNT, "[MOUNT]: Status -> %s", getStatusString().c_str());
         _lastMountPrint = now;
     }
 #endif
@@ -2856,21 +2854,21 @@ void Mount::loop()
 #endif
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    // LOGV2(DEBUG_MOUNT, F("[MOUNT]: Focuser running:  %d"), _stepperFocus->isRunning());
+    // LOG(DEBUG_MOUNT, "[MOUNT]: Focuser running:  %d", _stepperFocus->isRunning());
 
     if (_stepperFocus->isRunning())
     {
-        LOGV2(DEBUG_FOCUS, F("[MOUNT]: Loop: Focuser running at speed %f"), _stepperFocus->speed());
+        LOG(DEBUG_FOCUS, "[MOUNT]: Loop: Focuser running at speed %f", _stepperFocus->speed());
         _focuserWasRunning = true;
     }
     else if (_focuserWasRunning)
     {
-        LOGV1(DEBUG_FOCUS, F("[MOUNT]: Loop: Focuser is stopped, but was running "));
+        LOG(DEBUG_FOCUS, "[MOUNT]: Loop: Focuser is stopped, but was running ");
         // If focuser was running last time through the loop, but not this time, it has
         // either been stopped, or reached the target.
         _focuserMode       = FOCUS_IDLE;
         _focuserWasRunning = false;
-        LOGV1(DEBUG_FOCUS, F("[MOUNT]: Loop: Focuser is stopped, but was running, disabling"));
+        LOG(DEBUG_FOCUS, "[MOUNT]: Loop: Focuser is stopped, but was running, disabling");
         disableFocusMotor();
     }
 
@@ -2923,10 +2921,10 @@ void Mount::loop()
 
             if (_stepperWasRunning)
             {
-                LOGV3(DEBUG_MOUNT | DEBUG_STEPPERS,
-                      F("[MOUNT]: Loop: Reached target. RA:%l, DEC:%l"),
-                      _stepperRA->currentPosition(),
-                      _stepperDEC->currentPosition());
+                LOG(DEBUG_MOUNT | DEBUG_STEPPERS,
+                    "[MOUNT]: Loop: Reached target. RA:%l, DEC:%l",
+                    _stepperRA->currentPosition(),
+                    _stepperDEC->currentPosition());
                 // Mount is at Target!
                 // If we we're parking, we just reached home. Clear the flag, reset the motors and stop tracking.
                 if (isParking())
@@ -2935,12 +2933,12 @@ void Mount::loop()
                     // If we're on the second part of the slew to parking, don't set home here
                     if (!_slewingToPark)
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Was Parking, stop tracking and set home."));
+                        LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was Parking, stop tracking and set home.");
                         setHome(false);
                     }
                     else
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Was Parking, stop tracking."));
+                        LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was Parking, stop tracking.");
                     }
                 }
 
@@ -2949,7 +2947,7 @@ void Mount::loop()
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
                 if (!isFindingHome())  // When finding home, we never want to switch back to tracking until homing is finished.
                 {
-                    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: Loop: Arrived. RA driver setMicrosteps(%d)"), RA_TRACKING_MICROSTEPPING);
+                    LOG(DEBUG_STEPPERS, "[STEPPERS]: Loop: Arrived. RA driver setMicrosteps(%d)", RA_TRACKING_MICROSTEPPING);
                     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
                 }
 #endif
@@ -2960,11 +2958,11 @@ void Mount::loop()
                         now                             = millis();
                         unsigned long elapsed           = now - _trackerStoppedAt;
                         unsigned long compensationSteps = _trackingSpeed * elapsed / 1000.0f;
-                        LOGV4(DEBUG_STEPPERS,
-                              F("[STEPPERS]: loop: Arrived at %lms. Tracking was off for %lms (%l steps), compensating."),
-                              now,
-                              elapsed,
-                              compensationSteps);
+                        LOG(DEBUG_STEPPERS,
+                            "[STEPPERS]: loop: Arrived at %lms. Tracking was off for %lms (%l steps), compensating.",
+                            now,
+                            elapsed,
+                            compensationSteps);
                         _stepperTRK->runToNewPosition(_stepperTRK->currentPosition() + compensationSteps);
                         _compensateForTrackerOff = false;
                     }
@@ -2977,34 +2975,34 @@ void Mount::loop()
 
 // Reset DEC to guide microstepping so that guiding is always ready and no switch is neccessary on guide pulses.
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: Loop: Arrived. DEC driver setMicrosteps(%d)"), DEC_GUIDE_MICROSTEPPING);
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: Loop: Arrived. DEC driver setMicrosteps(%d)", DEC_GUIDE_MICROSTEPPING);
                 _driverDEC->microsteps(DEC_GUIDE_MICROSTEPPING == 1 ? 0 : DEC_GUIDE_MICROSTEPPING);
 #endif
 
                 if (_correctForBacklash)
                 {
-                    LOGV3(DEBUG_MOUNT | DEBUG_STEPPERS,
-                          F("[MOUNT]: Loop:   Reached target at %d. Compensating by %d"),
-                          (int) _currentRAStepperPosition,
-                          _backlashCorrectionSteps);
+                    LOG(DEBUG_MOUNT | DEBUG_STEPPERS,
+                        "[MOUNT]: Loop:   Reached target at %d. Compensating by %d",
+                        (int) _currentRAStepperPosition,
+                        _backlashCorrectionSteps);
                     _currentRAStepperPosition += _backlashCorrectionSteps;
                     _stepperRA->runToNewPosition(_currentRAStepperPosition);
                     _correctForBacklash = false;
-                    LOGV2(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Backlash correction done. Pos: %d"), _currentRAStepperPosition);
+                    LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Backlash correction done. Pos: %d", _currentRAStepperPosition);
                 }
                 else
                 {
-                    LOGV2(DEBUG_MOUNT | DEBUG_STEPPERS,
-                          F("[MOUNT]: Loop:   Reached target at %d, no backlash compensation needed"),
-                          _currentRAStepperPosition);
+                    LOG(DEBUG_MOUNT | DEBUG_STEPPERS,
+                        "[MOUNT]: Loop:   Reached target at %d, no backlash compensation needed",
+                        _currentRAStepperPosition);
                 }
 
                 if (_slewingToHome)
                 {
-                    LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Was Slewing home, so setting stepper RA and TRK to zero."));
+                    LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was Slewing home, so setting stepper RA and TRK to zero.");
                     _stepperRA->setCurrentPosition(0);
                     _stepperDEC->setCurrentPosition(0);
-                    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Loop:  TRK.setCurrentPos(0)"));
+                    LOG(DEBUG_STEPPERS, "[STEPPERS]: Loop:  TRK.setCurrentPos(0)");
                     _stepperTRK->setCurrentPosition(0);
                     _stepperGUIDE->setCurrentPosition(0);
                     _homeOffsetRA  = 0;
@@ -3013,20 +3011,19 @@ void Mount::loop()
                     _targetRA = currentRA();
                     if (isParking())
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS,
-                              F("[MOUNT]: Loop:   Was parking, so no tracking. Proceeding to park position..."));
+                        LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Was parking, so no tracking. Proceeding to park position...");
                         _mountStatus &= ~STATUS_PARKING;
                         _slewingToPark = true;
                         _stepperRA->moveTo(_raParkingPos);
                         _stepperDEC->moveTo(_decParkingPos);
                         _totalDECMove = 1.0f * _stepperDEC->distanceToGo();
                         _totalRAMove  = 1.0f * _stepperRA->distanceToGo();
-                        LOGV5(DEBUG_MOUNT | DEBUG_STEPPERS,
-                              F("[MOUNT]: Loop:   Park Position is R:%l  D:%l, TotalMove is R:%f, D:%f"),
-                              _raParkingPos,
-                              _decParkingPos,
-                              _totalRAMove,
-                              _totalDECMove);
+                        LOG(DEBUG_MOUNT | DEBUG_STEPPERS,
+                            "[MOUNT]: Loop:   Park Position is R:%l  D:%l, TotalMove is R:%f, D:%f",
+                            _raParkingPos,
+                            _decParkingPos,
+                            _totalRAMove,
+                            _totalDECMove);
                         if ((_stepperDEC->distanceToGo() != 0) || (_stepperRA->distanceToGo() != 0))
                         {
                             _mountStatus |= STATUS_PARKING_POS | STATUS_SLEWING;
@@ -3034,14 +3031,14 @@ void Mount::loop()
                     }
                     else
                     {
-                        LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Restart tracking."));
+                        LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Restart tracking.");
                         startSlewing(TRACKING);
                     }
                     _slewingToHome = false;
                 }
                 else if (_slewingToPark)
                 {
-                    LOGV1(DEBUG_MOUNT | DEBUG_STEPPERS, F("[MOUNT]: Loop:   Arrived at park position..."));
+                    LOG(DEBUG_MOUNT | DEBUG_STEPPERS, "[MOUNT]: Loop:   Arrived at park position...");
                     _mountStatus &= ~(STATUS_PARKING_POS | STATUS_SLEWING_TO_TARGET);
                     _slewingToPark = false;
                 }
@@ -3093,7 +3090,7 @@ void Mount::setParkingPosition()
     // TODO: Take guide pulses on DEC into account
     _decParkingPos = _stepperDEC->currentPosition();
 
-    LOGV3(DEBUG_MOUNT, F("[MOUNT]: setParkingPos: parking RA: %l  DEC:%l"), _raParkingPos, _decParkingPos);
+    LOG(DEBUG_MOUNT, "[MOUNT]: setParkingPos: parking RA: %l  DEC:%l", _raParkingPos, _decParkingPos);
 
     EEPROMStore::storeRAParkingPos(_raParkingPos);
     EEPROMStore::storeDECParkingPos(_decParkingPos);
@@ -3140,13 +3137,13 @@ void Mount::setDecLimitPositionAbs(bool upper, long stepperPos)
     {
         _decUpperLimit = DEC_LIMIT_UP * _stepsPerDECDegree;
         EEPROMStore::storeDECUpperLimit(_decUpperLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: setDecLimitPosition(Upper): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        LOG(DEBUG_MOUNT, "[MOUNT]: setDecLimitPosition(Upper): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
     else
     {
         _decLowerLimit = -(DEC_LIMIT_DOWN * _stepsPerDECDegree);
         EEPROMStore::storeDECLowerLimit(_decLowerLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: setDecLimitPosition(Lower): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        LOG(DEBUG_MOUNT, "[MOUNT]: setDecLimitPosition(Lower): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
 }
 
@@ -3161,13 +3158,13 @@ void Mount::clearDecLimitPosition(bool upper)
     {
         _decUpperLimit = DEC_LIMIT_UP * _stepsPerDECDegree;
         EEPROMStore::storeDECUpperLimit(_decUpperLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: clearDecLimitPosition(Upper): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        LOG(DEBUG_MOUNT, "[MOUNT]: clearDecLimitPosition(Upper): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
     else
     {
         _decLowerLimit = -(DEC_LIMIT_DOWN * _stepsPerDECDegree);
         EEPROMStore::storeDECLowerLimit(_decLowerLimit);
-        LOGV3(DEBUG_MOUNT, F("[MOUNT]: clearDecLimitPosition(Lower): limit DEC: %l -> %l"), _decLowerLimit, _decUpperLimit);
+        LOG(DEBUG_MOUNT, "[MOUNT]: clearDecLimitPosition(Lower): limit DEC: %l -> %l", _decLowerLimit, _decUpperLimit);
     }
 }
 
@@ -3189,10 +3186,10 @@ void Mount::getDecLimitPositions(long &lowerLimit, long &upperLimit)
 /////////////////////////////////
 void Mount::setHome(bool clearZeroPos)
 {
-    LOGV1(DEBUG_MOUNT, F("[MOUNT]: setHome() called"));
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePre: currentRA is %s"), currentRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePre: targetRA is %s"), targetRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePre: zeroPos is %s"), _zeroPosRA.ToString());
+    LOG(DEBUG_MOUNT, "[MOUNT]: setHome() called");
+    //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePre: currentRA is %s", currentRA().ToString());
+    //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePre: targetRA is %s", targetRA().ToString());
+    //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePre: zeroPos is %s", _zeroPosRA.ToString());
     _zeroPosRA = clearZeroPos ? DayTime(POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND) : calculateLst();
 #ifdef OAM
     _zeroPosRA.addHours(6);  // shift allcoordinates by 90° for EQ mount movement
@@ -3206,9 +3203,9 @@ void Mount::setHome(bool clearZeroPos)
 
     _targetRA = currentRA();
 
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePost: currentRA is %s"), currentRA().ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePost: zeroPos is %s"), _zeroPosRA.ToString());
-    //LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: setHomePost: targetRA is %s"), targetRA().ToString());
+    //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePost: currentRA is %s", currentRA().ToString());
+    //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePost: zeroPos is %s", _zeroPosRA.ToString());
+    //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: setHomePost: targetRA is %s", targetRA().ToString());
 }
 
 /////////////////////////////////
@@ -3259,23 +3256,23 @@ void Mount::calculateStepperPositions(float raCoord, float decCoord, long &raPos
 /////////////////////////////////
 void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps, long pSolutions[6]) const
 {
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersPre: Current : RA: %s, DEC: %s"), currentRA().ToString(), currentDEC().ToString());
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersPre: Target  : RA: %s, DEC: %s"), _targetRA.ToString(), _targetDEC.ToString());
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersPre: ZeroRA  : %s"), _zeroPosRA.ToString());
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersPre: ZeroDEC : %f"), _zeroPosDEC);
-    LOGV4(DEBUG_COORD_CALC,
-          F("[MOUNT]: CalcSteppersPre: Stepper: RA: %l, DEC: %l, TRK: %l"),
-          _stepperRA->currentPosition(),
-          _stepperDEC->currentPosition(),
-          _stepperTRK->currentPosition());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersPre: Current : RA: %s, DEC: %s", currentRA().ToString(), currentDEC().ToString());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersPre: Target  : RA: %s, DEC: %s", _targetRA.ToString(), _targetDEC.ToString());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersPre: ZeroRA  : %s", _zeroPosRA.ToString());
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersPre: ZeroDEC : %f", _zeroPosDEC);
+    LOG(DEBUG_COORD_CALC,
+        "[MOUNT]: CalcSteppersPre: Stepper: RA: %l, DEC: %l, TRK: %l",
+        _stepperRA->currentPosition(),
+        _stepperDEC->currentPosition(),
+        _stepperTRK->currentPosition());
     DayTime raTarget      = _targetRA;
     Declination decTarget = _targetDEC;
 
     raTarget.subtractTime(_zeroPosRA);
-    LOGV3(DEBUG_COORD_CALC,
-          F("[MOUNT]: CalcSteppersIn: Adjust RA by ZeroPosRA. New Target RA: %s, DEC: %s"),
-          raTarget.ToString(),
-          _targetDEC.ToString());
+    LOG(DEBUG_COORD_CALC,
+        "[MOUNT]: CalcSteppersIn: Adjust RA by ZeroPosRA. New Target RA: %s, DEC: %s",
+        raTarget.ToString(),
+        _targetDEC.ToString());
 
     // Where do we want to move RA to?
     float moveRA = raTarget.getTotalHours();
@@ -3286,7 +3283,7 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
 
     // Total hours of tracking-to-date
     float trackedHours = (_stepperTRK->currentPosition() / _trackingSpeed) / 3600.0F;  // steps / steps/s / 3600 = hours
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Tracked time is %l steps (%f h)."), _stepperTRK->currentPosition(), trackedHours);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Tracked time is %l steps (%f h).", _stepperTRK->currentPosition(), trackedHours);
 
     // The current RA of the home position, taking tracking-to-date into account
     float homeRA = _zeroPosRA.getTotalHours() + trackedHours;
@@ -3306,10 +3303,10 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
     while (moveRA > 12)
     {
         moveRA = moveRA - 24;
-        LOGV3(DEBUG_COORD_CALC,
-              F("[MOUNT]: CalcSteppersIn: moveRA>12 so -24. New Target RA: %s, DEC: %s"),
-              DayTime(moveRA).ToString(),
-              _targetDEC.ToString());
+        LOG(DEBUG_COORD_CALC,
+            "[MOUNT]: CalcSteppersIn: moveRA>12 so -24. New Target RA: %s, DEC: %s",
+            DayTime(moveRA).ToString(),
+            _targetDEC.ToString());
     }
 
     // How many u-steps moves the RA ring one sidereal hour along when slewing. One sidereal hour moves just shy of 15 degrees
@@ -3318,7 +3315,7 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
     // Where do we want to move DEC to?
     float moveDEC = decTarget.getTotalDegrees();
 
-    LOGV4(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Target hrs pos RA: %f (regRA: %f), DEC: %f"), homeTargetDeltaRA, moveRA, moveDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Target hrs pos RA: %f (regRA: %f), DEC: %f", homeTargetDeltaRA, moveRA, moveDEC);
 
     /*
   * Current RA wheel has a rotation limit of around 7 hours in each direction from home position.
@@ -3336,7 +3333,7 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
     float const RALimitL = -RA_LIMIT_RIGHT;
     float const RALimitR = RA_LIMIT_LEFT;
 #endif
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Limits are : %f to %f"), RALimitL, RALimitR);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Limits are : %f to %f", RALimitL, RALimitR);
 
     if (pSolutions != nullptr)
     {
@@ -3348,54 +3345,54 @@ void Mount::calculateRAandDECSteppers(long &targetRASteps, long &targetDECSteps,
         pSolutions[5] = long(-moveDEC) * _stepsPerDECDegree;
     }
 
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Solution 1: %f, %f"), -moveRA, moveDEC);
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Solution 2: %f, %f"), -(moveRA - 12.0f), -moveDEC);
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Solution 3: %f, %f"), -(moveRA + 12.0f), -moveDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Solution 1: %f, %f", -moveRA, moveDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Solution 2: %f, %f", -(moveRA - 12.0f), -moveDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Solution 3: %f, %f", -(moveRA + 12.0f), -moveDEC);
 
     // If we reach the limit in the positive direction ...
     if (homeTargetDeltaRA > RALimitR)
     {
-        LOGV4(DEBUG_COORD_CALC,
-              F("[MOUNT]: CalcSteppersIn: targetRA %f (RA:%f) is past max limit %f  (solution 2)"),
-              homeTargetDeltaRA,
-              moveRA,
-              RALimitR);
+        LOG(DEBUG_COORD_CALC,
+            "[MOUNT]: CalcSteppersIn: targetRA %f (RA:%f) is past max limit %f  (solution 2)",
+            homeTargetDeltaRA,
+            moveRA,
+            RALimitR);
 
         // ... turn both RA and DEC axis around
         moveRA -= 12.0f;
         moveDEC = -moveDEC;
-        LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Adjusted Target. RA: %f, DEC: %f"), moveRA, moveDEC);
+        LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Adjusted Target. RA: %f, DEC: %f", moveRA, moveDEC);
     }
     // If we reach the limit in the negative direction...
     else if (homeTargetDeltaRA < RALimitL)
     {
-        LOGV4(DEBUG_COORD_CALC,
-              F("[MOUNT]: CalcSteppersIn: targetRA %f (RA:%f) is past min limit: %f, (solution 3)"),
-              homeTargetDeltaRA,
-              moveRA,
-              RALimitL);
+        LOG(DEBUG_COORD_CALC,
+            "[MOUNT]: CalcSteppersIn: targetRA %f (RA:%f) is past min limit: %f, (solution 3)",
+            homeTargetDeltaRA,
+            moveRA,
+            RALimitL);
         // ... turn both RA and DEC axis around
 
         moveRA += 12.0f;
         moveDEC = -moveDEC;
-        LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Adjusted Target. RA: %f, DEC: %f"), moveRA, moveDEC);
+        LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Adjusted Target. RA: %f, DEC: %f", moveRA, moveDEC);
     }
     else
     {
-        LOGV4(DEBUG_COORD_CALC,
-              F("[MOUNT]: CalcSteppersIn: targetRA %f is in range. RA: %f, DEC: %f  (solution 1)"),
-              homeTargetDeltaRA,
-              moveRA,
-              moveDEC);
+        LOG(DEBUG_COORD_CALC,
+            "[MOUNT]: CalcSteppersIn: targetRA %f is in range. RA: %f, DEC: %f  (solution 1)",
+            homeTargetDeltaRA,
+            moveRA,
+            moveDEC);
     }
 
     moveDEC -= _zeroPosDEC;  // deg
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: _zeroPosDEC: %f"), _zeroPosDEC);
-    LOGV2(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersIn: Adjusted moveDEC: %f"), moveDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: _zeroPosDEC: %f", _zeroPosDEC);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersIn: Adjusted moveDEC: %f", moveDEC);
 
     targetRASteps  = -moveRA * stepsPerSiderealHour;
     targetDECSteps = moveDEC * _stepsPerDECDegree;
-    LOGV3(DEBUG_COORD_CALC, F("[MOUNT]: CalcSteppersPost: Target Steps RA: %l, DEC: %l"), targetRASteps, targetDECSteps);
+    LOG(DEBUG_COORD_CALC, "[MOUNT]: CalcSteppersPost: Target Steps RA: %l, DEC: %l", targetRASteps, targetDECSteps);
 }
 
 /////////////////////////////////
@@ -3407,12 +3404,12 @@ void Mount::moveSteppersTo(float targetRASteps, float targetDECSteps)
 {  // Units are u-steps (in slew mode)
     // Show time: tell the steppers where to go!
     _correctForBacklash = false;
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: MoveSteppersTo: RA  From: %l  To: %f"), _stepperRA->currentPosition(), targetRASteps);
-    LOGV3(DEBUG_STEPPERS, F("[STEPPERS]: MoveSteppersTo: DEC From: %l  To: %f"), _stepperDEC->currentPosition(), targetDECSteps);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: MoveSteppersTo: RA  From: %l  To: %f", _stepperRA->currentPosition(), targetRASteps);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: MoveSteppersTo: DEC From: %l  To: %f", _stepperDEC->currentPosition(), targetDECSteps);
 
     if ((_backlashCorrectionSteps != 0) && ((_stepperRA->currentPosition() - targetRASteps) > 0))
     {
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: MoveSteppersTo: Needs backlash correction of %d!"), _backlashCorrectionSteps);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: MoveSteppersTo: Needs backlash correction of %d!", _backlashCorrectionSteps);
         targetRASteps -= _backlashCorrectionSteps;
         _correctForBacklash = true;
     }
@@ -3422,12 +3419,12 @@ void Mount::moveSteppersTo(float targetRASteps, float targetDECSteps)
     if (_decUpperLimit != 0)
     {
         targetDECSteps = min(targetDECSteps, (float) _decUpperLimit);
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: MoveSteppersTo: DEC Upper Limit enforced. To: %f"), targetDECSteps);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: MoveSteppersTo: DEC Upper Limit enforced. To: %f", targetDECSteps);
     }
     if (_decLowerLimit != 0)
     {
         targetDECSteps = max(targetDECSteps, (float) _decLowerLimit);
-        LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: MoveSteppersTo: DEC Lower Limit enforced. To: %f"), targetDECSteps);
+        LOG(DEBUG_STEPPERS, "[STEPPERS]: MoveSteppersTo: DEC Lower Limit enforced. To: %f", targetDECSteps);
     }
 
     _stepperDEC->moveTo(targetDECSteps);
@@ -3440,7 +3437,7 @@ void Mount::moveSteppersTo(float targetRASteps, float targetDECSteps)
 /////////////////////////////////
 void Mount::moveStepperBy(StepperAxis direction, long steps)
 {
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: %l"), steps);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: %l", steps);
     switch (direction)
     {
         case RA_STEPS:
@@ -3451,18 +3448,18 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
             {
                 // Only stop tracking if we're actually going to slew somewhere else, otherwise the
                 // mount::loop() code won't detect the end of the slewing operation...
-                LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: Stop tracking (NEMA steppers)"));
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: Stop tracking (NEMA steppers)");
                 stopSlewing(TRACKING);
                 _trackerStoppedAt        = millis();
                 _compensateForTrackerOff = true;
 
 // set Slew microsteps for TMC2209 UART once the TRK stepper has stopped
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: Switching RA driver to microsteps(%d)"), RA_SLEW_MICROSTEPPING);
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: Switching RA driver to microsteps(%d)", RA_SLEW_MICROSTEPPING);
                 _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
 #endif
 
-                LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: TRK stopped at %lms"), _trackerStoppedAt);
+                LOG(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: TRK stopped at %lms", _trackerStoppedAt);
             }
             break;
         case DEC_STEPS:
@@ -3472,7 +3469,7 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
 
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
             // Since normal state for DEC is guide microstepping, switch to slew microstepping here.
-            LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: moveStepperBy: Switching DEC driver to microsteps(%d)"), DEC_SLEW_MICROSTEPPING);
+            LOG(DEBUG_STEPPERS, "[STEPPERS]: moveStepperBy: Switching DEC driver to microsteps(%d)", DEC_SLEW_MICROSTEPPING);
             _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
 #endif
 
@@ -3485,10 +3482,10 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
         case AZIMUTH_STEPS:
 #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
             enableAzAltMotors();
-            LOGV3(DEBUG_STEPPERS,
-                  "[STEPPERS]: moveStepperBy: AZ from %l to %l",
-                  _stepperAZ->currentPosition(),
-                  _stepperAZ->currentPosition() + steps);
+            LOG(DEBUG_STEPPERS,
+                "[STEPPERS]: moveStepperBy: AZ from %l to %l",
+                _stepperAZ->currentPosition(),
+                _stepperAZ->currentPosition() + steps);
             _stepperAZ->moveTo(_stepperAZ->currentPosition() + steps);
 #endif
             break;
@@ -3606,17 +3603,17 @@ String Mount::DECString(byte type, byte active)
     Declination dec;
     if ((type & TARGET_STRING) == TARGET_STRING)
     {
-        //LOGV1(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: DECString: TARGET!"));
+        //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: DECString: TARGET!");
         dec = _targetDEC;
     }
     else
     {
-        //LOGV1(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: DECString: CURRENT!"));
+        //LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: DECString: CURRENT!");
         dec = currentDEC();
     }
-    //LOGV5(DEBUG_INFO,F("[MOUNT]: DECString: Precheck  : %s   %s  %dm %ds"), dec.ToString(), dec.getDegreesDisplay().c_str(), dec.getMinutes(), dec.getSeconds());
+    //LOG(DEBUG_INFO, "[MOUNT]: DECString: Precheck  : %s   %s  %dm %ds", dec.ToString(), dec.getDegreesDisplay().c_str(), dec.getMinutes(), dec.getSeconds());
     // dec.checkHours();
-    // LOGV2(DEBUG_MOUNT_VERBOSE,F("[MOUNT]: DECString: Postcheck : %s"), dec.ToString());
+    // LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: DECString: Postcheck : %s", dec.ToString());
 
     dec.formatString(scratchBuffer, formatStringsDEC[type & FORMAT_STRING_MASK]);
 
@@ -3830,10 +3827,10 @@ void Mount::testRA_UART_TX()
     const int speed = (RA_STEPPER_SPEED / 2) / 0.715255737f;
     //Duration in ms to move X degrees at half of the max speed
     const int duration = UART_CONNECTION_TEST_TX_DEG * (_stepsPerRADegree / (RA_STEPPER_SPEED / 2)) * 1000;
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: uartTest: Switching RA driver to microsteps(%d) for UART test"), RA_SLEW_MICROSTEPPING);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: uartTest: Switching RA driver to microsteps(%d) for UART test", RA_SLEW_MICROSTEPPING);
     _driverRA->microsteps(RA_SLEW_MICROSTEPPING == 1 ? 0 : RA_SLEW_MICROSTEPPING);
     testUART_vactual(_driverRA, speed, duration);
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: uartTest: Switching RA driver to microsteps(%d) after UART test"), RA_TRACKING_MICROSTEPPING);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: uartTest: Switching RA driver to microsteps(%d) after UART test", RA_TRACKING_MICROSTEPPING);
     _driverRA->microsteps(RA_TRACKING_MICROSTEPPING == 1 ? 0 : RA_TRACKING_MICROSTEPPING);
 }
     #endif
@@ -3845,10 +3842,10 @@ void Mount::testDEC_UART_TX()
     const int speed = (DEC_STEPPER_SPEED / 2) / 0.715255737f;
     //Duration in ms to move X degrees at half of the max speed
     const int duration = UART_CONNECTION_TEST_TX_DEG * (_stepsPerDECDegree / (DEC_STEPPER_SPEED / 2)) * 1000;
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: uartTest: Switching DEC driver to microsteps(%d) for UART test"), DEC_SLEW_MICROSTEPPING);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: uartTest: Switching DEC driver to microsteps(%d) for UART test", DEC_SLEW_MICROSTEPPING);
     _driverDEC->microsteps(DEC_SLEW_MICROSTEPPING == 1 ? 0 : DEC_SLEW_MICROSTEPPING);
     testUART_vactual(_driverDEC, speed, duration);
-    LOGV2(DEBUG_STEPPERS, F("[STEPPERS]: uartTest: Switching DEC driver to microsteps(%d) after UART test"), DEC_GUIDE_MICROSTEPPING);
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: uartTest: Switching DEC driver to microsteps(%d) after UART test", DEC_GUIDE_MICROSTEPPING);
     _driverDEC->microsteps(DEC_GUIDE_MICROSTEPPING == 1 ? 0 : DEC_GUIDE_MICROSTEPPING);
 }
     #endif
@@ -3897,19 +3894,19 @@ void Mount::checkRALimit()
         if (hourPos < 0)
             hourPos += 24;
     }
-    LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: checkRALimit: homeRA: %f"), homeRA);
-    LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: checkRALimit: currentRA: %f"), currentRA().getTotalHours());
-    LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: checkRALimit: currentRA (adjusted): %f"), hourPos);
+    LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: checkRALimit: homeRA: %f", homeRA);
+    LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: checkRALimit: currentRA: %f", currentRA().getTotalHours());
+    LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: checkRALimit: currentRA (adjusted): %f", hourPos);
     float homeCurrentDeltaRA = homeRA - hourPos;
     while (homeCurrentDeltaRA > 12)
         homeCurrentDeltaRA -= 24;
     while (homeCurrentDeltaRA < -12)
         homeCurrentDeltaRA += 24;
-    LOGV2(DEBUG_MOUNT_VERBOSE, F("[MOUNT]: checkRALimit: homeRAdelta: %f"), homeCurrentDeltaRA);
+    LOG(DEBUG_MOUNT_VERBOSE, "[MOUNT]: checkRALimit: homeRAdelta: %f", homeCurrentDeltaRA);
 
     if (homeCurrentDeltaRA > RALimit)
     {
-        LOGV1(DEBUG_MOUNT, F("[MOUNT]: checkRALimit: Tracking limit reached"));
+        LOG(DEBUG_MOUNT, "[MOUNT]: checkRALimit: Tracking limit reached");
         stopSlewing(TRACKING);
     }
     _lastTRKCheck = millis();

--- a/src/Utility.hpp
+++ b/src/Utility.hpp
@@ -11,15 +11,7 @@ String getLogBuffer();
 int freeMemory();
 
 #if DEBUG_LEVEL > 0
-
-    #define LOGV1(level, a)                      logv((level), (a))
-    #define LOGV2(level, a, b)                   logv((level), (a), (b))
-    #define LOGV3(level, a, b, c)                logv((level), (a), (b), (c))
-    #define LOGV4(level, a, b, c, d)             logv((level), (a), (b), (c), (d))
-    #define LOGV5(level, a, b, c, d, e)          logv((level), (a), (b), (c), (d), (e))
-    #define LOGV6(level, a, b, c, d, e, f)       logv((level), (a), (b), (c), (d), (e), (f))
-    #define LOGV7(level, a, b, c, d, e, f, g)    logv((level), (a), (b), (c), (d), (e), (f), (g))
-    #define LOGV8(level, a, b, c, d, e, f, g, h) logv((level), (a), (b), (c), (d), (e), (f), (g), (h))
+    #define LOG(level, format, ...)  logv((level), (F(format)), ##__VA_ARGS__)
 
 // Realtime timer class using microseconds to time stuff
 class RealTime
@@ -138,15 +130,7 @@ String format(const char *input, ...);
 void logv(int levelFlags, String input, ...);
 
 #else  // DEBUG_LEVEL>0
-
-    #define LOGV1(level, a)
-    #define LOGV2(level, a, b)
-    #define LOGV3(level, a, b, c)
-    #define LOGV4(level, a, b, c, d)
-    #define LOGV5(level, a, b, c, d, e)
-    #define LOGV6(level, a, b, c, d, e, f)
-    #define LOGV7(level, a, b, c, d, e, f, g)
-
+    #define LOG(level, format, ...)
 #endif  // DEBUG_LEVEL>0
 
 // For some reason arduino just defines all float functions to be as double

--- a/src/Utility.hpp
+++ b/src/Utility.hpp
@@ -11,7 +11,7 @@ String getLogBuffer();
 int freeMemory();
 
 #if DEBUG_LEVEL > 0
-    #define LOG(level, format, ...)  logv((level), (F(format)), ##__VA_ARGS__)
+    #define LOG(level, format, ...) logv((level), (F(format)), ##__VA_ARGS__)
 
 // Realtime timer class using microseconds to time stuff
 class RealTime

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -14,7 +14,7 @@ WifiControl::WifiControl(Mount *mount, LcdMenu *lcdMenu)
 
 void WifiControl::setup()
 {
-    LOGV2(DEBUG_WIFI, F("[WIFI]: Starting up Wifi As Mode %d\n"), WIFI_MODE);
+    LOG(DEBUG_WIFI, "[WIFI]: Starting up Wifi As Mode %d\n", WIFI_MODE);
 
     _cmdProcessor = MeadeCommandProcessor::instance();
 
@@ -39,10 +39,10 @@ void WifiControl::setup()
 
 void WifiControl::startInfrastructureMode()
 {
-    LOGV1(DEBUG_WIFI, F("[WIFI]: Starting Infrastructure Mode Wifi"));
-    LOGV2(DEBUG_WIFI, F("[WIFI]:    with host name: %s"), String(WIFI_HOSTNAME).c_str());
-    LOGV2(DEBUG_WIFI, F("[WIFI]:          for SSID: %s"), String(WIFI_INFRASTRUCTURE_MODE_SSID).c_str());
-    LOGV2(DEBUG_WIFI, F("[WIFI]:       and WPA key: %s"), String(WIFI_INFRASTRUCTURE_MODE_WPAKEY).c_str());
+    LOG(DEBUG_WIFI, "[WIFI]: Starting Infrastructure Mode Wifi");
+    LOG(DEBUG_WIFI, "[WIFI]:    with host name: %s", String(WIFI_HOSTNAME).c_str());
+    LOG(DEBUG_WIFI, "[WIFI]:          for SSID: %s", String(WIFI_INFRASTRUCTURE_MODE_SSID).c_str());
+    LOG(DEBUG_WIFI, "[WIFI]:       and WPA key: %s", String(WIFI_INFRASTRUCTURE_MODE_WPAKEY).c_str());
 
     #if defined(ESP32)
     WiFi.setHostname(WIFI_HOSTNAME);
@@ -52,7 +52,7 @@ void WifiControl::startInfrastructureMode()
 
 void WifiControl::startAccessPointMode()
 {
-    LOGV1(DEBUG_WIFI, F("[WIFI]: Starting AP Mode Wifi"));
+    LOG(DEBUG_WIFI, "[WIFI]: Starting AP Mode Wifi");
     IPAddress local_ip(192, 168, 1, 1);
     IPAddress gateway(192, 168, 1, 1);
     IPAddress subnet(255, 255, 255, 0);
@@ -126,7 +126,7 @@ void WifiControl::loop()
     if (_status != WiFi.status())
     {
         _status = WiFi.status();
-        LOGV2(DEBUG_WIFI, F("[WIFI]: Connected status changed to %s"), wifiStatus(_status).c_str());
+        LOG(DEBUG_WIFI, "[WIFI]: Connected status changed to %s", wifiStatus(_status).c_str());
         if (_status == WL_CONNECTED)
         {
             _tcpServer = new WiFiServer(WIFI_PORT);
@@ -136,11 +136,11 @@ void WifiControl::loop()
             _udp = new WiFiUDP();
             _udp->begin(4031);
 
-            LOGV4(DEBUG_WIFI,
-                  F("[WIFI]: Connecting to SSID %s at %s:%d"),
-                  WIFI_INFRASTRUCTURE_MODE_SSID,
-                  WiFi.localIP().toString().c_str(),
-                  WIFI_PORT);
+            LOG(DEBUG_WIFI,
+                "[WIFI]: Connecting to SSID %s at %s:%d",
+                WIFI_INFRASTRUCTURE_MODE_SSID,
+                WiFi.localIP().toString().c_str(),
+                WIFI_PORT);
         }
     }
 
@@ -164,7 +164,7 @@ void WifiControl::infraToAPFailover()
         startAccessPointMode();
         _infraStart = 0;
 
-        LOGV1(DEBUG_WIFI, F("[WIFI]: Could not connect to Infra, Starting AP."));
+        LOG(DEBUG_WIFI, "[WIFI]: Could not connect to Infra, Starting AP.");
     }
 }
 
@@ -174,31 +174,31 @@ void WifiControl::tcpLoop()
     {
         while (client.available())
         {
-            LOGV2(DEBUG_WIFI, F("[WIFITCP]: Available bytes %d. Peeking."), client.available());
+            LOG(DEBUG_WIFI, "[WIFITCP]: Available bytes %d. Peeking.", client.available());
 
             // Peek first byte and check for ACK (0x06) handshake
-            LOGV2(DEBUG_WIFI, F("[WIFITCP]: First byte is %x"), client.peek());
+            LOG(DEBUG_WIFI, "[WIFITCP]: First byte is %x", client.peek());
             if (client.peek() == 0x06)
             {
                 client.read();
-                LOGV1(DEBUG_WIFI, F("[WIFITCP]: Query <-- Handshake request"));
+                LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
                 client.write("1");
-                LOGV1(DEBUG_WIFI, F("[WIFITCP]: Reply --> 1"));
+                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> 1");
             }
             else
             {
                 String cmd = client.readStringUntil('#');
-                LOGV2(DEBUG_WIFI, F("[WIFITCP]: Query <-- %s#"), cmd.c_str());
+                LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- %s#", cmd.c_str());
                 String retVal = _cmdProcessor->processCommand(cmd);
 
                 if (retVal != "")
                 {
                     client.write(retVal.c_str());
-                    LOGV2(DEBUG_WIFI, F("[WIFITCP]: Reply --> %s"), retVal.c_str());
+                    LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> %s", retVal.c_str());
                 }
                 else
                 {
-                    LOGV1(DEBUG_WIFI, F("[WIFITCP]: No Reply"));
+                    LOG(DEBUG_WIFI, "[WIFITCP]: No Reply");
                 }
             }
 
@@ -221,15 +221,15 @@ void WifiControl::udpLoop()
         reply += WIFI_HOSTNAME;
         reply += "@";
         reply += WiFi.localIP().toString();
-        LOGV4(DEBUG_WIFI,
-              F("[WIFIUDP]: Received %d bytes from %s, port %d"),
-              packetSize,
-              _udp->remoteIP().toString().c_str(),
-              _udp->remotePort());
+        LOG(DEBUG_WIFI,
+            "[WIFIUDP]: Received %d bytes from %s, port %d",
+            packetSize,
+            _udp->remoteIP().toString().c_str(),
+            _udp->remotePort());
         char incomingPacket[255];
         int len             = _udp->read(incomingPacket, 255);
         incomingPacket[len] = 0;
-        LOGV2(DEBUG_WIFI, F("[WIFIUDP]: Received: %s"), incomingPacket);
+        LOG(DEBUG_WIFI, "[WIFIUDP]: Received: %s", incomingPacket);
 
         incomingPacket[lookingFor.length()] = 0;
         if (lookingFor.equalsIgnoreCase(incomingPacket))
@@ -244,7 +244,7 @@ void WifiControl::udpLoop()
     #endif
 
             _udp->endPacket();
-            LOGV2(DEBUG_WIFI, F("[WIFIUDP]: Replied: %s"), reply.c_str());
+            LOG(DEBUG_WIFI, "[WIFIUDP]: Replied: %s", reply.c_str());
         }
     }
 }

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -105,7 +105,7 @@ void setup()
     #endif
 #endif
 
-    LOGV2(DEBUG_ANY, F("[SYSTEM]: Hello, universe, this is OAT %s!"), VERSION);
+    LOG(DEBUG_ANY, "[SYSTEM]: Hello, universe, this is OAT %s!", VERSION);
 
 #if USE_GPS == 1
     GPS_SERIAL_PORT.begin(GPS_BAUD_RATE);
@@ -186,13 +186,13 @@ void setup()
 #endif
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: setup(): focus disabling enable pin"));
+    LOG(DEBUG_FOCUS, "[FOCUS]: setup(): focus disabling enable pin");
     pinMode(FOCUS_EN_PIN, OUTPUT);
     digitalWrite(FOCUS_EN_PIN, HIGH);  // Logic HIGH to disable the driver initally
     #if FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
         // include TMC2209 UART pins
         #ifdef FOCUS_SERIAL_PORT
-    LOGV1(DEBUG_FOCUS, F("[FOCUS]: setup(): focus TMC2209U starting comms"));
+    LOG(DEBUG_FOCUS, "[FOCUS]: setup(): focus TMC2209U starting comms");
     FOCUS_SERIAL_PORT.begin(57600);  // Start HardwareSerial comms with driver
         #endif
     #endif
@@ -203,12 +203,12 @@ void setup()
     pinMode(RA_HOMING_SENSOR_PIN, INPUT);
 #endif
 
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Get EEPROM store ready..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Get EEPROM store ready...");
     EEPROMStore::initialize();
 
 // Calling the LCD startup here, I2C can't be found if called earlier
 #if DISPLAY_TYPE != DISPLAY_TYPE_NONE
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Get LCD ready..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Get LCD ready...");
     lcdMenu.startup();
 
     // Show a splash screen
@@ -225,17 +225,17 @@ void setup()
     // Check for EEPROM reset (Button down during boot)
     if (lcdButtons.currentState() == btnDOWN)
     {
-        LOGV1(DEBUG_INFO, F("[SYSTEM]: Erasing configuration in EEPROM!"));
+        LOG(DEBUG_INFO, "[SYSTEM]: Erasing configuration in EEPROM!");
         mount.clearConfiguration();
         // Wait for button release
         lcdMenu.setCursor(13, 1);
         lcdMenu.printMenu("CLR");
-        LOGV1(DEBUG_INFO, F("[SYSTEM]: Waiting for button release!"));
+        LOG(DEBUG_INFO, "[SYSTEM]: Waiting for button release!");
         while (lcdButtons.currentState() != btnNONE)
         {
             delay(10);
         }
-        LOGV1(DEBUG_INFO, F("[SYSTEM]: Button released, continuing"));
+        LOG(DEBUG_INFO, "[SYSTEM]: Button released, continuing");
     }
 
     // Create the LCD top-level menu items
@@ -268,14 +268,14 @@ void setup()
 
 #endif  // DISPLAY_TYPE > 0
 
-    LOGV2(DEBUG_ANY, F("[SYSTEM]: Hardware: %s"), mount.getMountHardwareInfo().c_str());
+    LOG(DEBUG_ANY, "[SYSTEM]: Hardware: %s", mount.getMountHardwareInfo().c_str());
 
     // Create the command processor singleton
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Initialize LX200 handler..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Initialize LX200 handler...");
     MeadeCommandProcessor::createProcessor(&mount, &lcdMenu);
 
 #if (WIFI_ENABLED == 1)
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Setup Wifi..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Setup Wifi...");
     wifiControl.setup();
 #endif
 
@@ -283,25 +283,25 @@ void setup()
     // Delay for a while to get UARTs booted...
     delay(1000);
 
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Configure steppers..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Configure steppers...");
 
 // Set the stepper motor parameters
 #if (RA_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure RA stepper NEMA..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure RA stepper NEMA...");
     mount.configureRAStepper(RAmotorPin1, RAmotorPin2, RA_STEPPER_SPEED, RA_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.
 #endif
 
 #if (DEC_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure DEC stepper NEMA..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure DEC stepper NEMA...");
     mount.configureDECStepper(DECmotorPin1, DECmotorPin2, DEC_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.
 #endif
 
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure RA driver TMC2209 UART..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure RA driver TMC2209 UART...");
     #if SW_SERIAL_UART == 0
     mount.configureRAdriver(&RA_SERIAL_PORT, R_SENSE, RA_DRIVER_ADDRESS, RA_RMSCURRENT, RA_STALL_VALUE);
     #elif SW_SERIAL_UART == 1
@@ -309,7 +309,7 @@ void setup()
     #endif
 #endif
 #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure DEC driver TMC2209 UART..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure DEC driver TMC2209 UART...");
     #if SW_SERIAL_UART == 0
     mount.configureDECdriver(&DEC_SERIAL_PORT, R_SENSE, DEC_DRIVER_ADDRESS, DEC_RMSCURRENT, DEC_STALL_VALUE);
     #elif SW_SERIAL_UART == 1
@@ -318,10 +318,10 @@ void setup()
 #endif
 
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure AZ stepper..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure AZ stepper...");
     mount.configureAZStepper(AZmotorPin1, AZmotorPin2, AZ_STEPPER_SPEED, AZ_STEPPER_ACCELERATION);
     #if AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure AZ driver..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure AZ driver...");
         #if SW_SERIAL_UART == 0
     mount.configureAZdriver(&AZ_SERIAL_PORT, R_SENSE, AZ_DRIVER_ADDRESS, AZ_RMSCURRENT, AZ_STALL_VALUE);
         #elif SW_SERIAL_UART == 1
@@ -330,10 +330,10 @@ void setup()
     #endif
 #endif
 #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure Alt stepper..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure Alt stepper...");
     mount.configureALTStepper(ALTmotorPin1, ALTmotorPin2, ALT_STEPPER_SPEED, ALT_STEPPER_ACCELERATION);
     #if ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: Configure ALT driver..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure ALT driver...");
         #if SW_SERIAL_UART == 0
     mount.configureALTdriver(&ALT_SERIAL_PORT, R_SENSE, ALT_DRIVER_ADDRESS, ALT_RMSCURRENT, ALT_STALL_VALUE);
         #elif SW_SERIAL_UART == 1
@@ -343,11 +343,11 @@ void setup()
 #endif
 
 #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: setup(): Configure Focus stepper..."));
+    LOG(DEBUG_ANY, "[STEPPERS]: setup(): Configure Focus stepper...");
     mount.configureFocusStepper(FOCUSmotorPin1, FOCUSmotorPin2, FOCUS_STEPPER_SPEED, FOCUS_STEPPER_ACCELERATION);
     #if FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_ANY, F("[STEPPERS]: setup(): Configure Focus driver..."));
-    LOGV3(DEBUG_FOCUS, F("[FOCUS]: setup(): RSense %f, RMS Current %fmA"), R_SENSE, FOCUS_RMSCURRENT);
+    LOG(DEBUG_ANY, "[STEPPERS]: setup(): Configure Focus driver...");
+    LOG(DEBUG_FOCUS, "[FOCUS]: setup(): RSense %f, RMS Current %fmA", R_SENSE, FOCUS_RMSCURRENT);
         #if SW_SERIAL_UART == 0
     mount.configureFocusDriver(&FOCUS_SERIAL_PORT, R_SENSE, FOCUS_DRIVER_ADDRESS, FOCUS_RMSCURRENT, FOCUS_STALL_VALUE);
         #elif SW_SERIAL_UART == 1
@@ -357,7 +357,7 @@ void setup()
     #endif
 #endif
 
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Read Configuration..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Read Configuration...");
 
     // The mount uses EEPROM storage locations 0-10 that it reads during construction
     // The LCD uses EEPROM storage location 11
@@ -366,8 +366,8 @@ void setup()
     // Read other persisted values and set in mount
     DayTime haTime = EEPROMStore::getHATime();
 
-    LOGV2(DEBUG_INFO, F("[SYSTEM]: SpeedCal: %s"), String(mount.getSpeedCalibration(), 5).c_str());
-    LOGV2(DEBUG_INFO, F("[SYSTEM]: TRKSpeed: %s"), String(mount.getSpeed(TRACKING), 5).c_str());
+    LOG(DEBUG_INFO, "[SYSTEM]: SpeedCal: %s", String(mount.getSpeedCalibration(), 5).c_str());
+    LOG(DEBUG_INFO, "[SYSTEM]: TRKSpeed: %s", String(mount.getSpeed(TRACKING), 5).c_str());
 
     mount.setHA(haTime);
 
@@ -390,30 +390,30 @@ void setup()
     // 2 kHz updates (higher frequency interferes with serial communications and complete messes up OATControl communications)
     if (!InterruptCallback::setInterval(0.5f, stepperControlTimerCallback, &mount))
     {
-        LOGV1(DEBUG_MOUNT, F("[SYSTEM]: CANNOT setup interrupt timer!"));
+        LOG(DEBUG_MOUNT, "[SYSTEM]: CANNOT setup interrupt timer!");
     }
 #endif
 
 #if UART_CONNECTION_TEST_TX == 1
     #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Moving RA axis using UART commands..."));
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: Moving RA axis using UART commands...");
     mount.testRA_UART_TX();
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Finished moving RA axis using UART commands."));
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: Finished moving RA axis using UART commands.");
     #endif
 
     #if DEC_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Moving DEC axis using UART commands..."));
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: Moving DEC axis using UART commands...");
     mount.testDEC_UART_TX();
-    LOGV1(DEBUG_STEPPERS, F("[STEPPERS]: Finished moving DEC axis using UART commands."));
+    LOG(DEBUG_STEPPERS, "[STEPPERS]: Finished moving DEC axis using UART commands.");
     #endif
 #endif
 
 #if TRACK_ON_BOOT == 1
     // Start the tracker.
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Start Tracking..."));
+    LOG(DEBUG_ANY, "[SYSTEM]: Start Tracking...");
     mount.startSlewing(TRACKING);
 #endif
 
     mount.bootComplete();
-    LOGV1(DEBUG_ANY, F("[SYSTEM]: Boot complete!"));
+    LOG(DEBUG_ANY, "[SYSTEM]: Boot complete!");
 }

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -38,7 +38,7 @@ int isInHomePosition        = NO;
 
 void startupIsCompleted()
 {
-    LOGV1(DEBUG_INFO, F("[STARTUP]: Completed!"));
+    LOG(DEBUG_INFO, "[STARTUP]: Completed!");
 
     startupState   = StartupCompleted;
     inStartup      = false;
@@ -72,7 +72,7 @@ bool processStartupKeys()
                         {
         #if USE_GYRO_LEVEL == 1
                             startupState = StartupSetRoll;
-                            LOGV1(DEBUG_INFO, F("[STARTUP]: State is set roll!"));
+                            LOG(DEBUG_INFO, "[STARTUP]: State is set roll!");
         #else
                             startupState = StartupSetHATime;
         #endif
@@ -102,7 +102,7 @@ bool processStartupKeys()
         case StartupSetRoll:
             {
                 inStartup = false;
-                LOGV1(DEBUG_INFO, F("[STARTUP]: Switching to CAL menu!"));
+                LOG(DEBUG_INFO, "[STARTUP]: Switching to CAL menu!");
 
                 lcdMenu.setCursor(0, 0);
                 lcdMenu.printMenu("Level front");
@@ -114,7 +114,7 @@ bool processStartupKeys()
 
         case StartupRollConfirmed:
             {
-                LOGV1(DEBUG_INFO, F("[STARTUP]: Roll confirmed!"));
+                LOG(DEBUG_INFO, "[STARTUP]: Roll confirmed!");
                 startupState = StartupSetHATime;
             }
             break;
@@ -123,7 +123,7 @@ bool processStartupKeys()
         case StartupSetHATime:
             {
                 inStartup = false;
-                LOGV1(DEBUG_INFO, F("[STARTUP]: Switching to HA menu!"));
+                LOG(DEBUG_INFO, "[STARTUP]: Switching to HA menu!");
 
         #if USE_GPS == 0
                 // Jump to the HA menu

--- a/src/c722_menuPOI.hpp
+++ b/src/c722_menuPOI.hpp
@@ -78,17 +78,17 @@ bool processPOIKeys()
                     else
                     {
                         PointOfInterest *poi = &pointOfInterest[currentPOI];
-                        LOGV5(DEBUG_INFO, F("[POI]: Selected %s.  RA: %d %d %d"), poi->pDisplay, poi->hourRA, poi->minRA, poi->secRA);
-                        LOGV5(DEBUG_INFO, F("[POI]: Selected %s. DEC: %d %d %d"), poi->pDisplay, poi->degreeDEC, poi->minDEC, poi->secDEC);
+                        LOG(DEBUG_INFO, "[POI]: Selected %s.  RA: %d %d %d", poi->pDisplay, poi->hourRA, poi->minRA, poi->secRA);
+                        LOG(DEBUG_INFO, "[POI]: Selected %s. DEC: %d %d %d", poi->pDisplay, poi->degreeDEC, poi->minDEC, poi->secDEC);
                         long targetSeconds = (60L * abs(poi->degreeDEC) + poi->minDEC) * 60L + poi->secDEC;
                         targetSeconds *= (poi->degreeDEC < 0 ? -1 : 1);
                         mount.targetRA().set(poi->hourRA, poi->minRA, poi->secRA);
                         mount.targetDEC() = Declination::FromSeconds(targetSeconds);
-                        LOGV3(DEBUG_INFO, F("[POI]: Target RA  is %s. %ls"), mount.targetRA().ToString(), targetSeconds);
-                        LOGV3(DEBUG_INFO,
-                              F("[POI]: mount target DEC is %s. %ls"),
-                              mount.targetDEC().ToString(),
-                              mount.targetDEC().getTotalSeconds());
+                        LOG(DEBUG_INFO, "[POI]: Target RA  is %s. %ls", mount.targetRA().ToString(), targetSeconds);
+                        LOG(DEBUG_INFO,
+                            "[POI]: mount target DEC is %s. %ls",
+                            mount.targetDEC().ToString(),
+                            mount.targetDEC().getTotalSeconds());
                         mount.startSlewingToTarget();
                     }
                 }

--- a/src/c72_menuHA_GPS.hpp
+++ b/src/c72_menuHA_GPS.hpp
@@ -36,21 +36,21 @@ bool gpsAqcuisitionComplete(int &indicator)
         {
     #if DEBUG_LEVEL & DEBUG_GPS
             gpsBuf[gpsBufPos++] = 0;
-            LOGV2(DEBUG_GPS, F("[GPS]: Sentence: [%s]"), gpsBuf);
+            LOG(DEBUG_GPS, "[GPS]: Sentence: [%s]", gpsBuf);
             gpsBufPos = 0;
     #endif
 
-            LOGV4(DEBUG_GPS,
-                  F("[GPS]: Encoded. %l sats, Location is%svalid, age is %lms"),
-                  gps.satellites.value(),
-                  (gps.location.isValid() ? " " : " NOT "),
-                  gps.location.age());
+            LOG(DEBUG_GPS,
+                "[GPS]: Encoded. %l sats, Location is%svalid, age is %lms",
+                gps.satellites.value(),
+                (gps.location.isValid() ? " " : " NOT "),
+                gps.location.age());
             // Make sure we got a fix in the last 30 seconds
             if ((gps.location.lng() != 0) && (gps.location.age() < 30000UL))
             {
-                LOGV2(DEBUG_INFO, F("[GPS]: Sync'd GPS location. Age is %d secs"), gps.location.age() / 1000);
-                LOGV3(DEBUG_INFO, F("[GPS]: Location: %f  %f"), gps.location.lat(), gps.location.lng());
-                LOGV4(DEBUG_INFO, F("[GPS]: UTC time is %dh%dm%ds"), gps.time.hour(), gps.time.minute(), gps.time.second());
+                LOG(DEBUG_INFO, "[GPS]: Sync'd GPS location. Age is %d secs", gps.location.age() / 1000);
+                LOG(DEBUG_INFO, "[GPS]: Location: %f  %f", gps.location.lat(), gps.location.lng());
+                LOG(DEBUG_INFO, "[GPS]: UTC time is %dh%dm%ds", gps.time.hour(), gps.time.minute(), gps.time.second());
                 lcdMenu.printMenu("GPS sync'd....");
 
                 DayTime utcNow = DayTime(gps.time.hour(), gps.time.minute(), gps.time.second());
@@ -92,13 +92,13 @@ bool processHAKeys()
     {
         if (gpsAqcuisitionComplete(indicator))
         {
-            LOGV1(DEBUG_INFO, F("[HA]: GPS acquired"));
+            LOG(DEBUG_INFO, "[HA]: GPS acquired");
             GPS_SERIAL_PORT.end();
             haState = SHOWING_HA_SYNC;
         #if SUPPORT_GUIDED_STARTUP == 1
             if (startupState == StartupWaitForHACompletion)
             {
-                LOGV1(DEBUG_INFO, F("[HA]: We were in startup, so confirm HA"));
+                LOG(DEBUG_INFO, "[HA]: We were in startup, so confirm HA");
                 startupState = StartupHAConfirmed;
                 inStartup    = true;
             }
@@ -109,7 +109,7 @@ bool processHAKeys()
     if (lcdButtons.keyChanged(&key))
     {
         waitForRelease = true;
-        LOGV3(DEBUG_INFO, F("[HA]: Key %d was pressed in state %d"), key, haState);
+        LOG(DEBUG_INFO, "[HA]: Key %d was pressed in state %d", key, haState);
         if (haState == SHOWING_HA_SYNC)
         {
             if (key == btnSELECT)
@@ -176,24 +176,24 @@ bool processHAKeys()
 
         if (key == btnRIGHT)
         {
-            LOGV1(DEBUG_INFO, F("[HA]: Right Key was pressed"));
+            LOG(DEBUG_INFO, "[HA]: Right Key was pressed");
             if (haState == STARTING_GPS)
             {
-                LOGV1(DEBUG_INFO, F("[HA]: In GPS Start mode, switching to manual"));
+                LOG(DEBUG_INFO, "[HA]: In GPS Start mode, switching to manual");
                 GPS_SERIAL_PORT.end();
                 haState = SHOWING_HA_SYNC;
             }
         #if SUPPORT_GUIDED_STARTUP == 1
             else if (startupState == StartupWaitForHACompletion)
             {
-                LOGV1(DEBUG_INFO, F("[HA]: In Startup, not in GPS Start mode, leaving"));
+                LOG(DEBUG_INFO, "[HA]: In Startup, not in GPS Start mode, leaving");
                 startupState = StartupHAConfirmed;
                 inStartup    = true;
             }
         #endif
             else
             {
-                LOGV1(DEBUG_INFO, F("[HA]: leaving HA"));
+                LOG(DEBUG_INFO, "[HA]: leaving HA");
                 lcdMenu.setNextActive();
             }
         }

--- a/src/c75_menuCTRL.hpp
+++ b/src/c75_menuCTRL.hpp
@@ -86,7 +86,7 @@ void processManualSlew(lcdButton_t key)
     const bool directionInTable = directionLookup.tryGet(key, &slewDirection);
     if (!directionInTable)
     {
-        LOGV2(DEBUG_MOUNT, F("[SYSTEM]: Unknown LCD button value: %i"), key);
+        LOG(DEBUG_MOUNT, "[SYSTEM]: Unknown LCD button value: %i", key);
         return;
     }
 
@@ -151,12 +151,12 @@ bool processControlKeys()
                     if (setZeroPoint)
                     {
                         // Leaving Control Menu, so set stepper motor positions to zero.
-                        LOGV1(DEBUG_GENERAL, F("[CTRL]: Calling setHome(true)!"));
+                        LOG(DEBUG_GENERAL, "[CTRL]: Calling setHome(true)!");
                         mount.setHome(true);
-                        LOGV3(DEBUG_GENERAL,
-                              F("[CTRL]: setHome(true) returned: RA Current %s, Target: %f"),
-                              mount.RAString(CURRENT_STRING | COMPACT_STRING).c_str(),
-                              mount.RAString(TARGET_STRING | COMPACT_STRING).c_str());
+                        LOG(DEBUG_GENERAL,
+                            "[CTRL]: setHome(true) returned: RA Current %s, Target: %f",
+                            mount.RAString(CURRENT_STRING | COMPACT_STRING).c_str(),
+                            mount.RAString(TARGET_STRING | COMPACT_STRING).c_str());
                         mount.startSlewing(TRACKING);
                     }
 

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -223,14 +223,14 @@ bool processCalibrationKeys()
         #if USE_GYRO_LEVEL == 1
     if (!gyroStarted)
     {
-        LOGV1(DEBUG_INFO, F("[CAL]: Starting Gyro!"));
+        LOG(DEBUG_INFO, "[CAL]: Starting Gyro!");
         Gyro::startup();
         gyroStarted = true;
     }
 
     if ((startupState == StartupWaitForRollCompletion) && (calState != ROLL_OFFSET_CALIBRATION))
     {
-        LOGV1(DEBUG_INFO, F("[CAL]: In Startup, so going to Roll confirm!"));
+        LOG(DEBUG_INFO, "[CAL]: In Startup, so going to Roll confirm!");
         calState = ROLL_OFFSET_CALIBRATION;
     }
         #endif
@@ -310,7 +310,7 @@ bool processCalibrationKeys()
             lcdMenu.getBacklightBrightnessRange(&minBrightness, &maxBrightness);
             Brightness = clamp(Brightness, minBrightness, maxBrightness);
             lcdMenu.setBacklightBrightness(Brightness, false);
-            LOGV2(DEBUG_INFO, F("[CAL]: Brightness set %i"), lcdMenu.getBacklightBrightness());
+            LOG(DEBUG_INFO, "[CAL]: Brightness set %i", lcdMenu.getBacklightBrightness());
         }
     }
     else if (calState == POLAR_CALIBRATION_WAIT_HOME)
@@ -540,7 +540,7 @@ bool processCalibrationKeys()
                     {
                         if (startupState == StartupWaitForRollCompletion)
                         {
-                            LOGV1(DEBUG_INFO, F("[CAL]: Confirmed roll. Going back to Startup, Roll confirmed!"));
+                            LOG(DEBUG_INFO, "[CAL]: Confirmed roll. Going back to Startup, Roll confirmed!");
                             gotoNextMenu();  // Turns of Gyro
                             inStartup    = true;
                             startupState = StartupRollConfirmed;
@@ -579,13 +579,13 @@ bool processCalibrationKeys()
                         auto angles = Gyro::getCurrentAngles();
                         if (setRollZeroPoint)
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Confirmed Roll offset is %f"), angles.rollAngle);
+                            LOG(DEBUG_GYRO, "[CAL]: Confirmed Roll offset is %f", angles.rollAngle);
                             mount.setRollCalibrationAngle(angles.rollAngle);
-                            LOGV2(DEBUG_GYRO, F("[CAL]: New Roll offset is %f"), mount.getRollCalibrationAngle());
+                            LOG(DEBUG_GYRO, "[CAL]: New Roll offset is %f", mount.getRollCalibrationAngle());
                         }
                         else
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Did not confirm, Roll offset was %f"), angles.rollAngle);
+                            LOG(DEBUG_GYRO, "[CAL]: Did not confirm, Roll offset was %f", angles.rollAngle);
                         }
                         calState       = HIGHLIGHT_ROLL_LEVEL;
                         okToUpdateMenu = true;
@@ -625,12 +625,12 @@ bool processCalibrationKeys()
                         auto angles = Gyro::getCurrentAngles();
                         if (setPitchZeroPoint)
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Confirmed Pitch offset is %f"), angles.pitchAngle);
+                            LOG(DEBUG_GYRO, "[CAL]: Confirmed Pitch offset is %f", angles.pitchAngle);
                             mount.setPitchCalibrationAngle(angles.pitchAngle);
                         }
                         else
                         {
-                            LOGV2(DEBUG_GYRO, F("[CAL]: Did not confirm, Pitch offset was %f"), angles.pitchAngle);
+                            LOG(DEBUG_GYRO, "[CAL]: Did not confirm, Pitch offset was %f", angles.pitchAngle);
                         }
                         calState       = HIGHLIGHT_PITCH_LEVEL;
                         okToUpdateMenu = true;
@@ -649,7 +649,7 @@ bool processCalibrationKeys()
                     // UP and DOWN are handled above
                     if (key == btnSELECT)
                     {
-                        LOGV2(DEBUG_GENERAL, F("[CAL]: Set brightness to %d"), Brightness);
+                        LOG(DEBUG_GENERAL, "[CAL]: Set brightness to %d", Brightness);
                         lcdMenu.setBacklightBrightness(Brightness);
                         lcdMenu.printMenu("Level stored.");
                         mount.delay(500);

--- a/src/f_serial.hpp
+++ b/src/f_serial.hpp
@@ -42,7 +42,7 @@ void processSerialData()
         {
             if (buffer[0] == 0x06)
             {
-                LOGV1(DEBUG_SERIAL, F("[SERIAL]: Received: ACK request, replying 1"));
+                LOG(DEBUG_SERIAL, "[SERIAL]: Received: ACK request, replying 1");
                 // When not debugging, print the result to the serial port .
                 // When debugging, only print the result to Serial if we're on seperate ports.
     #if (DEBUG_LEVEL == DEBUG_NONE) || (DEBUG_SEPARATE_SERIAL == 1)
@@ -52,12 +52,12 @@ void processSerialData()
             else
             {
                 String inCmd = String(buffer[0]) + Serial.readStringUntil('#');
-                LOGV3(DEBUG_SERIAL, F("[SERIAL]: ReceivedCommand(%d chars): [%s]"), inCmd.length(), inCmd.c_str());
+                LOG(DEBUG_SERIAL, "[SERIAL]: ReceivedCommand(%d chars): [%s]", inCmd.length(), inCmd.c_str());
 
                 String retVal = MeadeCommandProcessor::instance()->processCommand(inCmd);
                 if (retVal != "")
                 {
-                    LOGV2(DEBUG_SERIAL, F("[SERIAL]: RepliedWith:  [%s]"), retVal.c_str());
+                    LOG(DEBUG_SERIAL, "[SERIAL]: RepliedWith:  [%s]", retVal.c_str());
                     // When not debugging, print the result to the serial port .
                     // When debugging, only print the result to Serial if we're on seperate ports.
     #if (DEBUG_LEVEL == DEBUG_NONE) || (DEBUG_SEPARATE_SERIAL == 1)
@@ -66,7 +66,7 @@ void processSerialData()
                 }
                 else
                 {
-                    LOGV1(DEBUG_SERIAL, F("[SERIAL]: NoReply"));
+                    LOG(DEBUG_SERIAL, "[SERIAL]: NoReply");
                 }
             }
         }


### PR DESCRIPTION
Taking over the torch from #170

Breakdown of the regex used for the replacement:
## Match portion
```regex
LOGV\d\((?<log_level>.*?),\s*(?:F?\(?(?<fmt_str>\".*?\")\)?|(?<fmt_tern>.*?\?.*?\s:\s*.*?))(?<extra_args>,.*?)??\);
```
* Where the important groups are:
    * `<log_level>` (`$1`), `<fmt_str>` (`$2`), `<fmt_tern>` (`$3`), `<extra_args>` (`$4`)
* Matches `F()` macros, but not in a group and thus are not carried over to the replacement
* Matches ternaries in the string format field, but doesn't replace them. I've fixed those in a manual update
## Replacement portion:
```regex
LOG($1, $2$3$4);
```
* Just uses the groups as described above

----

You can use the following website breakdown to get a deeper understanding of what is happening, as well as the test cases that I used:
* https://regex101.com/r/XMdaQa/1
* https://www.debuggex.com/r/JBylBw2bmj4Uoux4

You can verify the changes by:
```bash
git checkout 8a1741d5860^ # Check out 1 commit before mass replacement
 # Echo commit message to file, cutting out everything before the embedded bash script
git log --format=%B -n 1 8a1741d5860 |tail -n +4 > regex.sh
chmod +x regex.sh && ./regex.sh # Run the script
git diff 8a1741d5860 -- # Show that the current changes are identical to the commit
```

I also added `DEBUG_LEVEL` to `matrix_build.py` to ensure that these kind of changes will be able to be compiled