### PR TITLE
actually allow for override of SUPPORT_POINTS_OF_INTEREST

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.10.8 - Updates**
+- Actually allow for override of SUPPORT_POINTS_OF_INTEREST.
+
 **V1.10.2 - Updates**
 - Revise default MKS LCD pins to match ribbon cable LCD assembly.
 

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -438,9 +438,11 @@
 // SUPPORT_POINTS_OF_INTEREST to 0
 //
 //
-// Set this to 1 to support full GO menu.
-// If this is set to 0 you still have a GO menu that has Home and Park.
-    #define SUPPORT_POINTS_OF_INTEREST 1
+    #ifndef SUPPORT_POINTS_OF_INTEREST
+        // Set this to 1 to support full GO menu.
+        // If this is set to 0 you still have a GO menu that has Home and Park.
+        #define SUPPORT_POINTS_OF_INTEREST 1
+    #endif
 
     // Set this to 1 to support Guided Startup
     #ifndef SUPPORT_GUIDED_STARTUP

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.10.2"
+#define VERSION "V1.10.8"


### PR DESCRIPTION
You can't override SUPPORT_POINTS_OF_INTEREST in your Configuration_local.hpp as you'd get compilation errors.