### PR TITLE
Set Home Revision

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.10.12 - Updates**
+- Remove enabling tracking when home is set.
+
 **V1.10.11 - Updates**
 - Revise default microstep settings when using UART
 - Revise default DEC guide pulse settings to match RA

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.10.11"
+#define VERSION "V1.10.12"

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1286,7 +1286,6 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
         {
             // Set home point
             _mount->setHome(false);
-            _mount->startSlewing(TRACKING);
         }
         else
         {


### PR DESCRIPTION
Removes enabling tracking as part of the "set home" Meade command.

Currently if TRACK_ON_BOOT is disabled, the DEC offset feature of OATcontrol triggers tracking once the home position is set, which is counter to the intention of disabling TRACK_ON_BOOT.