### PR TITLE
Protocol INDI corrections

### DIFF
--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -22,6 +22,12 @@
     #define BUFFER_LOGS false
 #endif
 
+// define USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL 1 in the local configuration if you want to use protocol compatible with old ASCOM driver.
+// Currently this will revert Meade longitude and UTC offset parsing to older functionality
+#ifndef USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL
+    #define USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL 0
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                            ////////
 // MOTOR & DRIVER SETTINGS    ////////

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -27,6 +27,9 @@
 #ifndef USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL
     #define USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL 0
 #endif
+#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 0
+    #pragma message("Note: INDI-compatible protocol format used, firmware will not function correctly with old ASCOM driver!")
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                            ////////

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -76,16 +76,11 @@ const char *Longitude::ToString() const
 
 const char *Longitude::formatString(char *targetBuffer, const char *format, long *) const
 {
+#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 1
     long secs = totalSeconds;
 
-#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 1
     // from indilib driver:  Meade classic handset defines longitude as 0 to 360 WESTWARD (https://github.com/indilib/indi/blob/1b2f462b9c9b0f75629b635d77dc626b9d4b74a3/drivers/telescope/lx200driver.cpp#L1019)
     secs = 180L * 3600L - secs;
-#else
-    // from indilib driver: Meade API expresses East Longitudes as negative, West Longitudes as positive. (https://github.com/indilib/indi/blob/8beeeb9c5809063929804b5066f5b8ba6696bcd0/drivers/telescope/lx200driver.cpp#L1180)
-    // Source: https://www.meade.com/support/LX200CommandSet.pdf from 2002 at :Gg#
-    secs = -secs;
-#endif
 
     long degs = secs / 3600;
     secs      = secs - degs * 3600;
@@ -93,4 +88,17 @@ const char *Longitude::formatString(char *targetBuffer, const char *format, long
     secs      = secs - mins * 60;
 
     return formatStringImpl(targetBuffer, format, '\0', degs, mins, secs);
+#else
+    // from indilib driver: Meade API expresses East Longitudes as negative, West Longitudes as positive. (https://github.com/indilib/indi/blob/8beeeb9c5809063929804b5066f5b8ba6696bcd0/drivers/telescope/lx200driver.cpp#L1180)
+    // Source: https://www.meade.com/support/LX200CommandSet.pdf from 2002 at :Gg#
+    long secs = -totalSeconds;
+    char sgn  = secs < 0 ? '-' : '+';
+    secs      = labs(secs);
+    long degs = secs / 3600;
+    secs      = secs - degs * 3600;
+    long mins = secs / 60;
+    secs      = secs - mins * 60;
+
+    return formatStringImpl(targetBuffer, format, sgn, degs, mins, secs);
+#endif
 }

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -40,13 +40,12 @@ Longitude Longitude::ParseFromMeade(String const &s)
     // Use the DayTime code to parse it.
     DayTime dt = DayTime::ParseFromMeade(s);
 
-#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL
+#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 1
     // from indilib driver:  Meade classic handset defines longitude as 0 to 360 WESTWARD (https://github.com/indilib/indi/blob/1b2f462b9c9b0f75629b635d77dc626b9d4b74a3/drivers/telescope/lx200driver.cpp#L1019)
     result.totalSeconds = 180L * 3600L - dt.getTotalSeconds();
 #else
     // from indilib driver: Meade API expresses East Longitudes as negative, West Longitudes as positive. (https://github.com/indilib/indi/blob/8beeeb9c5809063929804b5066f5b8ba6696bcd0/drivers/telescope/lx200driver.cpp#L1180)
     // Source: https://www.meade.com/support/LX200CommandSet.pdf from 2002 at :Gg#
-    #pragma message("Note: INDI-compatible longitude format used, firmware will not function correctly with old ASCOM driver!")
     result.totalSeconds = -dt.getTotalSeconds();
 #endif
 
@@ -79,13 +78,12 @@ const char *Longitude::formatString(char *targetBuffer, const char *format, long
 {
     long secs = totalSeconds;
 
-#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL
+#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 1
     // from indilib driver:  Meade classic handset defines longitude as 0 to 360 WESTWARD (https://github.com/indilib/indi/blob/1b2f462b9c9b0f75629b635d77dc626b9d4b74a3/drivers/telescope/lx200driver.cpp#L1019)
     secs = 180L * 3600L - secs;
 #else
     // from indilib driver: Meade API expresses East Longitudes as negative, West Longitudes as positive. (https://github.com/indilib/indi/blob/8beeeb9c5809063929804b5066f5b8ba6696bcd0/drivers/telescope/lx200driver.cpp#L1180)
     // Source: https://www.meade.com/support/LX200CommandSet.pdf from 2002 at :Gg#
-    #pragma message("Note: INDI-compatible longitude format used, firmware will not function correctly with old ASCOM driver!")
     secs = -secs;
 #endif
 

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -159,10 +159,10 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        "DDD*MM#"
 //      Parameters:
-//        "DDD" is the longitude in degrees
-//        "MM" the minutes
+//        "DDD" is degrees
+//        "MM" is minutes
 //      Remarks:
-//        Longitudes are from 0 to 360 going WEST. so 179W is 359 and 179E is 1.
+//        East Longitudes as negative, West Longitudes as positive. (Note that this is the opposite of cartography where East is positive)
 //
 // :Gc#
 //      Description:
@@ -339,10 +339,10 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //        "1" if successfully set
 //        "0" otherwise
 //      Parameters:
-//        "DDD" the nmber of degrees (0 to 360)
+//        "DDD" is degrees
 //        "MM" is minutes
 //      Remarks:
-//        Longitudes are from 0 to 360 going WEST. so 179W is 359 and 179E is 1.
+//        East Longitudes as negative, West Longitudes as positive. (Note that this is the opposite of cartography where East is positive)
 //
 // :SGsHH#
 //      Description:

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1141,12 +1141,9 @@ String MeadeCommandProcessor::handleMeadeGetInfo(String inCmd)
             {
                 int offset = _mount->getLocalUtcOffset();
 
-#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL
-                // Use protocol compatible with old ASCOM driver
-#else
-    //from indilib driver:  Meade defines UTC Offset as the offset ADDED to local time to yield UTC, which is the opposite of the standard definition of UTC offset!
-    // https://github.com/indilib/indi/blob/d6e9d74a82bbf6914709bab7063bb9bd68f45687/drivers/telescope/lx200gps.cpp#L372
-    #pragma message("Note: INDI-compatible UTC offset format used, firmware will not function correctly with old ASCOM driver!")
+#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 0
+                //from indilib driver:  Meade defines UTC Offset as the offset ADDED to local time to yield UTC, which is the opposite of the standard definition of UTC offset!
+                // https://github.com/indilib/indi/blob/d6e9d74a82bbf6914709bab7063bb9bd68f45687/drivers/telescope/lx200gps.cpp#L372
                 offset = -offset;
 #endif
 
@@ -1350,12 +1347,9 @@ String MeadeCommandProcessor::handleMeadeSetInfo(String inCmd)
     {
         int offset = inCmd.substring(1, 4).toInt();
 
-#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL
-        // Use protocol compatible with old ASCOM driver
-#else
-    //from indilib driver:  Meade defines UTC Offset as the offset ADDED to local time to yield UTC, which is the opposite of the standard definition of UTC offset!
-    // https://github.com/indilib/indi/blob/d6e9d74a82bbf6914709bab7063bb9bd68f45687/drivers/telescope/lx200gps.cpp#L372
-    #pragma message("Note: INDI-compatible UTC offset format used, firmware will not function correctly with old ASCOM driver!")
+#if USE_OLD_ASCOM_DRIVER_COMPATIBLE_PROTOCOL == 0
+        //from indilib driver:  Meade defines UTC Offset as the offset ADDED to local time to yield UTC, which is the opposite of the standard definition of UTC offset!
+        // https://github.com/indilib/indi/blob/d6e9d74a82bbf6914709bab7063bb9bd68f45687/drivers/telescope/lx200gps.cpp#L372
         offset = -offset;
 #endif
 


### PR DESCRIPTION
(Updated)
A new take on previous PR: #168

Preface:
* I am not an experienced c/c++ programmer.
* This PR is open to any and all suggestions.

From the sources I have found, the current implementation of UTC Offset protocol is inverted compared to Meade protocol.
This is changed in the first commit.

From the Meade 2002 protocol documents and sources the 0-360 westward format does not appear to be used. It uses a format that is basically the opposite of cartography format.
This is changed in the second commit.

Right now the changes are written as a default  general fix, with an optional fallback to be compatible with older(current) ASCOM driver. This logic could be inverted to be backwards compatible by default instead?  

Questions:
What route does the maintainers want to go with regards of these potential changes to the protocol?
My understanding is that you have tried to implement a protocol that follows the LX200 and that this protocol is implemented here in the firmware as well as the ASCOM driver.
So you do not strictly _have_ to follow the LX200 protocol if you choose not to, but making these changes seems to be a step towards following the LX200 more closely.
However, making these changes would also require changing the ASCOM driver and OATControl in https://github.com/OpenAstroTech/OpenAstroTracker-Desktop. 