### PR TITLE
Fixes to Meade Longitude and UC handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+**V1.11.5 - Updates**
+- Corrected Longitude parsing to account for sign
+- Corrected Longitude output to provide sign
+- Corrected inverted UTC offset
+- Corrected handshake response to 0x06 to be P for Polar mode
+
 **V1.11.4 - Updates**
 - Allow disabling Points Of Interest in LCD menu
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.11.4"
+#define VERSION "V1.11.5"

--- a/src/DayTime.cpp
+++ b/src/DayTime.cpp
@@ -267,13 +267,14 @@ const char *DayTime::formatStringImpl(char *targetBuffer, const char *format, ch
         i++;
     }
 
-    if (degs >= 100)
+    long absdegs = labs(degs);
+    if (absdegs >= 100)
     {
-        achDegs[i++] = '0' + min(9L, (degs / 100));
-        degs         = degs % 100;
+        achDegs[i++] = '0' + min(9L, (absdegs / 100));
+        absdegs      = absdegs % 100;
     }
 
-    printTwoDigits(achDegs + i, degs);
+    printTwoDigits(achDegs + i, absdegs);
     printTwoDigits(achMins, mins);
     printTwoDigits(achSecs, secs);
 

--- a/src/DayTime.cpp
+++ b/src/DayTime.cpp
@@ -294,6 +294,11 @@ const char *DayTime::formatStringImpl(char *targetBuffer, const char *format, ch
                     {
                         switch (macro)
                         {
+                            case '+':
+                                {
+                                    *p++ = (degs < 0 ? '-' : '+');
+                                }
+                                break;
                             case 'd':
                                 {
                                     strcpy(p, achDegs);

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -121,9 +121,9 @@ void EEPROMStore::displayContents()
     uint16_t marker = readUint16(MAGIC_MARKER_AND_FLAGS_ADDR);
     LOG(DEBUG_EEPROM, "[EEPROM]: Magic Marker: %x", marker);
 
-    LOG(DEBUG_INFO, "[EEPROM]: Values? %s", ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? F("Yes") : F("No"));
-    LOG(DEBUG_INFO, "[EEPROM]: Extended values? %s", ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? F("Yes") : F("No"));
-    LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED)? %s", (EEPROMStore::isPresent(EXTENDED_FLAG) ? F("Yes") : F("No")));
+    LOG(DEBUG_INFO, "[EEPROM]: Values? %s", ((marker & MAGIC_MARKER_MASK) == MAGIC_MARKER_VALUE) ? "Yes" : "No");
+    LOG(DEBUG_INFO, "[EEPROM]: Extended values? %s", ((marker & EXTENDED_FLAG) == EXTENDED_FLAG) ? "Yes" : "No");
+    LOG(DEBUG_INFO, "[EEPROM]: IsPresent(EXTENDED)? %s", (EEPROMStore::isPresent(EXTENDED_FLAG) ? "Yes" : "No"));
     LOG(DEBUG_INFO, "[EEPROM]: Stored HATime: %s", getHATime().ToString());
     LOG(DEBUG_INFO, "[EEPROM]: Stored UTC Offset: %d", getUtcOffset());
     LOG(DEBUG_INFO, "[EEPROM]: Stored Brightness: %d", getBrightness());

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -105,7 +105,7 @@ const char *Longitude::formatStringForMeade(char *targetBuffer) const
     // Since internal storage is actual longitude, Meade is negated
     if (totalSeconds > 0)
     {
-        // Since we already inverted it when it was negative (by using ABS a few 
+        // Since we already inverted it when it was negative (by using ABS a few
         // lines above here), we only invert it if it is positive.
         degs = -degs;
     }

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -40,8 +40,16 @@ Longitude Longitude::ParseFromMeade(String const &s)
     // Use the DayTime code to parse it.
     DayTime dt = DayTime::ParseFromMeade(s);
 
-    //from indilib driver:  Meade defines longitude as 0 to 360 WESTWARD (https://github.com/indilib/indi/blob/1b2f462b9c9b0f75629b635d77dc626b9d4b74a3/drivers/telescope/lx200driver.cpp#L1019)
-    result.totalSeconds = 180L * 3600L - dt.getTotalSeconds();
+    if ((s[0] == '-') || (s[0] == '+'))
+    {
+        // According to spec 2010.10, if a sign is present it is straight up longitude with east as negative.
+        result.totalSeconds = -dt.getTotalSeconds();
+    }
+    else
+    {
+        //from indilib driver:  Meade defines longitude as 0 to 360 WESTWARD (https://github.com/indilib/indi/blob/1b2f462b9c9b0f75629b635d77dc626b9d4b74a3/drivers/telescope/lx200driver.cpp#L1019)
+        result.totalSeconds = 180L * 3600L - dt.getTotalSeconds();
+    }
     result.checkHours();
 
     LOG(DEBUG_GENERAL, "[LONGITUDE]: Parse(%s) -> %s = %ls", s.c_str(), result.ToString(), result.getTotalSeconds());

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -90,3 +90,27 @@ const char *Longitude::formatString(char *targetBuffer, const char *format, long
 
     return formatStringImpl(targetBuffer, format, '\0', degs, mins, secs);
 }
+
+const char *Longitude::formatStringForMeade(char *targetBuffer) const
+{
+    LOG(DEBUG_MEADE, "[LONGITUDE] Format %l for Meade", totalSeconds);
+    long secs = labs(totalSeconds);
+
+    long degs = secs / 3600;
+    secs      = secs - degs * 3600;
+    long mins = secs / 60;
+    secs      = secs - mins * 60;
+    LOG(DEBUG_MEADE, "[LONGITUDE] Degs is %l, Mins is %l", degs, mins);
+
+    // Since internal storage is actual longitude, Meade is negated
+    if (totalSeconds > 0)
+    {
+        // Since we already inverted it when it was negative (by using ABS a few 
+        // lines above here), we only invert it if it is positive.
+        degs = -degs;
+    }
+
+    LOG(DEBUG_MEADE, "[LONGITUDE] Inverted Degs, now %l, Mins is %l", degs, mins);
+
+    return formatStringImpl(targetBuffer, "{+}{d}*{m}", '\0', degs, mins, secs);
+}

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -77,12 +77,16 @@ const char *Longitude::ToString() const
 
 const char *Longitude::formatString(char *targetBuffer, const char *format, long *) const
 {
-    long secs = totalSeconds;
+    long secs = labs(totalSeconds);
 
     long degs = secs / 3600;
     secs      = secs - degs * 3600;
     long mins = secs / 60;
     secs      = secs - mins * 60;
+    if (totalSeconds < 0)
+    {
+        degs = -degs;
+    }
 
     return formatStringImpl(targetBuffer, format, '\0', degs, mins, secs);
 }

--- a/src/Longitude.cpp
+++ b/src/Longitude.cpp
@@ -79,9 +79,6 @@ const char *Longitude::formatString(char *targetBuffer, const char *format, long
 {
     long secs = totalSeconds;
 
-    // Map to 0..360 westwards
-    secs = 180L * 3600L - secs;
-
     long degs = secs / 3600;
     secs      = secs - degs * 3600;
     long mins = secs / 60;

--- a/src/Longitude.hpp
+++ b/src/Longitude.hpp
@@ -14,6 +14,7 @@ class Longitude : public DayTime
     Longitude(float inDegrees);
 
     virtual const char *formatString(char *targetBuffer, const char *format, long *pSeconds = nullptr) const;
+    const char *formatStringForMeade(char *targetBuffer) const;
     virtual const char *ToString() const;
 
     static Longitude ParseFromMeade(String const &s);

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -380,7 +380,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        "1Updating Planetary Data#                              #"
 //      Parameters:
-//        "HHMM" is the month
+//        "MM" is the month
 //        "DD" is the day
 //        "YY" is the year since 2000
 //

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1135,8 +1135,8 @@ String MeadeCommandProcessor::handleMeadeGetInfo(String inCmd)
             }
         case 'g':  // :Gg
             {
-                _mount->longitude().formatString(achBuffer, "{+}{d}*{m}#");
-                return String(achBuffer);
+                _mount->longitude().formatStringForMeade(achBuffer);
+                return String(achBuffer) + "#";
             }
         case 'c':  // :Gc
             {

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -182,8 +182,8 @@ void WifiControl::tcpLoop()
             {
                 client.read();
                 LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
-                client.write("1");
-                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> 1");
+                client.write("P");
+                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> P (polar mode)");
             }
             else
             {

--- a/src/f_serial.hpp
+++ b/src/f_serial.hpp
@@ -42,11 +42,11 @@ void processSerialData()
         {
             if (buffer[0] == 0x06)
             {
-                LOG(DEBUG_SERIAL, "[SERIAL]: Received: ACK request, replying 1");
+                LOG(DEBUG_SERIAL, "[SERIAL]: Received: ACK request, replying P");
                 // When not debugging, print the result to the serial port .
                 // When debugging, only print the result to Serial if we're on seperate ports.
     #if (DEBUG_LEVEL == DEBUG_NONE) || (DEBUG_SEPARATE_SERIAL == 1)
-                Serial.print('1');
+                Serial.print('P');
     #endif
             }
             else


### PR DESCRIPTION
- Corrected Longitude parsing to account for sign
- Corrected Longitude output to provide sign
- Corrected inverted UTC offset
- Corrected handshake response to 0x06 to be P for Polar mode
- EEPROM debug code caused crash due to using F() macro in args
- Added specific Longitude output function for Meade
- Fixed comment on Meade :SC command
