### PR TITLE
Change default pin for RA_HOMING_SENSOR_PIN to pin 3 on mksgenlv21

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.11.6 - Updates**
+- Change RA Auto Home addon default pin to pin D11 for MKS Gen L v2.1
+
 **V1.11.5 - Updates**
 - Corrected Longitude parsing to account for sign
 - Corrected Longitude output to provide sign

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.11.5"
+#define VERSION "V1.11.6"

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -147,7 +147,7 @@
 
 // RA Homing pin for Hall sensor
 #ifndef RA_HOMING_SENSOR_PIN
-    #define RA_HOMING_SENSOR_PIN 53
+    #define RA_HOMING_SENSOR_PIN 11  // Just below the EXP2 Port
 #endif
 
 //GPS pin configuration


### PR DESCRIPTION
I am proposing to change the default pin for hall sensor from 53 to 3.

The board is designed to use pin 3 for homing the X-axis motor (RA-axis on OAT). And when using a hall sensor the 3-pin JST connector work perfectly in this port without splitting the cable to connect signal, voltage and ground in different places. It is a clean install.

**Premise:**
This change is based on the premise that the most common use-case would be to only use one method of homing per axis (at a time).

My assumption is that you would reasonably only use either a hall sensor for very exact homing, an endstop, or the TMC sensorless homing (If it is implemented).

On mksgenlv21 a jumper controls if the diag-pin is connected to pin 3 or not. Jumper missing, free to use for hall sensor. Jumper in place, connected to X-diag in use for potential sensorless homing with TMC stepper.

**Other:**
This wiki page would need to be updated along with this change:
https://wiki.openastrotech.com/OpenAstroTracker/Addons/RAHallSensor