### PR TITLE
V1.11.14 - Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+**V1.11.14 - Updates**
+- Prevented firmware from hanging at boot if LCD is defined but not connected.
+- Fixed a (rare) bug that would throw off GoTo commands when a target coordinate had been set.
+
 **V1.11.13 - Updates**
 - Added end switch support for RA and DEC.
 - Guide pulses are only executed when tracking.

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.11.13"
+#define VERSION "V1.11.14"

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1035,9 +1035,10 @@ String Mount::getMountHardwareInfo()
     #if (USE_RA_END_SWITCH == 1)
     ret += F("_RA");
     #endif
-    #if || (USE_DEC_END_SWITCH == 1)
+    #if (USE_DEC_END_SWITCH == 1)
     ret += F("_DEC");
     #endif
+    ret += F(",");
 #else
     ret += F("NO_ENDSW,");
 #endif
@@ -3407,7 +3408,7 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
     switch (direction)
     {
         case RA_STEPS:
-            moveSteppersTo(_stepperRA->targetPosition() + steps, _stepperDEC->targetPosition());
+            moveSteppersTo(_stepperRA->currentPosition() + steps, _stepperDEC->currentPosition());
             _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_TO_TARGET;
             _totalRAMove = 1.0f * _stepperRA->distanceToGo();
             if ((_stepperRA->distanceToGo() != 0) || (_stepperDEC->distanceToGo() != 0))
@@ -3429,7 +3430,7 @@ void Mount::moveStepperBy(StepperAxis direction, long steps)
             }
             break;
         case DEC_STEPS:
-            moveSteppersTo(_stepperRA->targetPosition(), _stepperDEC->targetPosition() + steps);
+            moveSteppersTo(_stepperRA->currentPosition(), _stepperDEC->currentPosition() + steps);
             _mountStatus |= STATUS_SLEWING | STATUS_SLEWING_TO_TARGET;
             _totalDECMove = 1.0f * _stepperDEC->distanceToGo();
 

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -255,9 +255,8 @@ void setup()
         {
             LOG(DEBUG_INFO, "[SYSTEM]: Erasing configuration in EEPROM!");
             mount.clearConfiguration();
+            LOG(DEBUG_INFO, "[SYSTEM]: Button released, continuing");
         }
-
-        LOG(DEBUG_INFO, "[SYSTEM]: Button released, continuing");
     }
 
     // Create the LCD top-level menu items

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -232,18 +232,31 @@ void setup()
     delay(1000);  // Pause on splash screen
 
     // Check for EEPROM reset (Button down during boot)
+    long lcdCheckStart = millis();
     if (lcdButtons.currentState() == btnDOWN)
     {
-        LOG(DEBUG_INFO, "[SYSTEM]: Erasing configuration in EEPROM!");
-        mount.clearConfiguration();
         // Wait for button release
         lcdMenu.setCursor(13, 1);
         lcdMenu.printMenu("CLR");
-        LOG(DEBUG_INFO, "[SYSTEM]: Waiting for button release!");
+        LOG(DEBUG_INFO, "[SYSTEM]: DOWN pressed, waiting for button release!");
+        bool timedOut = false;
         while (lcdButtons.currentState() != btnNONE)
         {
             delay(10);
+            // Wait 3s maximum for button to be released.
+            if (millis() - lcdCheckStart > 3000)
+            {
+                LOG(DEBUG_INFO, "[SYSTEM]: Timedout waiting for button release. LCD not installed?");
+                timedOut = true;
+                break;
+            }
         }
+        if (!timedOut)
+        {
+            LOG(DEBUG_INFO, "[SYSTEM]: Erasing configuration in EEPROM!");
+            mount.clearConfiguration();
+        }
+
         LOG(DEBUG_INFO, "[SYSTEM]: Button released, continuing");
     }
 


### PR DESCRIPTION
- Prevented firmware from hanging at boot if LCD is defined but not connected.
- Fixed a (rare) bug that would throw off GoTo commands when a target coordinate had been set.