### PR TITLE
V1.12.3 - Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.12.3 - Updates**
+- Fixed a bug that incorrectly calculated minimum stepper frequency. This caused Tracking to never run.
+
 **V1.12.2 - Updates**
 - Fixed a bug that caused Focuser stepper to misbehave after booting.
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.2"
+#define VERSION "V1.12.3"

--- a/src/InterruptAccelStepper.h
+++ b/src/InterruptAccelStepper.h
@@ -11,7 +11,7 @@
 #define SIGN(x) ((x >= 0) ? 1 : -1)
 
 // minimal stepping frequency (steps/s) based on cpu frequency, timer counter overflow and max amount of overflows
-#define MIN_STEPS_PER_SEC (static_cast<float>(F_CPU) / (UINT16_MAX * UINT8_MAX))
+#define MIN_STEPS_PER_SEC (static_cast<float>(F_CPU) / (static_cast<long>(UINT16_MAX) * static_cast<long>(UINT8_MAX)))
 
 template <typename STEPPER> class InterruptAccelStepper
 {
@@ -68,6 +68,7 @@ template <typename STEPPER> class InterruptAccelStepper
 
         if (fabsf(speed) < MIN_STEPS_PER_SEC)
         {
+            LOG(DEBUG_STEPPERS, "[IAS-%d] setSpeed(%f) - speed is too low (%f). Stopping.", STEPPER::TIMER_ID, speed, MIN_STEPS_PER_SEC);
             STEPPER::stop();
         }
         else
@@ -113,7 +114,7 @@ template <typename STEPPER> class InterruptAccelStepper
 
     void runToPosition()
     {
-        LOG(DEBUG_STEPPERS, "[IAS-%d] runToPosition(%l)", STEPPER::TIMER_ID);
+        LOG(DEBUG_STEPPERS, "[IAS-%d] runToPosition(%l)", STEPPER::TIMER_ID, _target);
         while (isRunning())
         {
             yield();


### PR DESCRIPTION
- Fixed a bug that incorrectly calculated minimum stepper frequency. This caused Tracking to never run.