### PR TITLE
V1.12.5 - Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.12.5 - Updates**
+- Bound interrupt stepper library to version 0.0.1.
+
 **V1.12.4 - Updates**
 - Fixed a bug that incorrectly stopped the RA motor after issuing a DEC move.
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.4"
+#define VERSION "V1.12.5"

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,7 +92,7 @@ debug_build_flags =
 lib_deps = 
 	${common.lib_deps}
 	jdolinay/avr-debugger @ 1.2
-	https://github.com/andre-stefanov/avr-interrupt-stepper
+	https://github.com/andre-stefanov/avr-interrupt-stepper@0.0.1
 
 [env:mksgenlv21]
 extends = env:ramps


### PR DESCRIPTION
- Bound interrupt stepper library to version 0.0.1.