### PR TITLE
Fixed RAMPS not building with GPS enabled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.12.8 - Updates**
+- Fixed a GPS leading to compile error on RAMPS.
+
 **V1.12.7 - Updates**
 - Fixed a bug where southern hemisphere setting would not persist between session.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 **V1.12.8 - Updates**
-- Fixed a GPS leading to compile error on RAMPS.
+- Fixed compile error caused by GPS being enabled in RAMPS environment.
 
 **V1.12.7 - Updates**
 - Fixed a bug where southern hemisphere setting would not persist between session.

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -581,7 +581,7 @@
 
 // GPS
 #if USE_GPS == 1
-    #define GPS_BAUD_RATE   9600
+    #define GPS_BAUD_RATE 9600
 #endif
 
 ////////////////////////////

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -581,13 +581,7 @@
 
 // GPS
 #if USE_GPS == 1
-    #if defined(ESP32)
-        #define GPS_SERIAL_PORT Serial2  // TODO: Resolve potential conflict with RA_SERIAL_PORT & DEC_SERIAL_PORT
-        #define GPS_BAUD_RATE   9600
-    #elif defined(__AVR_ATmega2560__)
-        #define GPS_SERIAL_PORT Serial1
-        #define GPS_BAUD_RATE   9600
-    #endif
+    #define GPS_BAUD_RATE   9600
 #endif
 
 ////////////////////////////

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.7"
+#define VERSION "V1.12.8"


### PR DESCRIPTION
We define Serial ports for each board/environment in the pins files already. Configuration_adv.hpp tried to redefine it for RAMPS board by changing the value. This caused a compile error.