### PR TITLE
V1.12.10 Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.12.10 - Updates**
+- Fixed a problem where slewing to targets more than 90degrees from the pole (in either hemisphere) would result in a target mirrored around the 'equator'.
+
 **V1.12.9 - Updates**
 - Fixed integer size mismatch for RA and DEC speeds. This caused integer overflows when RA was configured for 256 step microstepping.
 - Added some logging at boot to show stepper variables.

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.9"
+#define VERSION "V1.12.10"

--- a/src/Declination.cpp
+++ b/src/Declination.cpp
@@ -106,8 +106,8 @@ Declination Declination::ParseFromMeade(String const &s)
     LOG(DEBUG_MEADE, "[DECLINATION]: Declination DayTime is %l secs", dt.getTotalSeconds());
 
     // ...and then correct for hemisphere
-    result.totalSeconds = inNorthernHemisphere ? (arcSecondsPerHemisphere / 2) - labs(dt.getTotalSeconds())
-                                               : -(arcSecondsPerHemisphere / 2) + labs(dt.getTotalSeconds());
+    result.totalSeconds = inNorthernHemisphere ? (arcSecondsPerHemisphere / 2) - dt.getTotalSeconds()
+                                               : -(arcSecondsPerHemisphere / 2) + dt.getTotalSeconds();
     LOG(DEBUG_MEADE, "[DECLINATION]: Adjust for hemisphere. %s -> %s (%l secs)", s.c_str(), result.ToString(), result.totalSeconds);
     return result;
 }

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -308,7 +308,7 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
     LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
     LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
-    
+
     mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, RA_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.


### PR DESCRIPTION
- Fixed a problem where slewing to targets more than 90degrees from the pole (in either hemisphere) would result in a target mirrored around the 'equator'.