### PR TITLE
Change MKS-GenL v1.0,v2.0,v2.1 default separate serial port from Serial3 to Serial2.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
-**V1.12.11 - Updates**
+**V1.12.12 - Updates**
+- Change MKS Gen L v1.0, v2.0, v2.1 default separate debug serial port from `Serial3` to `Serial2`.
+
+- **V1.12.11 - Updates**
 - Allowed the active state of the hall sensors for auto homing RA and DEC to be configured.
 
 **V1.12.10 - Updates**

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.11"
+#define VERSION "V1.12.12"

--- a/boards/AVR_MKS_GEN_L_V1/pins_MKS_GEN_L_V1.h
+++ b/boards/AVR_MKS_GEN_L_V1/pins_MKS_GEN_L_V1.h
@@ -1,5 +1,6 @@
 /**
  * @brief a pins configuration file for an MKS Gen L V2.1 OAT.
+ * https://github.com/makerbase-mks/MKS-GEN_L/blob/master/hardware/MKS%20Gen_L%20V1.0_008/MKS%20Gen_L%20V1.0_008%20PIN.pdf
  */
 
 #pragma once
@@ -141,7 +142,7 @@
 //Serial port for external debugging
 #if DEBUG_SEPARATE_SERIAL == 1
     #ifndef DEBUG_SERIAL_PORT
-        #define DEBUG_SERIAL_PORT Serial3  //D14 (Y-MIN) - TX3 and D15 (Y-MAX) - RX3
+        #define DEBUG_SERIAL_PORT Serial2  //D16 (LCD_RS) - TXD2 and D17 (LCD_EN) - RXD2
     #endif
 #else
     #ifndef DEBUG_SERIAL_PORT

--- a/boards/AVR_MKS_GEN_L_V2/pins_MKS_GEN_L_V2.h
+++ b/boards/AVR_MKS_GEN_L_V2/pins_MKS_GEN_L_V2.h
@@ -1,5 +1,6 @@
 /**
  * @brief a pins configuration file for an MKS Gen L V2.1 OAT.
+ * https://github.com/makerbase-mks/MKS-GEN_L/blob/master/hardware/MKS%20Gen_L%20V2.0_001/MKS%20Gen_L%20V2.0_001%20PIN.pdf
  */
 
 #pragma once
@@ -183,7 +184,7 @@
 //Serial port for external debugging
 #if DEBUG_SEPARATE_SERIAL == 1
     #ifndef DEBUG_SERIAL_PORT
-        #define DEBUG_SERIAL_PORT Serial3  //D14 (Y-MIN) - TX3 and D15 (Y-MAX) - RX3
+        #define DEBUG_SERIAL_PORT Serial2  //D16 (LCD_RS) - TXD2 and D17 (LCD_EN) - RXD2
     #endif
 #else
     #ifndef DEBUG_SERIAL_PORT

--- a/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
+++ b/boards/AVR_MKS_GEN_L_V21/pins_MKS_GEN_L_V21.h
@@ -1,5 +1,6 @@
 /**
  * @brief a pins configuration file for an MKS Gen L V2.1 OAT.
+ * https://github.com/makerbase-mks/MKS-GEN_L/blob/master/hardware/MKS%20Gen_L%20V2.1_001/MKS%20GEN_L%20V2.1_001%20PIN.pdf
  */
 
 #pragma once
@@ -216,7 +217,7 @@
 //Serial port for external debugging
 #if DEBUG_SEPARATE_SERIAL == 1
     #ifndef DEBUG_SERIAL_PORT
-        #define DEBUG_SERIAL_PORT Serial3  //D14 (Y-MIN) - TX3 and D15 (Y-MAX) - RX3
+        #define DEBUG_SERIAL_PORT Serial2  //D16 (LCD_RS) - TXD2 and D17 (LCD_EN) - RXD2
     #endif
 #else
     #ifndef DEBUG_SERIAL_PORT


### PR DESCRIPTION
Serial3 (Y-MIN/Y-MAX port) has a low-pass filter that makes high speed serial communication impossible.
Scope capture @ 115200:  ![](https://imgur.com/qZv4k2B.png)