### PR TITLE
LCD menu updates (RA-DEC homing) and stop parking on setting home position via the LCD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+**V1.12.18 - Updates**
+- Added RA Autohoming via Hall sensor to the LCD menu
+- Added DEC Autohoming via Hall sensor to the LCD menu
+- Disabled tracking when setting up the home position via the LCD menu
+
 **V1.12.17 - Updates**
 - Fixed a bug that prevented clients from writing the DEC offset.
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.17"
+#define VERSION "V1.12.18"

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -17,7 +17,9 @@ void setControlMode(bool);  // In CTRL menu
 
 enum startupState_t
 {
-    StartupIsInHomePosition,
+    StartupAskIfRAHomingShouldRun,
+    StartupAskIfDECHomingShouldRun, //DEC
+    StartupAskIfIsInHomePosition,
     StartupSetRoll,
     StartupWaitForRollCompletion,
     StartupRollConfirmed,
@@ -33,8 +35,21 @@ enum startupState_t
         #define NO     2
         #define CANCEL 3
 
-startupState_t startupState = StartupIsInHomePosition;
-int isInHomePosition        = NO;
+        #if USE_HALL_SENSOR_RA_AUTOHOME == 1
+startupState_t startupState = StartupAskIfRAHomingShouldRun;
+        #else
+startupState_t startupState = StartupAskIfIsInHomePosition;
+        #endif
+
+//DEC-
+        #if USE_HALL_SENSOR_DEC_AUTOHOME == 1
+startupState_t startupState = StartupAskIfDECHomingShouldRun;
+        #else
+startupState_t startupState = StartupAskIfIsInHomePosition;
+        #endif
+//-DEC
+
+int isInHomePosition = NO;
 
 void startupIsCompleted()
 {
@@ -44,7 +59,7 @@ void startupIsCompleted()
     inStartup      = false;
     okToUpdateMenu = true;
 
-    mount.startSlewing(TRACKING);
+////    mount.startSlewing(TRACKING);
 
     // Start on the RA menu
     lcdMenu.setActive(RA_Menu);
@@ -57,7 +72,9 @@ bool processStartupKeys()
     bool waitForRelease = false;
     switch (startupState)
     {
-        case StartupIsInHomePosition:
+        case StartupAskIfRAHomingShouldRun: // RA
+        case StartupAskIfDECHomingShouldRun: // DEC
+        case StartupAskIfIsInHomePosition:
             {
                 if (lcdButtons.keyChanged(&key))
                 {
@@ -155,7 +172,7 @@ bool processStartupKeys()
                 isInHomePosition = YES;
 
                 // Ask again to confirm
-                startupState = StartupIsInHomePosition;
+                startupState = StartupAskIfIsInHomePosition;
             }
             break;
 
@@ -170,8 +187,10 @@ void printStartupMenu()
 {
     switch (startupState)
     {
-        case StartupIsInHomePosition:
-            {
+        case StartupAskIfRAHomingShouldRun: // RA
+        case StartupAskIfDECHomingShouldRun: // DEC
+
+        case StartupAskIfIsInHomePosition:            {
                 //              0123456789012345
                 String choices(" Yes  No  Cancl ");
                 if (isInHomePosition == YES)

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -18,7 +18,7 @@ void setControlMode(bool);  // In CTRL menu
 enum startupState_t
 {
     StartupAskIfRAHomingShouldRun,
-    StartupAskIfDECHomingShouldRun, //DEC
+    StartupAskIfDECHomingShouldRun,  //DEC
     StartupAskIfIsInHomePosition,
     StartupSetRoll,
     StartupWaitForRollCompletion,
@@ -41,7 +41,7 @@ startupState_t startupState = StartupAskIfRAHomingShouldRun;
 startupState_t startupState = StartupAskIfIsInHomePosition;
         #endif
 
-//DEC-
+    //DEC-
         #if USE_HALL_SENSOR_DEC_AUTOHOME == 1
 startupState_t startupState = StartupAskIfDECHomingShouldRun;
         #else
@@ -59,7 +59,7 @@ void startupIsCompleted()
     inStartup      = false;
     okToUpdateMenu = true;
 
-////    mount.startSlewing(TRACKING);
+    ////    mount.startSlewing(TRACKING);
 
     // Start on the RA menu
     lcdMenu.setActive(RA_Menu);
@@ -72,8 +72,8 @@ bool processStartupKeys()
     bool waitForRelease = false;
     switch (startupState)
     {
-        case StartupAskIfRAHomingShouldRun: // RA
-        case StartupAskIfDECHomingShouldRun: // DEC
+        case StartupAskIfRAHomingShouldRun:   // RA
+        case StartupAskIfDECHomingShouldRun:  // DEC
         case StartupAskIfIsInHomePosition:
             {
                 if (lcdButtons.keyChanged(&key))
@@ -187,10 +187,11 @@ void printStartupMenu()
 {
     switch (startupState)
     {
-        case StartupAskIfRAHomingShouldRun: // RA
-        case StartupAskIfDECHomingShouldRun: // DEC
+        case StartupAskIfRAHomingShouldRun:   // RA
+        case StartupAskIfDECHomingShouldRun:  // DEC
 
-        case StartupAskIfIsInHomePosition:            {
+        case StartupAskIfIsInHomePosition:
+            {
                 //              0123456789012345
                 String choices(" Yes  No  Cancl ");
                 if (isInHomePosition == YES)

--- a/src/c75_menuCTRL.hpp
+++ b/src/c75_menuCTRL.hpp
@@ -11,11 +11,11 @@ enum ctrlState_t
     HIGHLIGHT_MANUAL,
     HIGHLIGHT_SERIAL,
     HIGHLIGHT_RA_AUTO_HOME,
-    HIGHLIGHT_DEC_AUTO_HOME, //DEC
+    HIGHLIGHT_DEC_AUTO_HOME,  //DEC
     MANUAL_CONTROL_MODE,
     MANUAL_CONTROL_CONFIRM_HOME,
     RUNNING_RA_HOMING_MODE,
-    RUNNING_DEC_HOMING_MODE, //DEC
+    RUNNING_DEC_HOMING_MODE,  //DEC
 };
 
 ctrlState_t ctrlState = HIGHLIGHT_MANUAL;
@@ -123,7 +123,7 @@ bool processControlKeys()
                     ctrlState = HIGHLIGHT_SERIAL;
         #endif
                 }
-//DEC-
+                //DEC-
                 else if (key == btnDOWN)
                 {
         #if USE_HALL_SENSOR_DEC_AUTOHOME == 1
@@ -132,7 +132,7 @@ bool processControlKeys()
                     ctrlState = HIGHLIGHT_SERIAL;
         #endif
                 }
-//-DEC
+                //-DEC
                 else if (key == btnUP)
                 {
                     ctrlState = HIGHLIGHT_SERIAL;
@@ -161,12 +161,12 @@ bool processControlKeys()
                 {
                     ctrlState = HIGHLIGHT_MANUAL;
                 }
-//DEC-
+                //DEC-
                 else if (key == btnDOWN)
                 {
                     ctrlState = HIGHLIGHT_DEC_AUTO_HOME;
                 }
-//-DEC
+                //-DEC
                 else if (key == btnDOWN)
                 {
                     ctrlState = HIGHLIGHT_SERIAL;
@@ -188,7 +188,7 @@ bool processControlKeys()
             break;
         #endif
 
-//DEC-
+                //DEC-
         #if USE_HALL_SENSOR_DEC_AUTOHOME == 1
 
         case HIGHLIGHT_DEC_AUTO_HOME:
@@ -226,7 +226,7 @@ bool processControlKeys()
             }
             break;
         #endif
-//-DEC
+            //-DEC
         case HIGHLIGHT_SERIAL:
             if (lcdButtons.keyChanged(&key))
             {
@@ -247,7 +247,7 @@ bool processControlKeys()
                     ctrlState = HIGHLIGHT_MANUAL;
         #endif
                 }
-//DEC-
+                //DEC-
                 else if (key == btnUP)
                 {
         #if USE_HALL_SENSOR_DEC_AUTOHOME == 1
@@ -256,7 +256,7 @@ bool processControlKeys()
                     ctrlState = HIGHLIGHT_MANUAL;
         #endif
                 }
-//-DEC
+                //-DEC
                 else if (key == btnRIGHT)
                 {
                     inSerialControl = false;
@@ -295,7 +295,7 @@ bool processControlKeys()
                         lcdMenu.setNextActive();
                     }
 
-                    ctrlState      = HIGHLIGHT_MANUAL;
+                    ctrlState = HIGHLIGHT_MANUAL;
                     mount.stopSlewing(TRACKING);
                     okToUpdateMenu = true;
                     setZeroPoint   = true;
@@ -317,8 +317,8 @@ bool processControlKeys()
         #if SUPPORT_GUIDED_STARTUP == 1
                 if (startupState == StartupWaitForPoleCompletion)
                 {
-                    startupState   = StartupPoleConfirmed;
-                    ctrlState      = HIGHLIGHT_MANUAL;
+                    startupState = StartupPoleConfirmed;
+                    ctrlState    = HIGHLIGHT_MANUAL;
                     mount.stopSlewing(TRACKING);
                     waitForRelease = true;
                     inStartup      = true;
@@ -329,7 +329,7 @@ bool processControlKeys()
                     okToUpdateMenu = false;
                     lcdMenu.setCursor(0, 0);
                     lcdMenu.printMenu("Set home pos?");
-                    ctrlState      = MANUAL_CONTROL_CONFIRM_HOME;
+                    ctrlState = MANUAL_CONTROL_CONFIRM_HOME;
                     mount.stopSlewing(TRACKING);
                     waitForRelease = true;
                 }
@@ -350,11 +350,11 @@ void printControlSubmenu()
         case HIGHLIGHT_RA_AUTO_HOME:
             lcdMenu.printMenu(">Run RA Homing");
             break;
-//DEC-
+            //DEC-
         case HIGHLIGHT_DEC_AUTO_HOME:
             lcdMenu.printMenu(">Run DEC Homing");
             break;
-//-DEC
+            //-DEC
         case HIGHLIGHT_SERIAL:
             lcdMenu.printMenu(">Serial display");
             break;


### PR DESCRIPTION
I've added RA and DEC homing to the LCD menu and disabled the auto tracking when setting up the home position (LCD).