### PR TITLE
V1.13 Firmware updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+**V1.13.2 - Updates**
+- Added ability to detect new firmware flashed
+- Removed/disabled parking offset variable and commands, use home offset instead
+- Fixed Park command to slew home and then to the parking position (home offset)
+
 **V1.13.1 - Updates**
 - Re-integrated old stepper library
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,24 +1,16 @@
-**V1.13.6 - Updates**
+**V1.13.0 - Updates**
+NOTE: Make sure to do a Factory Reset when using this version.
 - Sped up ESP32 stepper code.
 - Re-instate some defines that were inadvertantly removed.
-
-**V1.13.5 - Updates**
 - Ported some bug fix code from the LCD branch (e.g. track on boot)
 - Potentially some DEC guide issues were fixed.
-
-**V1.13.4 - Updates**
 - Inadvertantly removed some default #defines. Put them back.
-
-**V1.13.3 - Updates**
 - Allow new stepper lib to be enabled by via #define
-
-**V1.13.2 - Updates**
 - Added ability to detect new firmware flashed
 - Removed/disabled parking offset variable and commands, use home offset instead
 - Fixed Park command to slew home and then to the parking position (home offset)
-
-**V1.13.1 - Updates**
 - Re-integrated old stepper library
+
 
 **V1.12.17 - Updates**
 - Fixed a bug that prevented clients from writing the DEC offset.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.13.3 - Updates**
+- Allow new stepper lib to be enabled by via #define
+
 **V1.13.2 - Updates**
 - Added ability to detect new firmware flashed
 - Removed/disabled parking offset variable and commands, use home offset instead
@@ -26,7 +29,7 @@
 **V1.12.12 - Updates**
 - Change MKS Gen L v1.0, v2.0, v2.1 default separate debug serial port from `Serial3` to `Serial2`.
 
-- **V1.12.11 - Updates**
+**V1.12.11 - Updates**
 - Allowed the active state of the hall sensors for auto homing RA and DEC to be configured.
 
 **V1.12.10 - Updates**

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+**V1.13.6 - Updates**
+- Sped up ESP32 stepper code.
+- Re-instate some defines that were inadvertantly removed.
+
 **V1.13.5 - Updates**
 - Ported some bug fix code from the LCD branch (e.g. track on boot)
 - Potentially some DEC guide issues were fixed.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.13.4 - Updates**
+- Inadvertantly removed some default #defines. Put them back.
+
 **V1.13.3 - Updates**
 - Allow new stepper lib to be enabled by via #define
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+**V1.13.5 - Updates**
+- Ported some bug fix code from the LCD branch (e.g. track on boot)
+- Potentially some DEC guide issues were fixed.
+
 **V1.13.4 - Updates**
 - Inadvertantly removed some default #defines. Put them back.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.13.1 - Updates**
+- Re-integrated old stepper library
+
 **V1.12.14 - Updates**
 - Southern hemisphere fix
 - Added and changed some logging

--- a/ConfigurationValidation.hpp
+++ b/ConfigurationValidation.hpp
@@ -434,3 +434,13 @@
         #endif
     #endif
 #endif
+
+// For OAT, we must have DEC limits defined, otherwise free slew does nto work.
+#ifndef OAM
+    #ifndef DEC_LIMIT_UP
+        #error "You must set DEC_LIMIT_UP to the number of degrees that your OAT can move upwards from the home position."
+    #endif
+    #ifndef DEC_LIMIT_DOWN
+        #error "You must set DEC_LIMIT_DOWN to the number of degrees that your OAT can move downwards from the home position."
+    #endif
+#endif

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -227,10 +227,18 @@
 #endif
 
 #ifndef DEC_LIMIT_UP
-    #define DEC_LIMIT_UP 0.0f
+    #ifdef OAM
+        #define DEC_LIMIT_UP 100.0f
+    #else
+        #define DEC_LIMIT_UP 0.0f
+    #endif
 #endif
 #ifndef DEC_LIMIT_DOWN
-    #define DEC_LIMIT_DOWN 0.0f
+    #ifdef OAM
+        #define DEC_LIMIT_DOWN 100.0f
+    #else
+        #define DEC_LIMIT_DOWN 0.0f
+    #endif
 #endif
 
 ////////////////////////////
@@ -326,7 +334,7 @@
     #ifndef AZIMUTH_STEPS_PER_REV
         #define AZIMUTH_STEPS_PER_REV                                                                                                      \
             (AZ_CORRECTION_FACTOR * (AZ_CIRCUMFERENCE / (AZ_PULLEY_TEETH * GT2_BELT_PITCH)) * AZ_STEPPER_SPR                               \
-             * AZ_MICROSTEPPING)  // Actually u-steps/rev
+             * AZ_MICROSTEPPING)                                                  // Actually u-steps/rev
     #endif
     #define AZIMUTH_STEPS_PER_ARC_MINUTE (AZIMUTH_STEPS_PER_REV / (360 * 60.0f))  // Used to determine move distance in steps
 

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -166,7 +166,7 @@
     #define RA_TRANSMISSION (RA_WHEEL_CIRCUMFERENCE / (RA_PULLEY_TEETH * GT2_BELT_PITCH))
 #endif
 
-/*
+
 #ifndef RA_SLEWING_SPEED_DEG
     #define RA_SLEWING_SPEED_DEG 4.0f  // deg/s
 #endif
@@ -182,7 +182,7 @@
 #ifndef DEC_SLEWING_ACCELERATION_DEG
     #define DEC_SLEWING_ACCELERATION_DEG 4.0f  // deg/s/s
 #endif
-*/
+
 // RA movement:
 // The radius of the surface that the belt runs on (in V1 of the ring) was 168.24mm.
 // Belt moves 40mm for one stepper revolution (2mm pitch, 20 teeth).

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -166,7 +166,6 @@
     #define RA_TRANSMISSION (RA_WHEEL_CIRCUMFERENCE / (RA_PULLEY_TEETH * GT2_BELT_PITCH))
 #endif
 
-
 #ifndef RA_SLEWING_SPEED_DEG
     #define RA_SLEWING_SPEED_DEG 4.0f  // deg/s
 #endif
@@ -334,7 +333,7 @@
     #ifndef AZIMUTH_STEPS_PER_REV
         #define AZIMUTH_STEPS_PER_REV                                                                                                      \
             (AZ_CORRECTION_FACTOR * (AZ_CIRCUMFERENCE / (AZ_PULLEY_TEETH * GT2_BELT_PITCH)) * AZ_STEPPER_SPR                               \
-             * AZ_MICROSTEPPING)                                                  // Actually u-steps/rev
+             * AZ_MICROSTEPPING)  // Actually u-steps/rev
     #endif
     #define AZIMUTH_STEPS_PER_ARC_MINUTE (AZIMUTH_STEPS_PER_REV / (360 * 60.0f))  // Used to determine move distance in steps
 

--- a/Configuration_adv.hpp
+++ b/Configuration_adv.hpp
@@ -166,6 +166,7 @@
     #define RA_TRANSMISSION (RA_WHEEL_CIRCUMFERENCE / (RA_PULLEY_TEETH * GT2_BELT_PITCH))
 #endif
 
+/*
 #ifndef RA_SLEWING_SPEED_DEG
     #define RA_SLEWING_SPEED_DEG 4.0f  // deg/s
 #endif
@@ -181,7 +182,7 @@
 #ifndef DEC_SLEWING_ACCELERATION_DEG
     #define DEC_SLEWING_ACCELERATION_DEG 4.0f  // deg/s/s
 #endif
-
+*/
 // RA movement:
 // The radius of the surface that the belt runs on (in V1 of the ring) was 168.24mm.
 // Belt moves 40mm for one stepper revolution (2mm pitch, 20 teeth).
@@ -319,7 +320,9 @@
     #endif
 
     // the Circumference of the AZ rotation. 808mm dia.
-    #define AZ_CIRCUMFERENCE 2538.4f
+    #ifndef AZ_CIRCUMFERENCE
+        #define AZ_CIRCUMFERENCE 2538.4f
+    #endif
     #ifndef AZIMUTH_STEPS_PER_REV
         #define AZIMUTH_STEPS_PER_REV                                                                                                      \
             (AZ_CORRECTION_FACTOR * (AZ_CIRCUMFERENCE / (AZ_PULLEY_TEETH * GT2_BELT_PITCH)) * AZ_STEPPER_SPR                               \

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.6"
+#define VERSION "V1.13.0"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.5"
+#define VERSION "V1.13.6"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.2"
+#define VERSION "V1.13.3"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.4"
+#define VERSION "V1.13.5"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.12.14"
+#define VERSION "V1.13.1"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.1"
+#define VERSION "V1.13.2"

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.3"
+#define VERSION "V1.13.4"

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,8 +36,10 @@ debug_build_flags =
 
 [common_embedded]
 framework = arduino
-monitor_speed = 19200
+monitor_speed = 115200
+monitor_port = COM7
 upload_speed = 115200
+upload_port = COM10
 test_ignore = test_native
 src_filter =
 	+<*> -<../.git/> -<../test/>

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,10 +36,8 @@ debug_build_flags =
 
 [common_embedded]
 framework = arduino
-monitor_speed = 115200
-monitor_port = COM7
+monitor_speed = 19200
 upload_speed = 115200
-upload_port = COM10
 test_ignore = test_native
 src_filter =
 	+<*> -<../.git/> -<../test/>

--- a/src/Core.cpp
+++ b/src/Core.cpp
@@ -18,8 +18,8 @@
 #include "c_buttons.hpp"
 #include "f_serial.hpp"
 
-#ifdef ARDUINO_ARCH_AVR
-/*
+#ifdef NEW_STEPPER_LIB
+    #ifdef ARDUINO_ARCH_AVR
 ISR(TIMER1_OVF_vect)
 {
     IntervalInterrupt_AVR<Timer::TIMER_1>::handle_overflow();
@@ -52,5 +52,5 @@ ISR(TIMER5_COMPA_vect)
 {
     IntervalInterrupt_AVR<Timer::TIMER_5>::handle_compare_match();
 }
-*/
+    #endif
 #endif

--- a/src/Core.cpp
+++ b/src/Core.cpp
@@ -19,6 +19,7 @@
 #include "f_serial.hpp"
 
 #ifdef ARDUINO_ARCH_AVR
+/*
 ISR(TIMER1_OVF_vect)
 {
     IntervalInterrupt_AVR<Timer::TIMER_1>::handle_overflow();
@@ -51,4 +52,5 @@ ISR(TIMER5_COMPA_vect)
 {
     IntervalInterrupt_AVR<Timer::TIMER_5>::handle_compare_match();
 }
+*/
 #endif

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -677,68 +677,6 @@ void EEPROMStore::storeRollCalibrationAngle(float rollCalibrationAngle)
     commit();  // Complete the transaction
 }
 
-// // Return the stored RA Parking Pos (slew microsteps relative to home).
-// // If it is not present then the default value of 0 steps.
-// int32_t EEPROMStore::getRAParkingPos()
-// {
-//     int32_t raParkingPos(0);  // microsteps (slew)
-
-//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-//     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
-//     {
-//         raParkingPos = readInt32(RA_PARKING_POS_ADDR);
-//         LOG(DEBUG_EEPROM, "[EEPROM]: RA Parking position read as %l", raParkingPos);
-//     }
-//     else
-//     {
-//         LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
-//     }
-
-//     return raParkingPos;  // microsteps (slew)
-// }
-
-// // Store the configured RA Parking Pos (slew microsteps relative to home).
-// void EEPROMStore::storeRAParkingPos(int32_t raParkingPos)
-// {
-//     LOG(DEBUG_EEPROM, "[EEPROM]: Updating RA Parking Pos to %l", raParkingPos);
-
-//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-//     updateInt32(RA_PARKING_POS_ADDR, raParkingPos);
-//     updateFlagsExtended(PARKING_POS_MARKER_FLAG);
-//     commit();  // Complete the transaction
-// }
-
-// // Return the stored DEC Parking Pos (slew microsteps relative to home).
-// // If it is not present then the default value of 0 steps.
-// int32_t EEPROMStore::getDECParkingPos()
-// {
-//     int32_t decParkingPos(0);  // microsteps (slew)
-
-//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-//     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
-//     {
-//         decParkingPos = readInt32(DEC_PARKING_POS_ADDR);
-//         LOG(DEBUG_EEPROM, "[EEPROM]: DEC Parking position read as %l", decParkingPos);
-//     }
-//     else
-//     {
-//         LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
-//     }
-
-//     return decParkingPos;  // microsteps (slew)
-// }
-
-// // Store the configured DEC Parking Pos (slew microsteps relative to home).
-// void EEPROMStore::storeDECParkingPos(int32_t decParkingPos)
-// {
-//     LOG(DEBUG_EEPROM, "[EEPROM]: Updating DEC Parking Pos to %l", decParkingPos);
-
-//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-//     updateInt32(DEC_PARKING_POS_ADDR, decParkingPos);
-//     updateFlagsExtended(PARKING_POS_MARKER_FLAG);
-//     commit();  // Complete the transaction
-// }
-
 // Return the stored DEC Lower Limit (slew microsteps relative to home).
 // If it is not present then the default value of 0 steps (limits are disabled).
 float EEPROMStore::getDECLowerLimit()

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -138,10 +138,11 @@ void EEPROMStore::displayContents()
     LOG(DEBUG_INFO, "[EEPROM]: Stored Longitude: %s", getLongitude().ToString());
     LOG(DEBUG_INFO, "[EEPROM]: Stored Pitch Calibration Angle: %f", getPitchCalibrationAngle());
     LOG(DEBUG_INFO, "[EEPROM]: Stored Roll Calibration Angle: %f", getRollCalibrationAngle());
-    LOG(DEBUG_INFO, "[EEPROM]: Stored RA Parking Position: %l", getRAParkingPos());
-    LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Parking Position: %l", getDECParkingPos());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored RA Homing Offset: %l", getRAHomingOffset());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Homing Offset : %l", getDECHomingOffset());
     LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Lower Limit: %l", getDECLowerLimit());
     LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Upper Limit: %l", getDECUpperLimit());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored Last Flashed Version: %d", getLastFlashedVersion());
 #endif
 }
 
@@ -412,7 +413,7 @@ float EEPROMStore::getRAStepsPerDegree()
 void EEPROMStore::storeRAStepsPerDegree(float raStepsPerDegree)
 {
     // Store steps as 100x steps/deg at 256 MS.
-    const float factor = SteppingStorageNormalized / RA_TRACKING_MICROSTEPPING;
+    const float factor = SteppingStorageNormalized / RA_SLEW_MICROSTEPPING;
     int32_t val        = raStepsPerDegree * factor;
     LOG(DEBUG_EEPROM, "[EEPROM]: Storing RA steps to %l (%f)", val, raStepsPerDegree);
 
@@ -430,7 +431,7 @@ float EEPROMStore::getDECStepsPerDegree()
     if (isPresentExtended(DEC_NORM_STEPS_MARKER_FLAG))
     {
         // This version stored 100x steps/deg for 256 MS
-        const float factor = SteppingStorageNormalized / DEC_GUIDE_MICROSTEPPING;
+        const float factor = SteppingStorageNormalized / DEC_SLEW_MICROSTEPPING;
         decStepsPerDegree  = readInt32(DEC_NORM_STEPS_DEGREE_ADDR) / factor;
         LOG(DEBUG_EEPROM, "[EEPROM]: DEC Normed Marker Present! DEC steps/deg is %f", decStepsPerDegree);
     }
@@ -451,12 +452,36 @@ float EEPROMStore::getDECStepsPerDegree()
 // Store the DEC steps per degree for guiding (actually microsteps per degree).
 void EEPROMStore::storeDECStepsPerDegree(float decStepsPerDegree)
 {
-    const float factor = SteppingStorageNormalized / DEC_GUIDE_MICROSTEPPING;
+    const float factor = SteppingStorageNormalized / DEC_SLEW_MICROSTEPPING;
     int32_t val        = decStepsPerDegree * factor;
     LOG(DEBUG_EEPROM, "[EEPROM]: Storing DEC steps to %l (%f)", val, decStepsPerDegree);
 
     updateInt32(DEC_NORM_STEPS_DEGREE_ADDR, val);
     updateFlagsExtended(DEC_NORM_STEPS_MARKER_FLAG);
+    commit();  // Complete the transaction
+}
+
+int16_t EEPROMStore::getLastFlashedVersion()
+{
+    if (isPresentExtended(LAST_FLASHED_MARKER_FLAG))
+    {
+        // This version stored 100x steps/deg for 256 MS
+        int16_t version = readInt16(LAST_FLASHED_VERSION);
+        LOG(DEBUG_EEPROM, "[EEPROM]: Last Flashed version Marker Present! last version %d", version);
+        return version;
+    }
+    else
+    {
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Last Flashed Version");
+    }
+    return 0;
+}
+
+void EEPROMStore::storeLastFlashedVersion(int16_t version)
+{
+    LOG(DEBUG_EEPROM, "[EEPROM]: Storing Last flashed version (%d)", version);
+    updateInt16(LAST_FLASHED_VERSION, version);
+    updateFlagsExtended(LAST_FLASHED_MARKER_FLAG);
     commit();  // Complete the transaction
 }
 
@@ -652,67 +677,67 @@ void EEPROMStore::storeRollCalibrationAngle(float rollCalibrationAngle)
     commit();  // Complete the transaction
 }
 
-// Return the stored RA Parking Pos (slew microsteps relative to home).
-// If it is not present then the default value of 0 steps.
-int32_t EEPROMStore::getRAParkingPos()
-{
-    int32_t raParkingPos(0);  // microsteps (slew)
+// // Return the stored RA Parking Pos (slew microsteps relative to home).
+// // If it is not present then the default value of 0 steps.
+// int32_t EEPROMStore::getRAParkingPos()
+// {
+//     int32_t raParkingPos(0);  // microsteps (slew)
 
-    // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-    if (isPresentExtended(PARKING_POS_MARKER_FLAG))
-    {
-        raParkingPos = readInt32(RA_PARKING_POS_ADDR);
-        LOG(DEBUG_EEPROM, "[EEPROM]: RA Parking position read as %l", raParkingPos);
-    }
-    else
-    {
-        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
-    }
+//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
+//     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
+//     {
+//         raParkingPos = readInt32(RA_PARKING_POS_ADDR);
+//         LOG(DEBUG_EEPROM, "[EEPROM]: RA Parking position read as %l", raParkingPos);
+//     }
+//     else
+//     {
+//         LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
+//     }
 
-    return raParkingPos;  // microsteps (slew)
-}
+//     return raParkingPos;  // microsteps (slew)
+// }
 
-// Store the configured RA Parking Pos (slew microsteps relative to home).
-void EEPROMStore::storeRAParkingPos(int32_t raParkingPos)
-{
-    LOG(DEBUG_EEPROM, "[EEPROM]: Updating RA Parking Pos to %l", raParkingPos);
+// // Store the configured RA Parking Pos (slew microsteps relative to home).
+// void EEPROMStore::storeRAParkingPos(int32_t raParkingPos)
+// {
+//     LOG(DEBUG_EEPROM, "[EEPROM]: Updating RA Parking Pos to %l", raParkingPos);
 
-    // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-    updateInt32(RA_PARKING_POS_ADDR, raParkingPos);
-    updateFlagsExtended(PARKING_POS_MARKER_FLAG);
-    commit();  // Complete the transaction
-}
+//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
+//     updateInt32(RA_PARKING_POS_ADDR, raParkingPos);
+//     updateFlagsExtended(PARKING_POS_MARKER_FLAG);
+//     commit();  // Complete the transaction
+// }
 
-// Return the stored DEC Parking Pos (slew microsteps relative to home).
-// If it is not present then the default value of 0 steps.
-int32_t EEPROMStore::getDECParkingPos()
-{
-    int32_t decParkingPos(0);  // microsteps (slew)
+// // Return the stored DEC Parking Pos (slew microsteps relative to home).
+// // If it is not present then the default value of 0 steps.
+// int32_t EEPROMStore::getDECParkingPos()
+// {
+//     int32_t decParkingPos(0);  // microsteps (slew)
 
-    // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-    if (isPresentExtended(PARKING_POS_MARKER_FLAG))
-    {
-        decParkingPos = readInt32(DEC_PARKING_POS_ADDR);
-        LOG(DEBUG_EEPROM, "[EEPROM]: DEC Parking position read as %l", decParkingPos);
-    }
-    else
-    {
-        LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
-    }
+//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
+//     if (isPresentExtended(PARKING_POS_MARKER_FLAG))
+//     {
+//         decParkingPos = readInt32(DEC_PARKING_POS_ADDR);
+//         LOG(DEBUG_EEPROM, "[EEPROM]: DEC Parking position read as %l", decParkingPos);
+//     }
+//     else
+//     {
+//         LOG(DEBUG_EEPROM, "[EEPROM]: No stored value for Parking position");
+//     }
 
-    return decParkingPos;  // microsteps (slew)
-}
+//     return decParkingPos;  // microsteps (slew)
+// }
 
-// Store the configured DEC Parking Pos (slew microsteps relative to home).
-void EEPROMStore::storeDECParkingPos(int32_t decParkingPos)
-{
-    LOG(DEBUG_EEPROM, "[EEPROM]: Updating DEC Parking Pos to %l", decParkingPos);
+// // Store the configured DEC Parking Pos (slew microsteps relative to home).
+// void EEPROMStore::storeDECParkingPos(int32_t decParkingPos)
+// {
+//     LOG(DEBUG_EEPROM, "[EEPROM]: Updating DEC Parking Pos to %l", decParkingPos);
 
-    // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
-    updateInt32(DEC_PARKING_POS_ADDR, decParkingPos);
-    updateFlagsExtended(PARKING_POS_MARKER_FLAG);
-    commit();  // Complete the transaction
-}
+//     // Note that flags doesn't verify that _both_ RA & DEC parking have been written - these should always be stored as a pair
+//     updateInt32(DEC_PARKING_POS_ADDR, decParkingPos);
+//     updateFlagsExtended(PARKING_POS_MARKER_FLAG);
+//     commit();  // Complete the transaction
+// }
 
 // Return the stored DEC Lower Limit (slew microsteps relative to home).
 // If it is not present then the default value of 0 steps (limits are disabled).

--- a/src/EPROMStore.hpp
+++ b/src/EPROMStore.hpp
@@ -47,11 +47,11 @@ class EEPROMStore
     static float getRollCalibrationAngle();
     static void storeRollCalibrationAngle(float rollCalibrationAngle);
 
-    static int32_t getRAParkingPos();
-    static void storeRAParkingPos(int32_t raParkingPos);
+    // static int32_t getRAParkingPos();
+    // static void storeRAParkingPos(int32_t raParkingPos);
 
-    static int32_t getDECParkingPos();
-    static void storeDECParkingPos(int32_t decParkingPos);
+    // static int32_t getDECParkingPos();
+    // static void storeDECParkingPos(int32_t decParkingPos);
 
     static float getDECLowerLimit();
     static void storeDECLowerLimit(float decLowerLimit);
@@ -64,6 +64,9 @@ class EEPROMStore
 
     static int32_t getDECHomingOffset();
     static void storeDECHomingOffset(int32_t decHomingOffset);
+
+    static int16_t getLastFlashedVersion();
+    static void storeLastFlashedVersion(int16_t lastVersion);
 
   private:
     /////////////////////////////////
@@ -88,11 +91,15 @@ class EEPROMStore
     // If Location 5 is 0xCF, then an extended 16-bit flag is stored in 21/22 and
     // indicates the additional fields that have been stored: 0000 0000 0000 0000
     //                                                        ^^^^ ^^^^ ^^^^ ^^^^
-    //                                                                       ||||
+    //                                                                  |||| ||||
+    //                   Last flashed version (56-57) ------------------+||| ||||
+    //                       DEC Homing Offet (52-55) -------------------+|| ||||
+    //      DEC Steps/deg, normalized to 256MS (48-51) -------------------+| ||||
+    //       RA Steps/deg, normalized to 256MS (44-47) --------------------+ ||||
     //                        RA Homing Offet (40-43) -----------------------+|||
     //                                UTC Offset (39) ------------------------+||
     //     DEC lower (31-34) and upper (35-38) limits -------------------------+|
-    //     RA (23-26) and DEC (27-30) Parking offsets --------------------------+
+    //     RA (23-26) and DEC (27-30) Parking offsets --------------------------+   ( ==== Obsolete after V1.13.1 ==== )
     //
     /////////////////////////////////
 
@@ -125,6 +132,7 @@ class EEPROMStore
         RA_NORM_STEPS_MARKER_FLAG  = 0x0010,
         DEC_NORM_STEPS_MARKER_FLAG = 0x0020,
         DEC_HOMING_MARKER_FLAG     = 0x0040,
+        LAST_FLASHED_MARKER_FLAG   = 0x0080,
     };
 
     // These are the offsets to each item stored in the EEPROM
@@ -187,6 +195,8 @@ class EEPROMStore
         _DEC_HOMING_OFFSET_ADDR_1,
         _DEC_HOMING_OFFSET_ADDR_2,
         _DEC_HOMING_OFFSET_ADDR_3,  // Int32
+        LAST_FLASHED_VERSION = 56,
+        _LAST_FLASHED_VERSION_1,
         STORE_SIZE = 64
     };
 

--- a/src/EPROMStore.hpp
+++ b/src/EPROMStore.hpp
@@ -47,12 +47,6 @@ class EEPROMStore
     static float getRollCalibrationAngle();
     static void storeRollCalibrationAngle(float rollCalibrationAngle);
 
-    // static int32_t getRAParkingPos();
-    // static void storeRAParkingPos(int32_t raParkingPos);
-
-    // static int32_t getDECParkingPos();
-    // static void storeDECParkingPos(int32_t decParkingPos);
-
     static float getDECLowerLimit();
     static void storeDECLowerLimit(float decLowerLimit);
 
@@ -99,7 +93,7 @@ class EEPROMStore
     //                        RA Homing Offet (40-43) -----------------------+|||
     //                                UTC Offset (39) ------------------------+||
     //     DEC lower (31-34) and upper (35-38) limits -------------------------+|
-    //     RA (23-26) and DEC (27-30) Parking offsets --------------------------+   ( ==== Obsolete after V1.13.1 ==== )
+    //     RA (23-26) and DEC (27-30) Parking offsets --------------------------+   ( ==== Obsolete V1.13.0 and beyond ==== )
     //
     /////////////////////////////////
 

--- a/src/InterruptAccelStepper.h
+++ b/src/InterruptAccelStepper.h
@@ -4,14 +4,16 @@
 
 #ifndef AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H
 #define AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H
-/*
+
 #include <stdint.h>
 #include <math.h>
 
-#define SIGN(x) ((x >= 0) ? 1 : -1)
+#ifdef NEW_STEPPER_LIB
 
-// minimal stepping frequency (steps/s) based on cpu frequency, timer counter overflow and max amount of overflows
-#define MIN_STEPS_PER_SEC (static_cast<float>(F_CPU) / (static_cast<long>(UINT16_MAX) * static_cast<long>(UINT8_MAX)))
+    #define SIGN(x) ((x >= 0) ? 1 : -1)
+
+    // minimal stepping frequency (steps/s) based on cpu frequency, timer counter overflow and max amount of overflows
+    #define MIN_STEPS_PER_SEC (static_cast<float>(F_CPU) / (static_cast<long>(UINT16_MAX) * static_cast<long>(UINT8_MAX)))
 
 template <typename STEPPER> class InterruptAccelStepper
 {
@@ -144,5 +146,6 @@ template <typename STEPPER> class InterruptAccelStepper
         return STEPPER::isRunning();
     }
 };
-*/
+    #endif
+
 #endif  //AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H

--- a/src/InterruptAccelStepper.h
+++ b/src/InterruptAccelStepper.h
@@ -146,6 +146,6 @@ template <typename STEPPER> class InterruptAccelStepper
         return STEPPER::isRunning();
     }
 };
-    #endif
+#endif
 
 #endif  //AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H

--- a/src/InterruptAccelStepper.h
+++ b/src/InterruptAccelStepper.h
@@ -4,7 +4,7 @@
 
 #ifndef AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H
 #define AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H
-
+/*
 #include <stdint.h>
 #include <math.h>
 
@@ -144,5 +144,5 @@ template <typename STEPPER> class InterruptAccelStepper
         return STEPPER::isRunning();
     }
 };
-
+*/
 #endif  //AVR_INTERRUPT_STEPPER_INTERRUPTACCELSTEPPER_H

--- a/src/InterruptCallback.cpp
+++ b/src/InterruptCallback.cpp
@@ -7,24 +7,26 @@
 // whatever timer is used for the hardware being run
 //////////////////////////////////////
 
-#if defined ESP32
-// We don't support ESP32 boards in interrupt mode
-#elif defined __AVR_ATmega2560__  // Arduino Mega
-    #define USE_TIMER_1 true
-    #define USE_TIMER_2 true
-    #define USE_TIMER_3 false
-    #define USE_TIMER_4 false
-    #define USE_TIMER_5 false
+#ifndef NEW_STEPPER_LIB
+
+    #if defined ESP32
+    // We don't support ESP32 boards in interrupt mode
+    #elif defined __AVR_ATmega2560__  // Arduino Mega
+        #define USE_TIMER_1 true
+        #define USE_TIMER_2 true
+        #define USE_TIMER_3 false
+        #define USE_TIMER_4 false
+        #define USE_TIMER_5 false
 PUSH_NO_WARNINGS
-    #include "libs/TimerInterrupt/TimerInterrupt.h"
+        #include "libs/TimerInterrupt/TimerInterrupt.h"
 POP_NO_WARNINGS
-#else
-    #error Unrecognized board selected. Either implement interrupt code or define the board here.
-#endif
+    #else
+        #error Unrecognized board selected. Either implement interrupt code or define the board here.
+    #endif
 
-#if defined(ESP32)
+    #if defined(ESP32)
 
-#elif defined __AVR_ATmega2560__
+    #elif defined __AVR_ATmega2560__
 
 bool InterruptCallback::setInterval(float intervalMs, interrupt_callback_p callback, void *payload)
 {
@@ -45,4 +47,5 @@ void InterruptCallback::start()
     ITimer2.restartTimer();
 }
 
+    #endif
 #endif

--- a/src/InterruptCallback.cpp
+++ b/src/InterruptCallback.cpp
@@ -1,0 +1,48 @@
+#include "../Configuration.hpp"
+#include "Utility.hpp"
+#include "InterruptCallback.hpp"
+
+//////////////////////////////////////
+// This is an hardware-independent abstraction layer over
+// whatever timer is used for the hardware being run
+//////////////////////////////////////
+
+#if defined ESP32
+// We don't support ESP32 boards in interrupt mode
+#elif defined __AVR_ATmega2560__  // Arduino Mega
+    #define USE_TIMER_1 true
+    #define USE_TIMER_2 true
+    #define USE_TIMER_3 false
+    #define USE_TIMER_4 false
+    #define USE_TIMER_5 false
+PUSH_NO_WARNINGS
+    #include "libs/TimerInterrupt/TimerInterrupt.h"
+POP_NO_WARNINGS
+#else
+    #error Unrecognized board selected. Either implement interrupt code or define the board here.
+#endif
+
+#if defined(ESP32)
+
+#elif defined __AVR_ATmega2560__
+
+bool InterruptCallback::setInterval(float intervalMs, interrupt_callback_p callback, void *payload)
+{
+    // We have requested to use Timer2 (see above)
+    ITimer2.init();
+
+    // This timer supports the callback with payload
+    return ITimer2.attachInterruptInterval<void *>(intervalMs, callback, payload, 0UL);
+}
+
+void InterruptCallback::stop()
+{
+    ITimer2.stopTimer();
+}
+
+void InterruptCallback::start()
+{
+    ITimer2.restartTimer();
+}
+
+#endif

--- a/src/InterruptCallback.hpp
+++ b/src/InterruptCallback.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+//////////////////////////////////////
+// This is an hardware-independent abstraction layer over
+// whatever timer is used for the hardware being run.
+//////////////////////////////////////
+
+// The callback function signature
+typedef void (*interrupt_callback_p)(void *);
+
+// The static class managing the callbacks.
+class InterruptCallback
+{
+  public:
+    // Requests the hardware to call the given callback with the given payload at the given interval in milliseconds.
+    // The interrupts should be started before returning.
+    bool static setInterval(float intervalMs, interrupt_callback_p callback, void *payload);
+
+    // Starts the timer interrupts (currently not called/used)
+    void static start();
+
+    // Stops the timer interrupts (currently not called/used)
+    void static stop();
+};

--- a/src/InterruptCallback.hpp
+++ b/src/InterruptCallback.hpp
@@ -5,6 +5,8 @@
 // whatever timer is used for the hardware being run.
 //////////////////////////////////////
 
+#ifndef NEW_STEPPER_LIB
+
 // The callback function signature
 typedef void (*interrupt_callback_p)(void *);
 
@@ -22,3 +24,5 @@ class InterruptCallback
     // Stops the timer interrupts (currently not called/used)
     void static stop();
 };
+
+#endif

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -572,7 +572,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //        Park Scope and stop motors
 //      Information:
 //        This slews the scope back to it's home position (RA ring centered, DEC at 90, basically
-//        pointing at celestial pole), then advances to the parking position (defined by the Homing offsets) 
+//        pointing at celestial pole), then advances to the parking position (defined by the Homing offsets)
 //        and stops all movement (including tracking).
 //      Returns:
 //        nothing
@@ -802,8 +802,8 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Get RA Homing offset
 //      Information:
-//        Get the RA ring homing offset. 
-//        If a Hall sensor is present this is the number of steps from the center of the sensor range to 
+//        Get the RA ring homing offset.
+//        If a Hall sensor is present this is the number of steps from the center of the sensor range to
 //        where the actual center position is located.
 //        If no Hall sensor is present this is the number of steps from the power on position of the RA axis to
 //        where the actual center position is located.
@@ -814,8 +814,8 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Get DEC Homing offset
 //      Information:
-//        Get the DEC ring homing offset. 
-//        If a Hall sensor is present this is the number of steps from the center of the sensor range to 
+//        Get the DEC ring homing offset.
+//        If a Hall sensor is present this is the number of steps from the center of the sensor range to
 //        where the actual center position is located.
 //        If no Hall sensor is present this is the number of steps from the power on position of the DEC axis to
 //        where the actual center position is located.
@@ -1183,19 +1183,19 @@ String MeadeCommandProcessor::handleMeadeGetInfo(String inCmd)
             }
             break;
 
-        case 'r':                                                     // :Gr
-            return _mount->RAString(MEADE_STRING | TARGET_STRING);    // returns trailing #
+        case 'r':                                                   // :Gr
+            return _mount->RAString(MEADE_STRING | TARGET_STRING);  // returns trailing #
 
-        case 'd':                                                     // :Gd
-            return _mount->DECString(MEADE_STRING | TARGET_STRING);   // returns trailing #
+        case 'd':                                                    // :Gd
+            return _mount->DECString(MEADE_STRING | TARGET_STRING);  // returns trailing #
 
-        case 'R':                                                     // :GR
-            return _mount->RAString(MEADE_STRING | CURRENT_STRING);   // returns trailing #
+        case 'R':                                                    // :GR
+            return _mount->RAString(MEADE_STRING | CURRENT_STRING);  // returns trailing #
 
         case 'D':                                                     // :GD
             return _mount->DECString(MEADE_STRING | CURRENT_STRING);  // returns trailing #
 
-        case 'X':                                                     // :GX
+        case 'X':  // :GX
             return _mount->getStatusString() + "#";
 
         case 'I':
@@ -1273,7 +1273,7 @@ String MeadeCommandProcessor::handleMeadeGetInfo(String inCmd)
             {
                 return "OAT4#";
             }
-        case 'T':                // :GT
+        case 'T':  // :GT
             {
                 return "60.0#";  //default MEADE Tracking Frequency
             }
@@ -1768,7 +1768,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
             }
             return _mount->getMountHardwareInfo() + "#";  // :XGM#
         }
-        else if (inCmd[1] == 'O')                         // :XGO#
+        else if (inCmd[1] == 'O')  // :XGO#
         {
             return getLogBuffer();
         }
@@ -1826,7 +1826,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
         {
             _mount->setStepsPerDegree(RA_STEPS, inCmd.substring(2).toFloat());
         }
-        else if (inCmd[1] == 'D')                           // :XSD
+        else if (inCmd[1] == 'D')  // :XSD
         {
             if ((inCmd.length() > 2) && (inCmd[2] == 'L'))  // :XSDL
             {

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1775,18 +1775,24 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
         {
             if (inCmd.length() > 2)
             {
+                LOG(DEBUG_MOUNT, "[MEADE]: XGH  -> %s", inCmd.c_str());
                 if (inCmd[2] == 'R')  // :XGHR#
                 {
+                    LOG(DEBUG_MOUNT, "[MEADE]: XGHR  -> %s", inCmd.c_str());
                     return String(_mount->getHomingOffset(StepperAxis::RA_STEPS)) + "#";
                 }
                 else if (inCmd[2] == 'D')  // :XGHD#
                 {
+                    LOG(DEBUG_MOUNT, "[MEADE]: XGHD  -> %s", inCmd.c_str());
                     return String(_mount->getHomingOffset(StepperAxis::DEC_STEPS)) + "#";
                 }
                 else if (inCmd[2] == 'S')  // :XGHS#
                 {
+                    LOG(DEBUG_MOUNT, "[MEADE]: XGHS  -> %s", inCmd.c_str());
                     return String(inNorthernHemisphere ? "N#" : "S#");
                 }
+                LOG(DEBUG_MOUNT, "[MEADE]: XGH?  -> %s", inCmd.c_str());
+
                 return "0#";
             }
             else
@@ -1901,10 +1907,10 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
                 {
                     _mount->setHomingOffset(StepperAxis::RA_STEPS, inCmd.substring(3).toInt());
                 }
-            }
-            else if (inCmd.length() > 2 && inCmd[2] == 'D')  // :XSHD
-            {
-                _mount->setHomingOffset(StepperAxis::DEC_STEPS, inCmd.substring(3).toInt());
+                else if( inCmd[2] == 'D')  // :XSHD
+                {
+                    _mount->setHomingOffset(StepperAxis::DEC_STEPS, inCmd.substring(3).toInt());
+                }
             }
         }
     }

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -571,8 +571,9 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Park Scope and stop motors
 //      Information:
-//        This slews the scope back to it's home position (RA ring centered, DEC
-//        at 90, basically pointing at celestial pole) and stops all movement (including tracking).
+//        This slews the scope back to it's home position (RA ring centered, DEC at 90, basically
+//        pointing at celestial pole), then advances to the parking position (defined by the Homing offsets) 
+//        and stops all movement (including tracking).
 //      Returns:
 //        nothing
 //
@@ -757,13 +758,13 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        "float#" or "float|float#"
 //
-// :XGDP#
+// :XGDP# (obsolete, disabled)
 //      Description:
 //        Get DEC parking position
 //      Information:
 //        Gets the number of steps from the home position to the parking position for DEC
 //      Returns:
-//        "long#"
+//        "0#"
 //
 // :XGS#
 //      Description:
@@ -801,9 +802,25 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Get RA Homing offset
 //      Information:
-//        Get the RA ring homing offset for Hall sensor auto homing
+//        Get the RA ring homing offset. 
+//        If a Hall sensor is present this is the number of steps from the center of the sensor range to 
+//        where the actual center position is located.
+//        If no Hall sensor is present this is the number of steps from the power on position of the RA axis to
+//        where the actual center position is located.
 //      Returns:
-//        "n#" - the number of steps from the center of the hall sensor trigger range to the home position.
+//        "n#" - the number of steps
+//
+// :XGHD#
+//      Description:
+//        Get DEC Homing offset
+//      Information:
+//        Get the DEC ring homing offset. 
+//        If a Hall sensor is present this is the number of steps from the center of the sensor range to 
+//        where the actual center position is located.
+//        If no Hall sensor is present this is the number of steps from the power on position of the DEC axis to
+//        where the actual center position is located.
+//      Returns:
+//        "n#" - the number of steps
 //
 // :XGHS#
 //      Description:
@@ -958,7 +975,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Returns:
 //        nothing
 //
-// :XSDPnnnn#
+// :XSDPnnnn# (obsolete, disabled)
 //      Description:
 //        Set DEC parking position offset
 //      Information:
@@ -1166,19 +1183,19 @@ String MeadeCommandProcessor::handleMeadeGetInfo(String inCmd)
             }
             break;
 
-        case 'r':                                                   // :Gr
-            return _mount->RAString(MEADE_STRING | TARGET_STRING);  // returns trailing #
+        case 'r':                                                     // :Gr
+            return _mount->RAString(MEADE_STRING | TARGET_STRING);    // returns trailing #
 
-        case 'd':                                                    // :Gd
-            return _mount->DECString(MEADE_STRING | TARGET_STRING);  // returns trailing #
+        case 'd':                                                     // :Gd
+            return _mount->DECString(MEADE_STRING | TARGET_STRING);   // returns trailing #
 
-        case 'R':                                                    // :GR
-            return _mount->RAString(MEADE_STRING | CURRENT_STRING);  // returns trailing #
+        case 'R':                                                     // :GR
+            return _mount->RAString(MEADE_STRING | CURRENT_STRING);   // returns trailing #
 
         case 'D':                                                     // :GD
             return _mount->DECString(MEADE_STRING | CURRENT_STRING);  // returns trailing #
 
-        case 'X':  // :GX
+        case 'X':                                                     // :GX
             return _mount->getStatusString() + "#";
 
         case 'I':
@@ -1256,7 +1273,7 @@ String MeadeCommandProcessor::handleMeadeGetInfo(String inCmd)
             {
                 return "OAT4#";
             }
-        case 'T':  // :GT
+        case 'T':                // :GT
             {
                 return "60.0#";  //default MEADE Tracking Frequency
             }
@@ -1700,7 +1717,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
                 }
                 if (inCmd[2] == 'P')  // :XGDP#
                 {
-                    return String(_mount->getDecParkingOffset()) + "#";
+                    return "0#";
                 }
             }
             else  // :XGD#
@@ -1750,7 +1767,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
             }
             return _mount->getMountHardwareInfo() + "#";  // :XGM#
         }
-        else if (inCmd[1] == 'O')  // :XGO#
+        else if (inCmd[1] == 'O')                         // :XGO#
         {
             return getLogBuffer();
         }
@@ -1762,17 +1779,17 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
                 {
                     return String(_mount->getHomingOffset(StepperAxis::RA_STEPS)) + "#";
                 }
+                else if (inCmd[2] == 'D')  // :XGHD#
+                {
+                    return String(_mount->getHomingOffset(StepperAxis::DEC_STEPS)) + "#";
+                }
                 else if (inCmd[2] == 'S')  // :XGHS#
                 {
                     return String(inNorthernHemisphere ? "N#" : "S#");
                 }
-            }
-            else if (inCmd.length() > 2 && inCmd[2] == 'D')  // :XGHD#
-            {
-                return String(_mount->getHomingOffset(StepperAxis::DEC_STEPS)) + "#";
+                return "0#";
             }
             else
-
             {
                 char scratchBuffer[10];
                 DayTime ha = _mount->calculateHa();
@@ -1802,7 +1819,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
         {
             _mount->setStepsPerDegree(RA_STEPS, inCmd.substring(2).toFloat());
         }
-        else if (inCmd[1] == 'D')  // :XSD
+        else if (inCmd[1] == 'D')                           // :XSD
         {
             if ((inCmd.length() > 2) && (inCmd[2] == 'L'))  // :XSDL
             {
@@ -1842,7 +1859,6 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
             }
             else if ((inCmd.length() > 3) && (inCmd[2] == 'P'))  // :XSDP
             {
-                _mount->setDecParkingOffset(inCmd.substring(3).toInt());
             }
             else
             {

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -462,7 +462,7 @@ void Mount::configureRAdriver(uint16_t RA_SW_RX, uint16_t RA_SW_TX, float rsense
     _driverRA->pdn_disable(true);
     bool UART_Rx_connected = false;
         #if UART_CONNECTION_TEST_TXRX == 1
-    UART_Rx_connected      = connectToDriver(_driverRA, "RA");
+    UART_Rx_connected = connectToDriver(_driverRA, "RA");
     if (!UART_Rx_connected)
     {
         digitalWrite(RA_EN_PIN,
@@ -545,7 +545,7 @@ void Mount::configureDECdriver(uint16_t DEC_SW_RX, uint16_t DEC_SW_TX, float rse
     _driverDEC->pdn_disable(true);
     bool UART_Rx_connected = false;
         #if UART_CONNECTION_TEST_TXRX == 1
-    UART_Rx_connected      = connectToDriver(_driverDEC, "DEC");
+    UART_Rx_connected = connectToDriver(_driverDEC, "DEC");
     if (!UART_Rx_connected)
     {
         digitalWrite(DEC_EN_PIN,
@@ -627,7 +627,7 @@ void Mount::configureAZdriver(uint16_t AZ_SW_RX, uint16_t AZ_SW_TX, float rsense
     _driverAZ->pdn_disable(true);
     bool UART_Rx_connected = false;
         #if UART_CONNECTION_TEST_TXRX == 1
-    UART_Rx_connected      = connectToDriver(_driverAZ, "AZ");
+    UART_Rx_connected = connectToDriver(_driverAZ, "AZ");
     if (!UART_Rx_connected)
     {
         digitalWrite(AZ_EN_PIN,
@@ -708,7 +708,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
     _driverALT->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected      = connectToDriver(_driverALT, "ALT");
+    UART_Rx_connected = connectToDriver(_driverALT, "ALT");
     if (!UART_Rx_connected)
     {
         digitalWrite(ALT_EN_PIN,
@@ -799,7 +799,7 @@ void Mount::configureFocusDriver(
     _driverFocus->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected      = connectToDriver(_driverFocus, "Focus");
+    UART_Rx_connected = connectToDriver(_driverFocus, "Focus");
     if (!UART_Rx_connected)
     {
         digitalWrite(FOCUS_EN_PIN,

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -270,8 +270,6 @@ void Mount::configureRAStepper(byte pin1, byte pin2, uint32_t maxSpeed, uint32_t
 
     _stepperTRK->setMaxSpeed(5000);
     _stepperTRK->setAcceleration(15000);
-
-    configureHemisphere(inNorthernHemisphere, true);
 }
 
 /////////////////////////////////

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2286,7 +2286,7 @@ void Mount::startSlewing(int direction)
 
             if (direction & NORTH)
             {
-                long targetLocation = 300000;
+                long targetLocation = _stepsPerDECDegree * DEC_LIMIT_UP;
                 if (_decUpperLimit != 0)
                 {
                     targetLocation = _decUpperLimit;
@@ -2306,7 +2306,7 @@ void Mount::startSlewing(int direction)
 
             if (direction & SOUTH)
             {
-                long targetLocation = -300000;
+                long targetLocation = -_stepsPerDECDegree * DEC_LIMIT_DOWN;
                 if (_decLowerLimit != 0)
                 {
                     targetLocation = _decLowerLimit;

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -2873,23 +2873,6 @@ void Mount::loop()
                         compensationSteps);
                     _stepperTRK->runToNewPosition(_stepperTRK->currentPosition() + compensationSteps);
 
-                    // calculate compensation distance by including tracking steps done during compensation
-                    // to avoid another difference after compensation
-                    //long totalCompensationSteps
-                    //    = compensationSteps * config::Ra::SPEED_COMPENSATION / (config::Ra::SPEED_COMPENSATION - config::Ra::SPEED_TRK);
-
-                    //LOG(DEBUG_STEPPERS,
-                    //    "[STEPPERS]: loop: Arrived at %lms. Tracking was off for %lms, result in %l steps (%l total) at speed %f, "
-                    //    "compensating.",
-                    //    now,
-                    //    elapsed,
-                    //    compensationSteps,
-                    //    totalCompensationSteps,
-                    //    config::Ra::SPEED_COMPENSATION);
-
-                    //_stepperTRK->setMaxSpeed(config::Ra::SPEED_COMPENSATION);
-                    //_stepperTRK->move(totalCompensationSteps);
-                    //_stepperTRK->runToPosition();
                     LOG(DEBUG_STEPPERS, "[STEPPERS]: loop: compensation complete.");
                     _compensateForTrackerOff = false;
                 }

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -6,28 +6,54 @@
 #include "Longitude.hpp"
 #include "Types.hpp"
 
-/*
-#include "StepperConfiguration.hpp"
+#ifdef NEW_STEPPER_LIB
 
-// Forward declarations
-#ifdef ARDUINO_AVR_ATmega2560
+    #include "StepperConfiguration.hpp"
+
+    // Forward declarations
+    #ifdef ARDUINO_AVR_ATmega2560
 using StepperRaSlew  = InterruptAccelStepper<config::Ra::stepper_slew>;
 using StepperRaTrk   = InterruptAccelStepper<config::Ra::stepper_trk>;
 using StepperDecSlew = InterruptAccelStepper<config::Dec::stepper_slew>;
 using StepperDecTrk  = InterruptAccelStepper<config::Dec::stepper_trk>;
 
-    #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
+        #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
 using StepperAzSlew = InterruptAccelStepper<config::Az::stepper_slew>;
-    #endif
+        #endif
 
-    #if ALT_STEPPER_TYPE != STEPPER_TYPE_NONE
+        #if ALT_STEPPER_TYPE != STEPPER_TYPE_NONE
 using StepperAltSlew = InterruptAccelStepper<config::Alt::stepper_slew>;
-    #endif
+        #endif
 
-    #if FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE
+        #if FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE
 using StepperFocusSlew = InterruptAccelStepper<config::Focus::stepper_slew>;
-    #endif
+        #endif
 
+    #else
+        #include "AccelStepper.h"
+class AccelStepper;
+using StepperRaSlew    = AccelStepper;
+using StepperRaTrk     = AccelStepper;
+using StepperDecSlew   = AccelStepper;
+using StepperDecTrk    = AccelStepper;
+
+        #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
+using StepperAzSlew    = AccelStepper;
+        #endif
+
+        #if ALT_STEPPER_TYPE != STEPPER_TYPE_NONE
+using StepperAltSlew   = AccelStepper;
+        #endif
+
+        #if ALT_STEPPER_TYPE != STEPPER_TYPE_NONE
+using StepperAltSlew   = AccelStepper;
+        #endif
+
+        #if FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE
+using StepperFocusSlew = AccelStepper;
+        #endif
+
+    #endif
 #else
     #include "AccelStepper.h"
 class AccelStepper;
@@ -51,11 +77,8 @@ using StepperAltSlew   = AccelStepper;
     #if FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE
 using StepperFocusSlew = AccelStepper;
     #endif
-
 #endif
-*/
 
-class AccelStepper;
 class LcdMenu;
 class TMC2209Stepper;
 class HallSensorHoming;
@@ -318,9 +341,9 @@ class Mount
     void loop();
 
 // Low-level process any stepper movement on interrupt callback.
-//#if defined(ESP32)
+#if defined(ESP32) || !defined(NEW_STEPPER_LIB)
     void interruptLoop();
-//#endif
+#endif
 
     // Set the current stepper positions to be home.
     void setHome(bool clearZeroPos);
@@ -517,14 +540,17 @@ class Mount
     Longitude _longitude;
 
     // Stepper control for RA, DEC and TRK.
-//    StepperRaSlew *_stepperRA;
-//    StepperRaTrk *_stepperTRK;
-//    StepperDecSlew *_stepperDEC;
-//    StepperDecTrk *_stepperGUIDE;
+#ifdef NEW_STEPPER_LIB
+    StepperRaSlew *_stepperRA;
+    StepperRaTrk *_stepperTRK;
+    StepperDecSlew *_stepperDEC;
+    StepperDecTrk *_stepperGUIDE;
+#else
     AccelStepper *_stepperRA;
     AccelStepper *_stepperDEC;
     AccelStepper *_stepperTRK;
     AccelStepper *_stepperGUIDE;
+#endif
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverRA;
 #endif
@@ -535,16 +561,22 @@ class Mount
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE) || (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
     bool _azAltWasRunning;
     #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    // StepperAzSlew *_stepperAZ;
+        #ifdef NEW_STEPPER_LIB
+    StepperAzSlew *_stepperAZ;
+        #else
     AccelStepper *_stepperAZ;
+        #endif
     const long _stepsPerAZDegree;  // u-steps/degree (from CTOR)
         #if AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverAZ;
         #endif
     #endif
     #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    // StepperAltSlew *_stepperALT;
+        #ifdef NEW_STEPPER_LIB
+    StepperAltSlew *_stepperALT;
+        #else
     AccelStepper *_stepperALT;
+        #endif
     const long _stepsPerALTDegree;  // u-steps/degree (from CTOR)
         #if ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverALT;
@@ -557,8 +589,11 @@ class Mount
     FocuserMode _focuserMode = FOCUS_IDLE;
     float _maxFocusRateSpeed;
     #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    // StepperFocusSlew *_stepperFocus;
+        #ifdef NEW_STEPPER_LIB
+    StepperFocusSlew *_stepperFocus;
+        #else
     AccelStepper *_stepperFocus;
+        #endif
     int _focusRate;
         #if FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverFocus;

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -325,13 +325,6 @@ class Mount
     // Set the current stepper positions to be home.
     void setHome(bool clearZeroPos);
 
-    // Set the current stepper positions to be parking position.
-    void setParkingPosition();
-
-    // Get and set the offset from home to the parking position for DEC.
-    long getDecParkingOffset();
-    void setDecParkingOffset(long offset);
-
     // Set the DEC limit position to the given angle in degrees (saved as DEC steps).
     // If upper is true, sets the upper limit, else the lower limit.
     // If limitAngle is 0, limit is set to current position.
@@ -499,8 +492,6 @@ class Mount
     int _maxFocusAcceleration;
     int _backlashCorrectionSteps;
     int _moveRate;
-    long _raParkingPos;   // Parking position in slewing steps
-    long _decParkingPos;  // Parking position in slewing steps
     long _decLowerLimit;  // Movement limit in slewing steps
     long _decUpperLimit;  // Movement limit in slewing steps
 
@@ -598,8 +589,6 @@ class Mount
     unsigned long _trackerStoppedAt;
     bool _compensateForTrackerOff;
     volatile int _mountStatus;
-    long _homeOffsetRA;
-    long _homeOffsetDEC;
 
     char scratchBuffer[24];
     bool _stepperWasRunning;

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -6,6 +6,7 @@
 #include "Longitude.hpp"
 #include "Types.hpp"
 
+/*
 #include "StepperConfiguration.hpp"
 
 // Forward declarations
@@ -52,7 +53,9 @@ using StepperFocusSlew = AccelStepper;
     #endif
 
 #endif
+*/
 
+class AccelStepper;
 class LcdMenu;
 class TMC2209Stepper;
 class HallSensorHoming;
@@ -314,10 +317,10 @@ class Mount
     // Process any stepper movement.
     void loop();
 
-// Low-leve process any stepper movement on interrupt callback.
-#if defined(ESP32)
+// Low-level process any stepper movement on interrupt callback.
+//#if defined(ESP32)
     void interruptLoop();
-#endif
+//#endif
 
     // Set the current stepper positions to be home.
     void setHome(bool clearZeroPos);
@@ -523,10 +526,14 @@ class Mount
     Longitude _longitude;
 
     // Stepper control for RA, DEC and TRK.
-    StepperRaSlew *_stepperRA;
-    StepperRaTrk *_stepperTRK;
-    StepperDecSlew *_stepperDEC;
-    StepperDecTrk *_stepperGUIDE;
+//    StepperRaSlew *_stepperRA;
+//    StepperRaTrk *_stepperTRK;
+//    StepperDecSlew *_stepperDEC;
+//    StepperDecTrk *_stepperGUIDE;
+    AccelStepper *_stepperRA;
+    AccelStepper *_stepperDEC;
+    AccelStepper *_stepperTRK;
+    AccelStepper *_stepperGUIDE;
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverRA;
 #endif
@@ -537,14 +544,16 @@ class Mount
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE) || (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
     bool _azAltWasRunning;
     #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    StepperAzSlew *_stepperAZ;
+    // StepperAzSlew *_stepperAZ;
+    AccelStepper *_stepperAZ;
     const long _stepsPerAZDegree;  // u-steps/degree (from CTOR)
         #if AZ_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverAZ;
         #endif
     #endif
     #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    StepperAltSlew *_stepperALT;
+    // StepperAltSlew *_stepperALT;
+    AccelStepper *_stepperALT;
     const long _stepsPerALTDegree;  // u-steps/degree (from CTOR)
         #if ALT_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverALT;
@@ -557,7 +566,8 @@ class Mount
     FocuserMode _focuserMode = FOCUS_IDLE;
     float _maxFocusRateSpeed;
     #if (FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    StepperFocusSlew *_stepperFocus;
+    // StepperFocusSlew *_stepperFocus;
+    AccelStepper *_stepperFocus;
     int _focusRate;
         #if FOCUS_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
     TMC2209Stepper *_driverFocus;

--- a/src/StepperConfiguration.hpp
+++ b/src/StepperConfiguration.hpp
@@ -1,4 +1,5 @@
 #pragma once
+/*
 #include "../Configuration.hpp"
 
 #ifdef ARDUINO_AVR_ATmega2560
@@ -131,3 +132,4 @@ struct Focus {
 #endif
 
 }  // namespace config
+*/

--- a/src/StepperConfiguration.hpp
+++ b/src/StepperConfiguration.hpp
@@ -1,19 +1,21 @@
 #pragma once
-/*
+
 #include "../Configuration.hpp"
 
-#ifdef ARDUINO_AVR_ATmega2560
-    #include "Pin.h"
-    #include "IntervalInterrupt.h"
-    #include "Driver.h"
+#ifdef NEW_STEPPER_LIB
+
+    #ifdef ARDUINO_AVR_ATmega2560
+        #include "Pin.h"
+        #include "IntervalInterrupt.h"
+        #include "Driver.h"
 
 PUSH_NO_WARNINGS
-    #include "Stepper.h"
-    #include "InterruptAccelStepper.h"
+        #include "Stepper.h"
+        #include "InterruptAccelStepper.h"
 POP_NO_WARNINGS
-#endif
+    #endif
 
-#define UINT32(x) static_cast<uint32_t>(x)
+    #define UINT32(x) static_cast<uint32_t>(x)
 
 namespace config
 {
@@ -28,7 +30,7 @@ struct Ra {
     constexpr static float SPEED_SLEW = SPR_SLEW / 360.0f * RA_SLEWING_SPEED_DEG;
     constexpr static float ACCEL_SLEW = SPR_SLEW / 360.0f * RA_SLEWING_ACCELERATION_DEG;
 
-#ifdef ARDUINO_AVR_ATmega2560
+    #ifdef ARDUINO_AVR_ATmega2560
     using pin_step = Pin<RA_STEP_PIN>;
     using pin_dir  = Pin<RA_DIR_PIN>;
 
@@ -42,9 +44,9 @@ struct Ra {
     using stepper_trk  = Stepper<interrupt, driver, ramp_trk>;
 
     constexpr static float SPEED_COMPENSATION = SPEED_SLEW;
-#else
+    #else
     constexpr static float SPEED_COMPENSATION = SPEED_SLEW;
-#endif
+    #endif
 };
 
 struct Dec {
@@ -59,7 +61,7 @@ struct Dec {
     constexpr static float SPEED_SLEW     = SPR_SLEW / 360.0f * DEC_SLEWING_SPEED_DEG;
     constexpr static float ACCEL_SLEW     = SPR_SLEW / 360.0f * DEC_SLEWING_ACCELERATION_DEG;
 
-#ifdef ARDUINO_AVR_ATmega2560
+    #ifdef ARDUINO_AVR_ATmega2560
     using pin_step = Pin<DEC_STEP_PIN>;
     using pin_dir  = Pin<DEC_DIR_PIN>;
 
@@ -71,15 +73,15 @@ struct Dec {
 
     using stepper_slew = Stepper<interrupt, driver, ramp_slew>;
     using stepper_trk  = Stepper<interrupt, driver, ramp_trk>;
-#endif
+    #endif
 };
 
-#if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
+    #if AZ_STEPPER_TYPE != STEPPER_TYPE_NONE
 struct Az {
     constexpr static float SPEED_SLEW = static_cast<float>(AZ_STEPPER_SPEED);
     constexpr static float ACCEL_SLEW = static_cast<float>(AZ_STEPPER_ACCELERATION);
 
-    #ifdef ARDUINO_AVR_ATmega2560
+        #ifdef ARDUINO_AVR_ATmega2560
     using pin_step = Pin<AZ_STEP_PIN>;
     using pin_dir  = Pin<AZ_DIR_PIN>;
 
@@ -89,16 +91,16 @@ struct Az {
     using ramp_slew = AccelerationRamp<64, interrupt::FREQ, UINT32(SPEED_SLEW), UINT32(ACCEL_SLEW)>;
 
     using stepper_slew = Stepper<interrupt, driver, ramp_slew>;
-    #endif
+        #endif
 };
-#endif
+    #endif
 
-#if ALT_STEPPER_TYPE != STEPPER_TYPE_NONE
+    #if ALT_STEPPER_TYPE != STEPPER_TYPE_NONE
 struct Alt {
     constexpr static float SPEED_SLEW = static_cast<float>(ALT_STEPPER_SPEED);
     constexpr static float ACCEL_SLEW = static_cast<float>(ALT_STEPPER_ACCELERATION);
 
-    #ifdef ARDUINO_AVR_ATmega2560
+        #ifdef ARDUINO_AVR_ATmega2560
     using pin_step = Pin<ALT_STEP_PIN>;
     using pin_dir  = Pin<ALT_DIR_PIN>;
 
@@ -108,16 +110,16 @@ struct Alt {
     using ramp_slew = AccelerationRamp<64, interrupt::FREQ, UINT32(SPEED_SLEW), UINT32(ACCEL_SLEW)>;
 
     using stepper_slew = Stepper<interrupt, driver, ramp_slew>;
-    #endif
+        #endif
 };
-#endif
+    #endif
 
-#if FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE
+    #if FOCUS_STEPPER_TYPE != STEPPER_TYPE_NONE
 struct Focus {
     constexpr static float SPEED_SLEW = static_cast<float>(FOCUS_STEPPER_SPEED);
     constexpr static float ACCEL_SLEW = static_cast<float>(FOCUS_STEPPER_ACCELERATION);
 
-    #ifdef ARDUINO_AVR_ATmega2560
+        #ifdef ARDUINO_AVR_ATmega2560
     using pin_step = Pin<FOCUS_STEP_PIN>;
     using pin_dir  = Pin<FOCUS_DIR_PIN>;
 
@@ -127,9 +129,10 @@ struct Focus {
     using ramp_slew = AccelerationRamp<64, interrupt::FREQ, UINT32(SPEED_SLEW), UINT32(ACCEL_SLEW)>;
 
     using stepper_slew = Stepper<interrupt, driver, ramp_slew>;
-    #endif
+        #endif
 };
-#endif
+    #endif
 
 }  // namespace config
-*/
+
+#endif

--- a/src/a_inits.hpp
+++ b/src/a_inits.hpp
@@ -2,9 +2,12 @@
 
 #include "../Configuration.hpp"
 #include "inc/Globals.hpp"
+
+#ifndef NEW_STEPPER_LIB
 PUSH_NO_WARNINGS
-#include <AccelStepper.h>
+    #include <AccelStepper.h>
 POP_NO_WARNINGS
+#endif
 
 #include "Utility.hpp"
 #include "DayTime.hpp"

--- a/src/a_inits.hpp
+++ b/src/a_inits.hpp
@@ -2,6 +2,9 @@
 
 #include "../Configuration.hpp"
 #include "inc/Globals.hpp"
+PUSH_NO_WARNINGS
+#include <AccelStepper.h>
+POP_NO_WARNINGS
 
 #include "Utility.hpp"
 #include "DayTime.hpp"

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -12,7 +12,9 @@ PUSH_NO_WARNINGS
 POP_NO_WARNINGS
 #endif
 
-#include "InterruptCallback.hpp"
+#ifndef NEW_STEPPER_LIB
+    #include "InterruptCallback.hpp"
+#endif
 
 #include "Utility.hpp"
 #include "EPROMStore.hpp"
@@ -72,6 +74,8 @@ void IRAM_ATTR stepperControlTask(void *payload)
 }
 
 #else
+    #ifndef NEW_STEPPER_LIB
+
 // This is the callback function for the timer interrupt on ATMega platforms.
 // It should do very minimal work, only calling Mount::interruptLoop() to step the stepper motors as needed.
 // It is called every 500 us (2 kHz rate)
@@ -81,7 +85,7 @@ void stepperControlTimerCallback(void *payload)
     if (mountCopy)
         mountCopy->interruptLoop();
 }
-
+    #endif
 #endif
 
 /////////////////////////////////
@@ -318,20 +322,21 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: Trk Microsteps  : %d", RA_TRACKING_MICROSTEPPING);
     LOG(DEBUG_ANY, "[STEPPERS]: Stepper SPR     : %d", RA_STEPPER_SPR);
     LOG(DEBUG_ANY, "[STEPPERS]: Transmission    : %f", RA_TRANSMISSION);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Ra::DRIVER_SPR_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Ra::DRIVER_SPR_TRK);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Ra::SPR_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Ra::ACCEL_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed TrkComp   : %f", config::Ra::SPEED_COMPENSATION);
-
-    //    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, config::Ra::ACCEL_SLEW);
+    #ifdef NEW_STEPPER_LIB
+    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Ra::DRIVER_SPR_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Ra::DRIVER_SPR_TRK);
+    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Ra::SPR_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
+    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Ra::ACCEL_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
+    LOG(DEBUG_ANY, "[STEPPERS]: Speed TrkComp   : %f", config::Ra::SPEED_COMPENSATION);
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure RA stepper NEMA...");
+    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, config::Ra::ACCEL_SLEW);
+    #else
     LOG(DEBUG_ANY, "[STEPPERS]: Configure RA stepper NEMA...");
     mount.configureRAStepper(RAmotorPin1, RAmotorPin2, RA_STEPPER_SPEED, RA_STEPPER_ACCELERATION);
-#else
-    #error New stepper type? Configure it here.
+    #endif
 #endif
 
 #if (DEC_STEPPER_TYPE != STEPPER_TYPE_NONE)
@@ -339,19 +344,20 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: Slew Microsteps : %d", DEC_SLEW_MICROSTEPPING);
     LOG(DEBUG_ANY, "[STEPPERS]: Stepper SPR     : %d", DEC_STEPPER_SPR);
     LOG(DEBUG_ANY, "[STEPPERS]: Transmission    : %f", DEC_TRANSMISSION);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Dec::DRIVER_SPR_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Dec::DRIVER_SPR_TRK);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Dec::SPR_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Dec::SPR_TRK);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Dec::SPEED_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Dec::ACCEL_SLEW);
-    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Dec::SPEED_TRK);
-
-    // mount.configureDECStepper(DECmotorPin1, DECmotorPin2, config::Dec::SPEED_SLEW, config::Dec::ACCEL_SLEW);
+    #ifdef NEW_STEPPER_LIB
+    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Dec::DRIVER_SPR_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Dec::DRIVER_SPR_TRK);
+    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Dec::SPR_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Dec::SPR_TRK);
+    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Dec::SPEED_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Dec::ACCEL_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Dec::SPEED_TRK);
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure DEC stepper NEMA...");
+    mount.configureDECStepper(DECmotorPin1, DECmotorPin2, config::Dec::SPEED_SLEW, config::Dec::ACCEL_SLEW);
+    #else
     LOG(DEBUG_ANY, "[STEPPERS]: Configure DEC stepper NEMA...");
     mount.configureDECStepper(DECmotorPin1, DECmotorPin2, DEC_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
-#else
-    #error New stepper type? Configure it here.
+    #endif
 #endif
 
 #if RA_DRIVER_TYPE == DRIVER_TYPE_TMC2209_UART
@@ -441,11 +447,13 @@ void setup()
                             0);                  // The core to run this on
 
 #else
+    #ifndef NEW_STEPPER_LIB
     // 2 kHz updates (higher frequency interferes with serial communications and complete messes up OATControl communications)
     if (!InterruptCallback::setInterval(0.5f, stepperControlTimerCallback, &mount))
     {
         LOG(DEBUG_MOUNT, "[SYSTEM]: CANNOT setup interrupt timer!");
     }
+    #endif
 #endif
 
 #if UART_CONNECTION_TEST_TX == 1
@@ -462,7 +470,7 @@ void setup()
     #endif
 #endif
 
-    LOG(DEBUG_ANY, "[SYSTEM]: Setting %s hemisphere...", inNorthernHemisphere?"northern":"southern");
+    LOG(DEBUG_ANY, "[SYSTEM]: Setting %s hemisphere...", inNorthernHemisphere ? "northern" : "southern");
     mount.configureHemisphere(inNorthernHemisphere, true);
 
 #if TRACK_ON_BOOT == 1

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -12,6 +12,8 @@ PUSH_NO_WARNINGS
 POP_NO_WARNINGS
 #endif
 
+#include "InterruptCallback.hpp"
+
 #include "Utility.hpp"
 #include "EPROMStore.hpp"
 #include "a_inits.hpp"
@@ -67,6 +69,17 @@ void IRAM_ATTR stepperControlTask(void *payload)
         mountCopy->interruptLoop();
         vTaskDelay(1);  // 1 ms 	// This will limit max stepping rate to 1 kHz
     }
+}
+
+#else
+// This is the callback function for the timer interrupt on ATMega platforms.
+// It should do very minimal work, only calling Mount::interruptLoop() to step the stepper motors as needed.
+// It is called every 500 us (2 kHz rate)
+void stepperControlTimerCallback(void *payload)
+{
+    Mount *mountCopy = reinterpret_cast<Mount *>(payload);
+    if (mountCopy)
+        mountCopy->interruptLoop();
 }
 
 #endif
@@ -305,16 +318,18 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: Trk Microsteps  : %d", RA_TRACKING_MICROSTEPPING);
     LOG(DEBUG_ANY, "[STEPPERS]: Stepper SPR     : %d", RA_STEPPER_SPR);
     LOG(DEBUG_ANY, "[STEPPERS]: Transmission    : %f", RA_TRANSMISSION);
-    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Ra::DRIVER_SPR_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Ra::DRIVER_SPR_TRK);
-    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Ra::SPR_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
-    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Ra::ACCEL_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
-    LOG(DEBUG_ANY, "[STEPPERS]: Speed TrkComp   : %f", config::Ra::SPEED_COMPENSATION);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Ra::DRIVER_SPR_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Ra::DRIVER_SPR_TRK);
+//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Ra::SPR_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Ra::ACCEL_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Speed TrkComp   : %f", config::Ra::SPEED_COMPENSATION);
 
-    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, config::Ra::ACCEL_SLEW);
+//    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, config::Ra::ACCEL_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure RA stepper NEMA...");
+    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, RA_STEPPER_SPEED, RA_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.
 #endif
@@ -324,15 +339,17 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: Slew Microsteps : %d", DEC_SLEW_MICROSTEPPING);
     LOG(DEBUG_ANY, "[STEPPERS]: Stepper SPR     : %d", DEC_STEPPER_SPR);
     LOG(DEBUG_ANY, "[STEPPERS]: Transmission    : %f", DEC_TRANSMISSION);
-    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Dec::DRIVER_SPR_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Dec::DRIVER_SPR_TRK);
-    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Dec::SPR_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Dec::SPR_TRK);
-    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Dec::SPEED_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Dec::ACCEL_SLEW);
-    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Dec::SPEED_TRK);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Dec::DRIVER_SPR_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Dec::DRIVER_SPR_TRK);
+//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Dec::SPR_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Dec::SPR_TRK);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Dec::SPEED_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Dec::ACCEL_SLEW);
+//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Dec::SPEED_TRK);
 
-    mount.configureDECStepper(DECmotorPin1, DECmotorPin2, config::Dec::SPEED_SLEW, config::Dec::ACCEL_SLEW);
+    // mount.configureDECStepper(DECmotorPin1, DECmotorPin2, config::Dec::SPEED_SLEW, config::Dec::ACCEL_SLEW);
+    LOG(DEBUG_ANY, "[STEPPERS]: Configure DEC stepper NEMA...");
+    mount.configureDECStepper(DECmotorPin1, DECmotorPin2, DEC_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
 #else
     #error New stepper type? Configure it here.
 #endif
@@ -422,6 +439,13 @@ void setup()
                             2,                   // Priority (2 is higher than 1)
                             &StepperTask,        // The location that receives the thread id
                             0);                  // The core to run this on
+
+#else
+    // 2 kHz updates (higher frequency interferes with serial communications and complete messes up OATControl communications)
+    if (!InterruptCallback::setInterval(0.5f, stepperControlTimerCallback, &mount))
+    {
+        LOG(DEBUG_MOUNT, "[SYSTEM]: CANNOT setup interrupt timer!");
+    }
 #endif
 
 #if UART_CONNECTION_TEST_TX == 1

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -462,14 +462,14 @@ void setup()
     #endif
 #endif
 
+    LOG(DEBUG_ANY, "[SYSTEM]: Setting %s hemisphere...", inNorthernHemisphere?"northern":"southern");
+    mount.configureHemisphere(inNorthernHemisphere, true);
+
 #if TRACK_ON_BOOT == 1
     // Start the tracker.
     LOG(DEBUG_ANY, "[SYSTEM]: Start Tracking...");
     mount.startSlewing(TRACKING);
 #endif
-
-    LOG(DEBUG_ANY, "[SYSTEM]: Setting %s hemisphere...", inNorthernHemisphere ? "northern" : "southern");
-    mount.configureHemisphere(inNorthernHemisphere, true);
 
     mount.bootComplete();
     LOG(DEBUG_ANY, "[SYSTEM]: Boot complete!");

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -69,7 +69,6 @@ void IRAM_ATTR stepperControlTask(void *payload)
     for (;;)
     {
         mountCopy->interruptLoop();
-        vTaskDelay(1);  // 1 ms 	// This will limit max stepping rate to 1 kHz
     }
 }
 

--- a/src/b_setup.hpp
+++ b/src/b_setup.hpp
@@ -318,16 +318,16 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: Trk Microsteps  : %d", RA_TRACKING_MICROSTEPPING);
     LOG(DEBUG_ANY, "[STEPPERS]: Stepper SPR     : %d", RA_STEPPER_SPR);
     LOG(DEBUG_ANY, "[STEPPERS]: Transmission    : %f", RA_TRANSMISSION);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Ra::DRIVER_SPR_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Ra::DRIVER_SPR_TRK);
-//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Ra::SPR_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Ra::ACCEL_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Speed TrkComp   : %f", config::Ra::SPEED_COMPENSATION);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Ra::DRIVER_SPR_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Ra::DRIVER_SPR_TRK);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Ra::SPR_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Ra::SPR_TRK);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Ra::SPEED_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Ra::ACCEL_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Ra::SPEED_TRK);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed TrkComp   : %f", config::Ra::SPEED_COMPENSATION);
 
-//    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, config::Ra::ACCEL_SLEW);
+    //    mount.configureRAStepper(RAmotorPin1, RAmotorPin2, config::Ra::SPEED_SLEW, config::Ra::ACCEL_SLEW);
     LOG(DEBUG_ANY, "[STEPPERS]: Configure RA stepper NEMA...");
     mount.configureRAStepper(RAmotorPin1, RAmotorPin2, RA_STEPPER_SPEED, RA_STEPPER_ACCELERATION);
 #else
@@ -339,13 +339,13 @@ void setup()
     LOG(DEBUG_ANY, "[STEPPERS]: Slew Microsteps : %d", DEC_SLEW_MICROSTEPPING);
     LOG(DEBUG_ANY, "[STEPPERS]: Stepper SPR     : %d", DEC_STEPPER_SPR);
     LOG(DEBUG_ANY, "[STEPPERS]: Transmission    : %f", DEC_TRANSMISSION);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Dec::DRIVER_SPR_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Dec::DRIVER_SPR_TRK);
-//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Dec::SPR_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Dec::SPR_TRK);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Dec::SPEED_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Dec::ACCEL_SLEW);
-//    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Dec::SPEED_TRK);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Slew SPR : %l", config::Dec::DRIVER_SPR_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Driver Trk SPR  : %l", config::Dec::DRIVER_SPR_TRK);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Slew        : %f", config::Dec::SPR_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: SPR Trk         : %f", config::Dec::SPR_TRK);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Slew      : %f", config::Dec::SPEED_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Accel Slew      : %f", config::Dec::ACCEL_SLEW);
+    //    LOG(DEBUG_ANY, "[STEPPERS]: Speed Trk       : %f", config::Dec::SPEED_TRK);
 
     // mount.configureDECStepper(DECmotorPin1, DECmotorPin2, config::Dec::SPEED_SLEW, config::Dec::ACCEL_SLEW);
     LOG(DEBUG_ANY, "[STEPPERS]: Configure DEC stepper NEMA...");
@@ -467,6 +467,9 @@ void setup()
     LOG(DEBUG_ANY, "[SYSTEM]: Start Tracking...");
     mount.startSlewing(TRACKING);
 #endif
+
+    LOG(DEBUG_ANY, "[SYSTEM]: Setting %s hemisphere...", inNorthernHemisphere ? "northern" : "southern");
+    mount.configureHemisphere(inNorthernHemisphere, true);
 
     mount.bootComplete();
     LOG(DEBUG_ANY, "[SYSTEM]: Boot complete!");

--- a/src/c65_startup.hpp
+++ b/src/c65_startup.hpp
@@ -44,11 +44,16 @@ void startupIsCompleted()
     inStartup      = false;
     okToUpdateMenu = true;
 
+        #if TRACK_ON_BOOT == 1
+    // Start tracking.
+    LOG(DEBUG_ANY, "[STARTUP]: Start Tracking.");
     mount.startSlewing(TRACKING);
+        #endif
 
     // Start on the RA menu
     lcdMenu.setActive(RA_Menu);
     lcdMenu.updateDisplay();
+    LOG(DEBUG_ANY, "[STARTUP]: Completed!");
 }
 
 bool processStartupKeys()

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -784,41 +784,41 @@ bool processCalibrationKeys()
                 }
                 break;
 
-            // case PARKING_POS_CONFIRM:
-            //     {
-            //         if (key == btnDOWN || key == btnLEFT || key == btnUP)
-            //         {
-            //             parkYesNoIndex = adjustWrap(parkYesNoIndex, 1, 0, 1);
-            //         }
-            //         if (key == btnSELECT)
-            //         {
-            //             if (parkYesNoIndex == 0)
-            //             {  // Yes
-            //                 mount.setParkingPosition();
-            //                 lcdMenu.printMenu("Position stored.");
-            //                 mount.delay(800);
-            //             }
-            //             else
-            //             {
-            //                 lcdMenu.printMenu("Use CTRL to move");
-            //                 mount.delay(750);
-            //                 lcdMenu.setCursor(0, 1);
-            //                 lcdMenu.printMenu("OAT to park pos,");
-            //                 mount.delay(750);
-            //                 lcdMenu.setCursor(0, 1);
-            //                 lcdMenu.printMenu("then come back.");
-            //                 mount.delay(700);
-            //             }
-            //             calState = HIGHLIGHT_PARKING_POS;
-            //         }
-            //         else if (key == btnRIGHT)
-            //         {
-            //             // RIGHT cancels duration selection and returns to menu
-            //             calState      = HIGHLIGHT_PARKING_POS;
-            //             driftSubIndex = 1;
-            //         }
-            //     }
-            //     break;
+                // case PARKING_POS_CONFIRM:
+                //     {
+                //         if (key == btnDOWN || key == btnLEFT || key == btnUP)
+                //         {
+                //             parkYesNoIndex = adjustWrap(parkYesNoIndex, 1, 0, 1);
+                //         }
+                //         if (key == btnSELECT)
+                //         {
+                //             if (parkYesNoIndex == 0)
+                //             {  // Yes
+                //                 mount.setParkingPosition();
+                //                 lcdMenu.printMenu("Position stored.");
+                //                 mount.delay(800);
+                //             }
+                //             else
+                //             {
+                //                 lcdMenu.printMenu("Use CTRL to move");
+                //                 mount.delay(750);
+                //                 lcdMenu.setCursor(0, 1);
+                //                 lcdMenu.printMenu("OAT to park pos,");
+                //                 mount.delay(750);
+                //                 lcdMenu.setCursor(0, 1);
+                //                 lcdMenu.printMenu("then come back.");
+                //                 mount.delay(700);
+                //             }
+                //             calState = HIGHLIGHT_PARKING_POS;
+                //         }
+                //         else if (key == btnRIGHT)
+                //         {
+                //             // RIGHT cancels duration selection and returns to menu
+                //             calState      = HIGHLIGHT_PARKING_POS;
+                //             driftSubIndex = 1;
+                //         }
+                //     }
+                //     break;
 
             case DEC_LOWER_LIMIT_CONFIRM:
             case DEC_UPPER_LIMIT_CONFIRM:
@@ -913,21 +913,21 @@ bool processCalibrationKeys()
                 }
                 break;
 
-            // case HIGHLIGHT_PARKING_POS:
-            //     {
-            //         if (key == btnDOWN)
-            //             gotoNextHighlightState(1);
-            //         if (key == btnUP)
-            //             gotoNextHighlightState(-1);
-            //         else if (key == btnSELECT)
-            //             calState = PARKING_POS_CONFIRM;
-            //         else if (key == btnRIGHT)
-            //         {
-            //             gotoNextMenu();
-            //             calState = HIGHLIGHT_FIRST;
-            //         }
-            //     }
-            //     break;
+                // case HIGHLIGHT_PARKING_POS:
+                //     {
+                //         if (key == btnDOWN)
+                //             gotoNextHighlightState(1);
+                //         if (key == btnUP)
+                //             gotoNextHighlightState(-1);
+                //         else if (key == btnSELECT)
+                //             calState = PARKING_POS_CONFIRM;
+                //         else if (key == btnRIGHT)
+                //         {
+                //             gotoNextMenu();
+                //             calState = HIGHLIGHT_FIRST;
+                //         }
+                //     }
+                //     break;
 
             case HIGHLIGHT_DEC_LOWER_LIMIT:
             case HIGHLIGHT_DEC_UPPER_LIMIT:

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -17,7 +17,6 @@ enum
     HIGHLIGHT_RA_STEPS,
     HIGHLIGHT_DEC_STEPS,
     HIGHLIGHT_BACKLASH_STEPS,
-    // HIGHLIGHT_PARKING_POS,
     HIGHLIGHT_DEC_LOWER_LIMIT,
     HIGHLIGHT_DEC_UPPER_LIMIT,
     HIGHLIGHT_UTC_OFFSET,
@@ -61,9 +60,6 @@ enum
 
         // Backlash calibration only has one state, allowing you to adjust the number of steps with UP and DOWN
         #define BACKLASH_CALIBRATION 70
-
-        // Confirm that the current position is the parking position
-        // #define PARKING_POS_CONFIRM 80
 
         // Confirm that current position is the DEC Lower limit
         #define DEC_LOWER_LIMIT_CONFIRM 90
@@ -784,42 +780,6 @@ bool processCalibrationKeys()
                 }
                 break;
 
-                // case PARKING_POS_CONFIRM:
-                //     {
-                //         if (key == btnDOWN || key == btnLEFT || key == btnUP)
-                //         {
-                //             parkYesNoIndex = adjustWrap(parkYesNoIndex, 1, 0, 1);
-                //         }
-                //         if (key == btnSELECT)
-                //         {
-                //             if (parkYesNoIndex == 0)
-                //             {  // Yes
-                //                 mount.setParkingPosition();
-                //                 lcdMenu.printMenu("Position stored.");
-                //                 mount.delay(800);
-                //             }
-                //             else
-                //             {
-                //                 lcdMenu.printMenu("Use CTRL to move");
-                //                 mount.delay(750);
-                //                 lcdMenu.setCursor(0, 1);
-                //                 lcdMenu.printMenu("OAT to park pos,");
-                //                 mount.delay(750);
-                //                 lcdMenu.setCursor(0, 1);
-                //                 lcdMenu.printMenu("then come back.");
-                //                 mount.delay(700);
-                //             }
-                //             calState = HIGHLIGHT_PARKING_POS;
-                //         }
-                //         else if (key == btnRIGHT)
-                //         {
-                //             // RIGHT cancels duration selection and returns to menu
-                //             calState      = HIGHLIGHT_PARKING_POS;
-                //             driftSubIndex = 1;
-                //         }
-                //     }
-                //     break;
-
             case DEC_LOWER_LIMIT_CONFIRM:
             case DEC_UPPER_LIMIT_CONFIRM:
                 {
@@ -912,22 +872,6 @@ bool processCalibrationKeys()
                     }
                 }
                 break;
-
-                // case HIGHLIGHT_PARKING_POS:
-                //     {
-                //         if (key == btnDOWN)
-                //             gotoNextHighlightState(1);
-                //         if (key == btnUP)
-                //             gotoNextHighlightState(-1);
-                //         else if (key == btnSELECT)
-                //             calState = PARKING_POS_CONFIRM;
-                //         else if (key == btnRIGHT)
-                //         {
-                //             gotoNextMenu();
-                //             calState = HIGHLIGHT_FIRST;
-                //         }
-                //     }
-                //     break;
 
             case HIGHLIGHT_DEC_LOWER_LIMIT:
             case HIGHLIGHT_DEC_UPPER_LIMIT:
@@ -1102,10 +1046,6 @@ void printCalibrationSubmenu()
     {
         lcdMenu.printMenu(">Backlash Adjust");
     }
-    // else if (calState == HIGHLIGHT_PARKING_POS)
-    // {
-    //     lcdMenu.printMenu(">Set Parking Pos");
-    // }
     else if (calState == HIGHLIGHT_DEC_LOWER_LIMIT)
     {
         lcdMenu.printMenu(">DEC Lower Limit");
@@ -1182,12 +1122,6 @@ void printCalibrationSubmenu()
         sprintf(scratchBuffer, "Backlash: %d", BacklashSteps);
         lcdMenu.printMenu(scratchBuffer);
     }
-    // else if (calState == PARKING_POS_CONFIRM)
-    // {
-    //     sprintf(scratchBuffer, "Parked?  Yes  No");
-    //     scratchBuffer[8 + parkYesNoIndex * 5] = '>';
-    //     lcdMenu.printMenu(scratchBuffer);
-    // }
     else if (calState == DEC_LOWER_LIMIT_CONFIRM)
     {
         lcdMenu.setCursor(0, 0);

--- a/src/c76_menuCAL.hpp
+++ b/src/c76_menuCAL.hpp
@@ -17,7 +17,7 @@ enum
     HIGHLIGHT_RA_STEPS,
     HIGHLIGHT_DEC_STEPS,
     HIGHLIGHT_BACKLASH_STEPS,
-    HIGHLIGHT_PARKING_POS,
+    // HIGHLIGHT_PARKING_POS,
     HIGHLIGHT_DEC_LOWER_LIMIT,
     HIGHLIGHT_DEC_UPPER_LIMIT,
     HIGHLIGHT_UTC_OFFSET,
@@ -63,7 +63,7 @@ enum
         #define BACKLASH_CALIBRATION 70
 
         // Confirm that the current position is the parking position
-        #define PARKING_POS_CONFIRM 80
+        // #define PARKING_POS_CONFIRM 80
 
         // Confirm that current position is the DEC Lower limit
         #define DEC_LOWER_LIMIT_CONFIRM 90
@@ -784,41 +784,41 @@ bool processCalibrationKeys()
                 }
                 break;
 
-            case PARKING_POS_CONFIRM:
-                {
-                    if (key == btnDOWN || key == btnLEFT || key == btnUP)
-                    {
-                        parkYesNoIndex = adjustWrap(parkYesNoIndex, 1, 0, 1);
-                    }
-                    if (key == btnSELECT)
-                    {
-                        if (parkYesNoIndex == 0)
-                        {  // Yes
-                            mount.setParkingPosition();
-                            lcdMenu.printMenu("Position stored.");
-                            mount.delay(800);
-                        }
-                        else
-                        {
-                            lcdMenu.printMenu("Use CTRL to move");
-                            mount.delay(750);
-                            lcdMenu.setCursor(0, 1);
-                            lcdMenu.printMenu("OAT to park pos,");
-                            mount.delay(750);
-                            lcdMenu.setCursor(0, 1);
-                            lcdMenu.printMenu("then come back.");
-                            mount.delay(700);
-                        }
-                        calState = HIGHLIGHT_PARKING_POS;
-                    }
-                    else if (key == btnRIGHT)
-                    {
-                        // RIGHT cancels duration selection and returns to menu
-                        calState      = HIGHLIGHT_PARKING_POS;
-                        driftSubIndex = 1;
-                    }
-                }
-                break;
+            // case PARKING_POS_CONFIRM:
+            //     {
+            //         if (key == btnDOWN || key == btnLEFT || key == btnUP)
+            //         {
+            //             parkYesNoIndex = adjustWrap(parkYesNoIndex, 1, 0, 1);
+            //         }
+            //         if (key == btnSELECT)
+            //         {
+            //             if (parkYesNoIndex == 0)
+            //             {  // Yes
+            //                 mount.setParkingPosition();
+            //                 lcdMenu.printMenu("Position stored.");
+            //                 mount.delay(800);
+            //             }
+            //             else
+            //             {
+            //                 lcdMenu.printMenu("Use CTRL to move");
+            //                 mount.delay(750);
+            //                 lcdMenu.setCursor(0, 1);
+            //                 lcdMenu.printMenu("OAT to park pos,");
+            //                 mount.delay(750);
+            //                 lcdMenu.setCursor(0, 1);
+            //                 lcdMenu.printMenu("then come back.");
+            //                 mount.delay(700);
+            //             }
+            //             calState = HIGHLIGHT_PARKING_POS;
+            //         }
+            //         else if (key == btnRIGHT)
+            //         {
+            //             // RIGHT cancels duration selection and returns to menu
+            //             calState      = HIGHLIGHT_PARKING_POS;
+            //             driftSubIndex = 1;
+            //         }
+            //     }
+            //     break;
 
             case DEC_LOWER_LIMIT_CONFIRM:
             case DEC_UPPER_LIMIT_CONFIRM:
@@ -913,21 +913,21 @@ bool processCalibrationKeys()
                 }
                 break;
 
-            case HIGHLIGHT_PARKING_POS:
-                {
-                    if (key == btnDOWN)
-                        gotoNextHighlightState(1);
-                    if (key == btnUP)
-                        gotoNextHighlightState(-1);
-                    else if (key == btnSELECT)
-                        calState = PARKING_POS_CONFIRM;
-                    else if (key == btnRIGHT)
-                    {
-                        gotoNextMenu();
-                        calState = HIGHLIGHT_FIRST;
-                    }
-                }
-                break;
+            // case HIGHLIGHT_PARKING_POS:
+            //     {
+            //         if (key == btnDOWN)
+            //             gotoNextHighlightState(1);
+            //         if (key == btnUP)
+            //             gotoNextHighlightState(-1);
+            //         else if (key == btnSELECT)
+            //             calState = PARKING_POS_CONFIRM;
+            //         else if (key == btnRIGHT)
+            //         {
+            //             gotoNextMenu();
+            //             calState = HIGHLIGHT_FIRST;
+            //         }
+            //     }
+            //     break;
 
             case HIGHLIGHT_DEC_LOWER_LIMIT:
             case HIGHLIGHT_DEC_UPPER_LIMIT:
@@ -1102,10 +1102,10 @@ void printCalibrationSubmenu()
     {
         lcdMenu.printMenu(">Backlash Adjust");
     }
-    else if (calState == HIGHLIGHT_PARKING_POS)
-    {
-        lcdMenu.printMenu(">Set Parking Pos");
-    }
+    // else if (calState == HIGHLIGHT_PARKING_POS)
+    // {
+    //     lcdMenu.printMenu(">Set Parking Pos");
+    // }
     else if (calState == HIGHLIGHT_DEC_LOWER_LIMIT)
     {
         lcdMenu.printMenu(">DEC Lower Limit");
@@ -1182,12 +1182,12 @@ void printCalibrationSubmenu()
         sprintf(scratchBuffer, "Backlash: %d", BacklashSteps);
         lcdMenu.printMenu(scratchBuffer);
     }
-    else if (calState == PARKING_POS_CONFIRM)
-    {
-        sprintf(scratchBuffer, "Parked?  Yes  No");
-        scratchBuffer[8 + parkYesNoIndex * 5] = '>';
-        lcdMenu.printMenu(scratchBuffer);
-    }
+    // else if (calState == PARKING_POS_CONFIRM)
+    // {
+    //     sprintf(scratchBuffer, "Parked?  Yes  No");
+    //     scratchBuffer[8 + parkYesNoIndex * 5] = '>';
+    //     lcdMenu.printMenu(scratchBuffer);
+    // }
     else if (calState == DEC_LOWER_LIMIT_CONFIRM)
     {
         lcdMenu.setCursor(0, 0);

--- a/src/libs/TimerInterrupt/LICENSE
+++ b/src/libs/TimerInterrupt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Khoi Hoang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/libs/TimerInterrupt/TimerInterrupt.cpp
+++ b/src/libs/TimerInterrupt/TimerInterrupt.cpp
@@ -1,0 +1,685 @@
+/****************************************************************************************************************************
+   TimerInterrupt.cpp
+   For Arduino AVR boards
+   Written by Khoi Hoang
+
+   Built by Khoi Hoang https://github.com/khoih-prog/TimerInterrupt
+   Licensed under MIT license
+   Version: 1.0.2
+
+   TCNTx - Timer/Counter Register. The actual timer value is stored here.
+   OCRx - Output Compare Register
+   ICRx - Input Capture Register (only for 16bit timer)
+   TIMSKx - Timer/Counter Interrupt Mask Register. To enable/disable timer interrupts.
+   TIFRx - Timer/Counter Interrupt Flag Register. Indicates a pending timer interrupt.
+
+   Now with we can use these new 16 ISR-based timers, while consuming only 1 hwarware Timer.
+   Their independently-selected, maximum interval is practically unlimited (limited only by unsigned long miliseconds)
+   The accuracy is nearly perfect compared to software timers. The most important feature is they're ISR-based timers
+   Therefore, their executions are not blocked by bad-behaving functions / tasks.
+   This important feature is absolutely necessary for mission-critical tasks.
+
+   Version Modified By   Date      Comments
+   ------- -----------  ---------- -----------
+    1.0.0   K Hoang      13/11/2019 Initial coding
+    1.0.1   K Hoang      16/11/2019 Add long timer feature, clean up, higher accuracy
+    1.0.2   K Hoang      28/11/2019 Permit up to 16 super-long-time, super-accurate ISR-based timers to avoid being blocked
+****************************************************************************************************************************/
+#if !defined(ESP32)
+
+#define TIMER_INTERRUPT_DEBUG      0
+#include "TimerInterrupt.h"
+
+//#ifndef TIMER_INTERRUPT_DEBUG
+#define TIMER_INTERRUPT_DEBUG      0
+//#endif
+
+void TimerInterrupt::init(int8_t timer)
+{
+  // Set timer specific stuff
+  // All timers in CTC mode
+  // 8 bit timers will require changing prescalar values,
+  // whereas 16 bit timers are set to either ck/1 or ck/64 prescalar
+
+  //cli();//stop interrupts
+  noInterrupts();
+
+  switch (timer)
+  {
+#if defined(TCCR1A) && defined(TCCR1B) && defined(WGM12)
+    case 1:
+      // 16 bit timer
+      TCCR1A = 0;
+      TCCR1B = 0;
+      // Page 172-173. ATmega 328/328P or Page 145-146 of ATmega 640/1280/2560
+      // Mode 4 => Clear Timer on Compare match (CTC) using OCR1A for counter value
+      bitWrite(TCCR1B, WGM12, 1);
+      // No scaling now
+      bitWrite(TCCR1B, CS10, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T1");
+#endif
+
+      break;
+#endif
+
+#if defined(TCCR2A) && defined(TCCR2B)
+    case 2:
+      // 8 bit timer
+      TCCR2A = 0;
+      TCCR2B = 0;
+      // Page 205-206. ATmegal328, Page 184-185 ATmega 640/1280/2560
+      // Mode 2 => Clear Timer on Compare match (CTC) using OCR2A for counter value
+      bitWrite(TCCR2A, WGM21, 1);
+      // No scaling now
+      bitWrite(TCCR2B, CS20, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T2");
+#endif
+
+      break;
+#endif
+
+#if defined(TCCR3A) && defined(TCCR3B) &&  defined(TIMSK3)
+    case 3:
+      // 16 bit timer
+      TCCR3A = 0;
+      TCCR3B = 0;
+      bitWrite(TCCR3B, WGM32, 1);
+      bitWrite(TCCR3B, CS30, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T3");
+#endif
+
+      break;
+#endif
+
+#if defined(TCCR4A) && defined(TCCR4B) &&  defined(TIMSK4)
+    case 4:
+      // 16 bit timer
+      TCCR4A = 0;
+      TCCR4B = 0;
+#if defined(WGM42)
+      bitWrite(TCCR4B, WGM42, 1);
+#elif defined(CS43)
+      // TODO this may not be correct
+      // atmega32u4
+      bitWrite(TCCR4B, CS43, 1);
+#endif
+      bitWrite(TCCR4B, CS40, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T4");
+#endif
+
+      break;
+#endif
+
+#if defined(TCCR5A) && defined(TCCR5B) &&  defined(TIMSK5)
+    case 5:
+      // 16 bit timer
+      TCCR5A = 0;
+      TCCR5B = 0;
+      bitWrite(TCCR5B, WGM52, 1);
+      bitWrite(TCCR5B, CS50, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T5");
+#endif
+
+      break;
+#endif
+  }
+
+  _timer = timer;
+
+  //sei();//enable interrupts
+  interrupts();
+
+}
+
+void TimerInterrupt::set_OCR()
+{
+  // Run with noInterrupt()
+  // Set the OCR for the given timer,
+  // set the toggle count,
+  // then turn on the interrupts
+  uint32_t _OCRValueToUse;
+
+#if TIMER_INTERRUPT_DEBUG > 2
+  Serial.println("set_OCR: start with " + String(_timer));
+#endif
+
+
+  switch (_timer)
+  {
+    case 1:
+      _OCRValueToUse = min(MAX_COUNT_16BIT, _OCRValueRemaining);
+      OCR1A = _OCRValueToUse;
+      _OCRValueRemaining -= _OCRValueToUse;
+
+#if defined(OCR1A) && defined(TIMSK1) && defined(OCIE1A)
+      // Bit 1 – OCIEA: Output Compare A Match Interrupt Enable
+      // When this bit is written to '1', and the I-flag in the Status Register is set (interrupts globally enabled), the
+      // Timer/Counter Output Compare A Match interrupt is enabled. The corresponding Interrupt Vector is
+      // executed when the OCFA Flag, located in TIFR1, is set.
+      bitWrite(TIMSK1, OCIE1A, 1);
+#elif defined(OCR1A) && defined(TIMSK) && defined(OCIE1A)
+      // this combination is for at least the ATmega32
+      bitWrite(TIMSK, OCIE1A, 1);
+#endif
+      break;
+
+#if defined(OCR2A) && defined(TIMSK2) && defined(OCIE2A)
+    case 2:
+      _OCRValueToUse = min(MAX_COUNT_8BIT, _OCRValueRemaining);
+      OCR2A = _OCRValueToUse;
+      _OCRValueRemaining -= _OCRValueToUse;
+
+      bitWrite(TIMSK2, OCIE2A, 1);
+#if TIMER_INTERRUPT_DEBUG > 2
+      Serial.println("set_OCR: case 2 " + String(_OCRValueToUse)+" "+String(_OCRValueRemaining));
+#endif
+      break;
+#endif
+
+#if defined(OCR3A) && defined(TIMSK3) && defined(OCIE3A)
+    case 3:
+      _OCRValueToUse = min(MAX_COUNT_16BIT, _OCRValueRemaining);
+      OCR3A = _OCRValueToUse;
+      _OCRValueRemaining -= _OCRValueToUse;
+
+      bitWrite(TIMSK3, OCIE3A, 1);
+      break;
+#endif
+
+#if defined(OCR4A) && defined(TIMSK4) && defined(OCIE4A)
+    case 4:
+      _OCRValueToUse = min(MAX_COUNT_16BIT, _OCRValueRemaining);
+      OCR4A = _OCRValueToUse;
+      _OCRValueRemaining -= _OCRValueToUse;
+
+      bitWrite(TIMSK4, OCIE4A, 1);
+      break;
+#endif
+
+#if defined(OCR5A) && defined(TIMSK5) && defined(OCIE5A)
+    case 5:
+      _OCRValueToUse = min(MAX_COUNT_16BIT, _OCRValueRemaining);
+      OCR5A = _OCRValueToUse;
+      _OCRValueRemaining -= _OCRValueToUse;
+
+      bitWrite(TIMSK5, OCIE5A, 1);
+      break;
+#endif
+  }
+
+  // Flag _OCRValue == 0 => end of long timer
+  if (_OCRValueRemaining == 0)
+    _timerDone = true;
+
+}
+
+// frequency (in hertz) and duration (in milliseconds).
+// Return true if frequency is OK with selected timer (OCRValue is in range)
+bool TimerInterrupt::setFrequency(float frequency, timer_callback_p callback, uint32_t params, unsigned long duration)
+{
+#if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("setFrequency: called (" + String(frequency, 3) + ")");
+#endif
+
+  uint8_t       andMask = 0b11111000;
+  unsigned long OCRValue;
+  bool isSuccess = false;
+
+  //frequencyLimit must > 1
+  float frequencyLimit = frequency * 17179.840;
+
+  #if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("setFreq: limit is " + String(frequencyLimit, 1));
+  #endif
+
+  // Limit frequency to larger than (0.00372529 / 64) Hz or interval 17179.840s / 17179840 ms to avoid uint32_t overflow
+  if ((_timer <= 0) || (callback == NULL) || ((frequencyLimit) < 1) )
+  {
+#if (TIMER_INTERRUPT_DEBUG > 2)
+    Serial.println("setFreq: limit out of range!");
+#endif
+    return false;
+  }
+  else
+  {
+    // Calculate the toggle count. Duration must be at least longer then one cycle
+    if (duration > 0)
+    {
+      _toggle_count = frequency * duration / 1000;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("setFrequency => _toggle_count = " + String(_toggle_count) + ", frequency = " + String(frequency) + ", duration = " + String(duration));
+#endif
+
+      if (_toggle_count < 1)
+      {
+        return false;
+      }
+    }
+    else
+    {
+      _toggle_count = -1;
+    }
+
+    //Timer0 and timer2 are 8 bit timers, meaning they can store a maximum counter value of 255.
+    //Timer2 does not have the option of 1024 prescaler, only 1, 8, 32, 64
+    //Timer1 is a 16 bit timer, meaning it can store a maximum counter value of 65535.
+    int prescalerIndexStart;
+
+    //Use smallest prescaler first, then increase until fits (<255)
+    if (_timer != 2)
+    {
+      if (frequencyLimit > 64)
+        prescalerIndexStart = NO_PRESCALER;
+      else if (frequencyLimit > 8)
+        prescalerIndexStart = PRESCALER_8;
+      else
+        prescalerIndexStart = PRESCALER_64;
+
+
+      for (int prescalerIndex = prescalerIndexStart; prescalerIndex <= PRESCALER_1024; prescalerIndex++)
+      {
+        OCRValue = F_CPU / (frequency * prescalerDiv[prescalerIndex]) - 1;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+        Serial.println("Freq * 1000 = " + String(frequency * 1000));
+        Serial.println("F_CPU = " + String(F_CPU) + ", preScalerDiv = " + String(prescalerDiv[prescalerIndex]));
+        Serial.println("OCR = " + String(OCRValue) + ", preScalerIndex = " + String(prescalerIndex));
+#endif
+
+        // We use very large _OCRValue now, and every time timer ISR activates, we deduct min(MAX_COUNT_16BIT, _OCRValueRemaining) from _OCRValueRemaining
+        // So that we can create very long timer, even if the counter is only 16-bit.
+        // Use very high frequency (OCRValue / MAX_COUNT_16BIT) around 64 * 1024 to achieve higher accuracy
+        if ( (OCRValue / MAX_COUNT_16BIT) < 16384 )
+        {
+          _OCRValue           = OCRValue;
+          _OCRValueRemaining  = OCRValue;
+          _prescalerIndex = prescalerIndex;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+          Serial.println("OK in loop => _OCR = " + String(_OCRValue) + ", _preScalerIndex = " + String(_prescalerIndex) + ", preScalerDiv = " + String(prescalerDiv[_prescalerIndex]));
+#endif
+
+          isSuccess = true;
+
+          break;
+        }
+      }
+
+      if (!isSuccess)
+      {
+        // Always do this
+        _OCRValue           = OCRValue;
+        _OCRValueRemaining  = OCRValue;
+        _prescalerIndex = PRESCALER_1024;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+        Serial.println("OK out loop => _OCR = " + String(_OCRValue) + ", _preScalerIndex = " + String(_prescalerIndex) + ", preScalerDiv = " + String(prescalerDiv[_prescalerIndex]));
+#endif
+      }
+    }
+    else
+    {
+      if (frequencyLimit > 64)
+        prescalerIndexStart = T2_NO_PRESCALER;
+      else if (frequencyLimit > 8)
+        prescalerIndexStart = T2_PRESCALER_8;
+      else if (frequencyLimit > 2)
+        prescalerIndexStart = T2_PRESCALER_32;
+      else
+        prescalerIndexStart = T2_PRESCALER_64;
+
+      // Page 206-207. ATmegal328
+      //8-bit Timer2 has more options up to 1024 prescaler, from 1, 8, 32, 64, 128, 256 and 1024
+      for (int prescalerIndex = prescalerIndexStart; prescalerIndex <= T2_PRESCALER_1024; prescalerIndex++)
+      {
+        OCRValue = F_CPU / (frequency * prescalerDivT2[prescalerIndex]) - 1;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+        Serial.println("F_CPU = " + String(F_CPU) + ", preScalerDiv = " + String(prescalerDivT2[prescalerIndex]));
+        Serial.println("OCR2 = " + String(OCRValue) + ", preScalerIndex = " + String(prescalerIndex));
+#endif
+
+        // We use very large _OCRValue now, and every time timer ISR activates, we deduct min(MAX_COUNT_8BIT, _OCRValue) from _OCRValue
+        // to create very long timer, even if the counter is only 16-bit.
+        // Use very high frequency (OCRValue / MAX_COUNT_16BIT) around 64 * 1024 to achieve higher accuracy
+        if ( (OCRValue / MAX_COUNT_8BIT) < 16384 )
+        {
+          _OCRValue           = OCRValue;
+          _OCRValueRemaining  = OCRValue;
+          // same as prescalarbits
+          _prescalerIndex = prescalerIndex;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+          Serial.println("OK in loop => _OCR = " + String(_OCRValue) + ", _preScalerIndex = " + String(_prescalerIndex) + ", preScalerDiv = " + String(prescalerDivT2[_prescalerIndex]));
+#endif
+
+          isSuccess = true;
+
+          break;
+        }
+      }
+
+      if (!isSuccess)
+      {
+        // Always do this
+        _OCRValue           = OCRValue;
+        _OCRValueRemaining  = OCRValue;
+        // same as prescalarbits
+        _prescalerIndex = T2_PRESCALER_1024;
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+        Serial.println("OK out loop => _OCR = " + String(_OCRValue) + ", _preScalerIndex = " + String(_prescalerIndex) + ", preScalerDiv = " + String(prescalerDivT2[_prescalerIndex]));
+#endif
+      }
+    }
+
+    //cli();//stop interrupts
+    noInterrupts();
+
+    _frequency = frequency;
+    _callback  = (void*) callback;
+    _params    = reinterpret_cast<void*>(params);
+
+    _timerDone = false;
+
+    // 8 bit timers from here
+#if defined(TCCR2B)
+    if (_timer == 2)
+    {
+      TCCR2B = (TCCR2B & andMask) | _prescalerIndex;   //prescalarbits;
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("TCCR2B = " + String(TCCR2B));
+#endif
+    }
+#endif
+
+    // 16 bit timers from here
+#if defined(TCCR1B)
+    else if (_timer == 1)
+    {
+      TCCR1B = (TCCR1B & andMask) | _prescalerIndex;   //prescalarbits;
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("TCCR1B = " + String(TCCR1B));
+#endif
+
+    }
+#endif
+
+#if defined(TCCR3B)
+    else if (_timer == 3)
+      TCCR3B = (TCCR3B & andMask) | _prescalerIndex;   //prescalarbits;
+#endif
+
+#if defined(TCCR4B)
+    else if (_timer == 4)
+      TCCR4B = (TCCR4B & andMask) | _prescalerIndex;   //prescalarbits;
+#endif
+
+#if defined(TCCR5B)
+    else if (_timer == 5)
+      TCCR5B = (TCCR5B & andMask) | _prescalerIndex;   //prescalarbits;
+#endif
+
+    // Set the OCR for the given timer,
+    // set the toggle count,
+    // then turn on the interrupts
+    set_OCR();
+
+#if TIMER_INTERRUPT_DEBUG > 2
+    Serial.println("setfreq: set Ocr returned . Enabling interrupts.");
+#endif
+
+    //sei();//allow interrupts
+    interrupts();
+
+
+    return true;
+  }
+}
+
+void TimerInterrupt::detachInterrupt(void)
+{
+  //cli();//stop interrupts
+  noInterrupts();
+
+  switch (_timer)
+  {
+#if defined(TIMSK1) && defined(OCIE1A)
+    case 1:
+      bitWrite(TIMSK1, OCIE1A, 0);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Disable T1");
+#endif
+
+      break;
+#endif
+
+    case 2:
+#if defined(TIMSK2) && defined(OCIE2A)
+      bitWrite(TIMSK2, OCIE2A, 0); // disable interrupt
+#endif
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Disable T2");
+#endif
+
+      break;
+
+#if defined(TIMSK3) && defined(OCIE3A)
+    case 3:
+      bitWrite(TIMSK3, OCIE3A, 0);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Disable T3");
+#endif
+
+      break;
+#endif
+
+#if defined(TIMSK4) && defined(OCIE4A)
+    case 4:
+      bitWrite(TIMSK4, OCIE4A, 0);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Disable T4");
+#endif
+
+      break;
+#endif
+
+#if defined(TIMSK5) && defined(OCIE5A)
+    case 5:
+      bitWrite(TIMSK5, OCIE5A, 0);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Disable T5");
+#endif
+
+      break;
+#endif
+  }
+
+  //sei();//allow interrupts
+  interrupts();
+}
+
+// Duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+void TimerInterrupt::reattachInterrupt(unsigned long duration)
+{
+  //cli();//stop interrupts
+  noInterrupts();
+
+  // Calculate the toggle count
+  if (duration > 0)
+  {
+    _toggle_count = _frequency * duration / 1000;
+  }
+  else
+  {
+    _toggle_count = -1;
+  }
+
+  switch (_timer)
+  {
+#if defined(TIMSK1) && defined(OCIE1A)
+    case 1:
+      bitWrite(TIMSK1, OCIE1A, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Enable T1");
+#endif
+
+      break;
+#endif
+
+    case 2:
+#if defined(TIMSK2) && defined(OCIE2A)
+      bitWrite(TIMSK2, OCIE2A, 1); // enable interrupt
+#endif
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Enable T2");
+#endif
+
+      break;
+
+#if defined(TIMSK3) && defined(OCIE3A)
+    case 3:
+      bitWrite(TIMSK3, OCIE3A, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Enable T3");
+#endif
+
+      break;
+#endif
+
+#if defined(TIMSK4) && defined(OCIE4A)
+    case 4:
+      bitWrite(TIMSK4, OCIE4A, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Enable T4");
+#endif
+
+      break;
+#endif
+
+#if defined(TIMSK5) && defined(OCIE5A)
+    case 5:
+      bitWrite(TIMSK5, OCIE5A, 1);
+
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("Enable T5");
+#endif
+
+      break;
+#endif
+  }
+
+  //sei();//allow interrupts
+  interrupts();
+}
+
+// Just stop clock source, still keep the count
+void TimerInterrupt::pauseTimer(void)
+{
+  uint8_t andMask = 0b11111000;
+
+  //Just clear the CSx2-CSx0. Still keep the count in TCNT and Timer Interrupt mask TIMKSx.
+
+  // 8 bit timers from here
+#if defined(TCCR2B)
+  if (_timer == 2)
+  {
+    TCCR2B = (TCCR2B & andMask);
+#if (TIMER_INTERRUPT_DEBUG > 0)
+    Serial.println("TCCR2B = " + String(TCCR2B));
+#endif
+  }
+#endif
+
+  // 16 bit timers from here
+#if defined(TCCR1B)
+  else if (_timer == 1)
+  {
+    TCCR1B = (TCCR1B & andMask);
+#if (TIMER_INTERRUPT_DEBUG > 0)
+    Serial.println("TCCR1B = " + String(TCCR1B));
+#endif
+  }
+#endif
+
+#if defined(TCCR3B)
+  else if (_timer == 3)
+    TCCR3B = (TCCR3B & andMask);
+#endif
+
+#if defined(TCCR4B)
+  else if (_timer == 4)
+    TCCR4B = (TCCR4B & andMask);
+#endif
+
+#if defined(TCCR5B)
+  else if (_timer == 5)
+    TCCR5B = (TCCR5B & andMask);
+#endif
+}
+
+// Just reconnect clock source, continue from the current count
+void TimerInterrupt::resumeTimer(void)
+{
+  uint8_t andMask = 0b11111000;
+
+  //Just restore the CSx2-CSx0 stored in _prescalerIndex. Still keep the count in TCNT and Timer Interrupt mask TIMKSx.
+  // 8 bit timers from here
+#if defined(TCCR2B)
+  if (_timer == 2)
+  {
+    TCCR2B = (TCCR2B & andMask) | _prescalerIndex;   //prescalarbits;
+#if (TIMER_INTERRUPT_DEBUG > 0)
+    Serial.println("TCCR2B = " + String(TCCR2B));
+#endif
+  }
+#endif
+
+  // 16 bit timers from here
+#if defined(TCCR1B)
+  else if (_timer == 1)
+  {
+    TCCR1B = (TCCR1B & andMask) | _prescalerIndex;   //prescalarbits;
+#if (TIMER_INTERRUPT_DEBUG > 0)
+    Serial.println("TCCR1B = " + String(TCCR1B));
+#endif
+  }
+#endif
+
+#if defined(TCCR3B)
+  else if (_timer == 3)
+    TCCR3B = (TCCR3B & andMask) | _prescalerIndex;   //prescalarbits;
+#endif
+
+#if defined(TCCR4B)
+  else if (_timer == 4)
+    TCCR4B = (TCCR4B & andMask) | _prescalerIndex;   //prescalarbits;
+#endif
+
+#if defined(TCCR5B)
+  else if (_timer == 5)
+    TCCR5B = (TCCR5B & andMask) | _prescalerIndex;   //prescalarbits;
+#endif
+}
+
+#endif

--- a/src/libs/TimerInterrupt/TimerInterrupt.h
+++ b/src/libs/TimerInterrupt/TimerInterrupt.h
@@ -1,0 +1,628 @@
+/****************************************************************************************************************************
+   TimerInterrupt.h
+   For Arduino boards (UNO, Nano, Mega, etc. )
+   Written by Khoi Hoang
+
+   Built by Khoi Hoang https://github.com/khoih-prog/TimerInterrupt
+   Licensed under MIT license
+   Version: 1.0.2
+
+   TCNTx - Timer/Counter Register. The actual timer value is stored here.
+   OCRx - Output Compare Register
+   ICRx - Input Capture Register (only for 16bit timer)
+   TIMSKx - Timer/Counter Interrupt Mask Register. To enable/disable timer interrupts.
+   TIFRx - Timer/Counter Interrupt Flag Register. Indicates a pending timer interrupt.
+
+   Now with we can use these new 16 ISR-based timers, while consuming only 1 hwarware Timer.
+   Their independently-selected, maximum interval is practically unlimited (limited only by unsigned long miliseconds)
+   The accuracy is nearly perfect compared to software timers. The most important feature is they're ISR-based timers
+   Therefore, their executions are not blocked by bad-behaving functions / tasks.
+   This important feature is absolutely necessary for mission-critical tasks.
+
+   Version Modified By   Date      Comments
+   ------- -----------  ---------- -----------
+    1.0.0   K Hoang      13/11/2019 Initial coding
+    1.0.1   K Hoang      16/11/2019 Add long timer feature, clean up, higher accuracy
+    1.0.2   K Hoang      28/11/2019 Permit up to 16 super-long-time, super-accurate ISR-based timers to avoid being blocked
+****************************************************************************************************************************/
+
+#ifndef TimerInterrupt_h
+#define TimerInterrupt_h
+
+#ifndef TIMER_INTERRUPT_DEBUG
+#define TIMER_INTERRUPT_DEBUG      0
+#endif
+
+#if !defined(ESP32)
+
+#include <avr/interrupt.h>
+#include <avr/pgmspace.h>
+#include "Arduino.h"
+#include "pins_arduino.h"
+
+#define MAX_COUNT_8BIT            255
+#define MAX_COUNT_16BIT           65535
+
+#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega128__)
+#define TCCR2A TCCR2
+#define TCCR2B TCCR2
+#define COM2A1 COM21
+#define COM2A0 COM20
+#define OCR2A OCR2
+#define TIMSK2 TIMSK
+#define OCIE2A OCIE2
+#define TIMER2_COMPA_vect TIMER2_COMP_vect
+#define TIMSK1 TIMSK
+#endif
+
+typedef void (*timer_callback)(void);
+typedef void (*timer_callback_p)(void *);
+
+enum
+{
+  HW_TIMER_0 = 0,
+  HW_TIMER_1,
+  HW_TIMER_2,
+  HW_TIMER_3,
+  HW_TIMER_4,
+  HW_TIMER_5,
+  NUM_HW_TIMERS
+};
+
+enum
+{
+  NO_CLOCK_SOURCE = 0,
+  NO_PRESCALER,
+  PRESCALER_8,
+  PRESCALER_64,
+  PRESCALER_256,
+  PRESCALER_1024,
+  NUM_ITEMS
+};
+
+enum
+{
+  T2_NO_CLOCK_SOURCE = 0,
+  T2_NO_PRESCALER,
+  T2_PRESCALER_8,
+  T2_PRESCALER_32,
+  T2_PRESCALER_64,
+  T2_PRESCALER_128,
+  T2_PRESCALER_256,
+  T2_PRESCALER_1024,
+  T2_NUM_ITEMS
+};
+
+const unsigned int prescalerDiv   [NUM_ITEMS]     = { 1, 1, 8, 64, 256, 1024 };
+const unsigned int prescalerDivT2 [T2_NUM_ITEMS]  = { 1, 1, 8, 32,  64,  128, 256, 1024 };
+
+class TimerInterrupt
+{
+  private:
+
+    bool            _timerDone;
+    int8_t          _timer;
+    unsigned int    _prescalerIndex;
+    uint32_t        _OCRValue;
+    uint32_t        _OCRValueRemaining;
+    volatile long   _toggle_count;
+    double           _frequency;
+
+    void*           _callback;        // pointer to the callback function
+    void*           _params;          // function parameter
+
+    void set_OCR(void);
+
+  public:
+
+    TimerInterrupt()
+    {
+      _timer = -1;
+      _frequency = 0;
+      _callback = NULL;
+      _params = NULL;
+    };
+
+    TimerInterrupt(uint8_t timerNo)
+    {
+      _timer = timerNo;
+      _frequency = 0;
+      _callback = NULL;
+      _params = NULL;
+    };
+
+    void callback() __attribute__((always_inline))
+    {
+      if (_callback != NULL)
+      {
+        if (_params != NULL)
+          (*(timer_callback_p)_callback)(_params);
+        else
+          (*(timer_callback)_callback)();
+      }
+    }
+
+    void init(int8_t timer);
+
+    void init()
+    {
+      init(_timer);
+    };
+
+    // frequency (in hertz) and duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    bool setFrequency(float frequency, timer_callback_p callback, /* void* */ uint32_t params, unsigned long duration = 0);
+
+    // frequency (in hertz) and duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    bool setFrequency(float frequency, timer_callback callback, unsigned long duration)
+    {
+      return setFrequency(frequency, reinterpret_cast<timer_callback_p>(callback), /*NULL*/ 0, duration);
+    }
+
+    // interval (in ms) and duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    template<typename TArg>
+    bool setInterval(unsigned long interval, void (*callback)(TArg), TArg params, unsigned long duration = 0)
+    {
+      static_assert(sizeof(TArg) <= sizeof(uint32_t), "setInterval() callback argument size must be <= 4 bytes");
+      return setFrequency((float) (1000.0f / interval), reinterpret_cast<timer_callback_p>(callback), (uint32_t) params, duration);
+    }
+
+    // interval (in ms) and duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    bool setInterval(unsigned long interval, timer_callback callback, unsigned long duration)
+    {
+      return setFrequency((float) (1000.0f / interval), reinterpret_cast<timer_callback_p>(callback), /*NULL*/ 0, duration);
+    }
+
+    template<typename TArg>
+    bool attachInterrupt(float frequency, void (*callback)(TArg), TArg params, unsigned long duration = 0)
+    {
+      static_assert(sizeof(TArg) <= sizeof(uint32_t), "attachInterrupt() callback argument size must be <= 4 bytes");
+      return setFrequency(frequency, reinterpret_cast<timer_callback_p>(callback), (uint32_t) params, duration);
+    }
+
+    bool attachInterrupt(float frequency, timer_callback callback, unsigned long duration)
+    {
+      return setFrequency(frequency, reinterpret_cast<timer_callback_p>(callback), /*NULL*/ 0, duration);
+    }
+
+    // Interval (in ms) and duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    template<typename TArg>
+    bool attachInterruptInterval(float interval, void (*callback)(TArg), TArg params, unsigned long duration = 0)
+    {
+#if (TIMER_INTERRUPT_DEBUG > 2)
+      Serial.println("attachIntr: size is " +String(sizeof(TArg)));
+#endif
+
+      static_assert(sizeof(TArg) <= sizeof(uint32_t), "attachInterruptInterval() callback argument size must be <= 4 bytes");
+#if (TIMER_INTERRUPT_DEBUG > 2)
+      Serial.println("attachIntr: calling setFreq(" + String(1000.0f/interval,1)+")");
+#endif
+      return setFrequency( (float) ( 1000.0f / interval), reinterpret_cast<timer_callback_p>(callback), (uint32_t) params, duration);
+    }
+
+    // Interval (in ms) and duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    bool attachInterruptInterval(unsigned long interval, timer_callback callback, unsigned long duration = 0)
+    {
+      return setFrequency( (float) ( 1000.0f / interval), reinterpret_cast<timer_callback_p> (callback), /*NULL*/ 0, duration);
+    }
+
+    void detachInterrupt();
+
+    void disableTimer(void)
+    {
+      detachInterrupt();
+    }
+
+    // Duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    void reattachInterrupt(unsigned long duration = 0);
+
+    // Duration (in milliseconds). Duration = 0 or not specified => run indefinitely
+    void enableTimer(unsigned long duration = 0) __attribute__((always_inline))
+    {
+      reattachInterrupt(duration);
+    }
+
+    // Just stop clock source, still keep the count
+    void pauseTimer(void);
+
+    // Just reconnect clock source, continue from the current count
+    void resumeTimer(void);
+
+    // Just stop clock source, clear the count
+    void stopTimer(void)
+    {
+      detachInterrupt();
+    }
+
+    // Just reconnect clock source, start current count from 0
+    void restartTimer(unsigned long duration = 0)
+    {
+      reattachInterrupt(duration);
+    }
+
+    int8_t getTimer() __attribute__((always_inline))
+    {
+      return _timer;
+    };
+
+    volatile long getCount() __attribute__((always_inline))
+    {
+      return _toggle_count;
+    };
+
+    void setCount(long countInput) __attribute__((always_inline))
+    {
+      //cli();//stop interrupts
+      //noInterrupts();
+
+      _toggle_count = countInput;
+
+      //sei();//enable interrupts
+      //interrupts();
+    };
+
+    volatile long get_OCRValue() __attribute__((always_inline))
+    {
+      return _OCRValue;
+    };
+
+    volatile long get_OCRValueRemaining() __attribute__((always_inline))
+    {
+      return _OCRValueRemaining;
+    };
+
+    void adjust_OCRValue() //__attribute__((always_inline))
+    {
+      //cli();//stop interrupts
+      noInterrupts();
+
+      if (_timer != 2)
+        _OCRValueRemaining -= min(MAX_COUNT_16BIT, _OCRValueRemaining);
+      else
+        _OCRValueRemaining -= min(MAX_COUNT_8BIT, _OCRValueRemaining);
+
+      if (_OCRValueRemaining <= 0)
+      {
+        // Reset value for next cycle
+        _OCRValueRemaining = _OCRValue;
+        _timerDone = true;
+      }
+      else
+        _timerDone = false;
+
+      //sei();//enable interrupts
+      interrupts();
+    };
+
+    void reload_OCRValue() //__attribute__((always_inline))
+    {
+      //cli();//stop interrupts
+      noInterrupts();
+
+      // Reset value for next cycle, have to deduct the value already loaded to OCR register
+
+      if (_timer != 2)
+        _OCRValueRemaining = _OCRValue - min(MAX_COUNT_16BIT, _OCRValueRemaining);
+      else
+        _OCRValueRemaining = _OCRValue - min(MAX_COUNT_8BIT, _OCRValueRemaining);
+
+      _timerDone = false;
+
+      //sei();//enable interrupts
+      interrupts();
+    };
+
+    bool checkTimerDone(void) //__attribute__((always_inline))
+    {
+      return _timerDone;
+    };
+
+}; // class TimerInterrupt
+
+#if USE_TIMER_1
+#ifndef TIMER1_INSTANTIATED
+// To force pre-instatiate only once
+#define TIMER1_INSTANTIATED
+TimerInterrupt ITimer1(HW_TIMER_1);
+
+// Timer0 is used for micros(), millis(), delay(), etc and can't be used
+// Pre-instatiate
+
+ISR(TIMER1_COMPA_vect)
+{
+  long countLocal = ITimer1.getCount();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("T1 count = " + String(countLocal) + ", _OCRValueRemaining = " + String(ITimer1.get_OCRValueRemaining()) );
+#endif
+
+  if (ITimer1.getTimer() == 1)
+  {
+    if (countLocal != 0)
+    {
+      if (ITimer1.checkTimerDone())
+      {
+#if (TIMER_INTERRUPT_DEBUG > 1)
+        Serial.println("T1 callback, _OCRValueRemaining = " + String(ITimer1.get_OCRValueRemaining()) + ", millis = " + String(millis()) );
+#endif
+        ITimer1.callback();
+
+        // To reload _OCRValueRemaining as well as _OCR register to MAX_COUNT_16BIT if _OCRValueRemaining > MAX_COUNT_16BIT
+        ITimer1.reload_OCRValue();
+
+        if (countLocal > 0)
+          ITimer1.setCount(countLocal - 1);
+      }
+      else
+      {
+        //Deduct _OCRValue by min(MAX_COUNT_16BIT, _OCRValue)
+        // If _OCRValue == 0, flag _timerDone for next cycle
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T1 before _OCRValueRemaining = " + String(ITimer1.get_OCRValueRemaining()) );
+#endif
+
+        // If last one (_OCRValueRemaining < MAX_COUNT_16BIT) => load _OCR register _OCRValueRemaining
+        ITimer1.adjust_OCRValue();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T1 after _OCRValueRemaining = " + String(ITimer1.get_OCRValueRemaining()) );
+#endif
+      }
+    }
+    else
+    {
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T1 done");
+#endif
+      ITimer1.detachInterrupt();
+    }
+  }
+}
+
+#endif  //#ifndef TIMER1_INSTANTIATED
+#endif    //#if USE_TIMER_1
+
+#if USE_TIMER_2
+#ifndef TIMER2_INSTANTIATED
+#define TIMER2_INSTANTIATED
+TimerInterrupt ITimer2(HW_TIMER_2);
+
+ISR(TIMER2_COMPA_vect)
+{
+  long countLocal = ITimer2.getCount();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("T2 count = " + String(countLocal) + ", _OCRValueRemaining = " + String(ITimer2.get_OCRValueRemaining()) );
+#endif
+
+  if (ITimer2.getTimer() == 2)
+  {
+    if (countLocal != 0)
+    {
+      if (ITimer2.checkTimerDone())
+      {
+#if (TIMER_INTERRUPT_DEBUG > 1)
+        Serial.println("T2 callback, _OCRValueRemaining = " + String(ITimer2.get_OCRValueRemaining()) + ", millis = " + String(millis()) );
+#endif
+        ITimer2.callback();
+        // To reload _OCRValue
+        ITimer2.reload_OCRValue();
+
+        if (countLocal > 0)
+          ITimer2.setCount(countLocal - 1);
+
+      }
+      else
+      {
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T2 before _OCRValueRemaining = " + String(ITimer2.get_OCRValueRemaining()) );
+#endif
+
+        //Deduct _OCRValue by min(MAX_COUNT_8BIT, _OCRValue)
+        // If _OCRValue == 0, flag _timerDone for next cycle
+        ITimer2.adjust_OCRValue();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T2 after _OCRValueRemaining = " + String(ITimer2.get_OCRValueRemaining()) );
+#endif
+      }
+    }
+    else
+    {
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T2 done");
+#endif
+      ITimer2.detachInterrupt();
+    }
+  }
+}
+#endif  //#ifndef TIMER2_INSTANTIATED
+#endif    //#if USE_TIMER_2
+
+#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega128__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__)
+
+// Pre-instatiate
+#if USE_TIMER_3
+#ifndef TIMER3_INSTANTIATED
+// To force pre-instatiate only once
+#define TIMER3_INSTANTIATED
+TimerInterrupt ITimer3(HW_TIMER_3);
+
+ISR(TIMER3_COMPA_vect)
+{
+  long countLocal = ITimer3.getCount();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("T3 count = " + String(countLocal) + ", _OCRValueRemaining = " + String(ITimer3.get_OCRValueRemaining()) );
+#endif
+
+  if (ITimer3.getTimer() == 3)
+  {
+    if (countLocal != 0)
+    {
+      if (ITimer3.checkTimerDone())
+      {
+#if (TIMER_INTERRUPT_DEBUG > 1)
+        Serial.println("T3 callback, _OCRValueRemaining = " + String(ITimer3.get_OCRValueRemaining()) + ", millis = " + String(millis()) );
+#endif
+        ITimer3.callback();
+
+        // To reload _OCRValueRemaining as well as _OCR register to MAX_COUNT_16BIT
+        ITimer3.reload_OCRValue();
+
+        if (countLocal > 0)
+          ITimer3.setCount(countLocal - 1);
+      }
+      else
+      {
+        //Deduct _OCRValue by min(MAX_COUNT_16BIT, _OCRValue)
+        // If _OCRValue == 0, flag _timerDone for next cycle
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T3 before _OCRValueRemaining = " + String(ITimer3.get_OCRValueRemaining()) );
+#endif
+
+        // If last one (_OCRValueRemaining < MAX_COUNT_16BIT) => load _OCR register _OCRValueRemaining
+        ITimer3.adjust_OCRValue();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T3 after _OCRValueRemaining = " + String(ITimer3.get_OCRValueRemaining()) );
+#endif
+      }
+    }
+    else
+    {
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T3 done");
+#endif
+      ITimer3.detachInterrupt();
+    }
+  }
+}
+
+#endif  //#ifndef TIMER3_INSTANTIATED
+#endif    //#if USE_TIMER_3
+
+#if USE_TIMER_4
+#ifndef TIMER4_INSTANTIATED
+// To force pre-instatiate only once
+#define TIMER4_INSTANTIATED
+TimerInterrupt ITimer4(HW_TIMER_4);
+
+ISR(TIMER4_COMPA_vect)
+{
+  long countLocal = ITimer4.getCount();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("T4 count = " + String(countLocal) + ", _OCRValueRemaining = " + String(ITimer4.get_OCRValueRemaining()) );
+#endif
+
+  if (ITimer4.getTimer() == 4)
+  {
+    if (countLocal != 0)
+    {
+      if (ITimer4.checkTimerDone())
+      {
+#if (TIMER_INTERRUPT_DEBUG > 1)
+        Serial.println("T4 callback, _OCRValueRemaining = " + String(ITimer4.get_OCRValueRemaining()) + ", millis = " + String(millis()) );
+#endif
+        ITimer4.callback();
+
+        // To reload _OCRValueRemaining as well as _OCR register to MAX_COUNT_16BIT
+        ITimer4.reload_OCRValue();
+
+        if (countLocal > 0)
+          ITimer4.setCount(countLocal - 1);
+      }
+      else
+      {
+        //Deduct _OCRValue by min(MAX_COUNT_16BIT, _OCRValue)
+        // If _OCRValue == 0, flag _timerDone for next cycle
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T4 before _OCRValueRemaining = " + String(ITimer4.get_OCRValueRemaining()) );
+#endif
+
+        // If last one (_OCRValueRemaining < MAX_COUNT_16BIT) => load _OCR register _OCRValueRemaining
+        ITimer4.adjust_OCRValue();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T4 after _OCRValueRemaining = " + String(ITimer4.get_OCRValueRemaining()) );
+#endif
+      }
+    }
+    else
+    {
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T4 done");
+#endif
+      ITimer4.detachInterrupt();
+    }
+  }
+}
+
+
+#endif  //#ifndef TIMER4_INSTANTIATED
+#endif    //#if USE_TIMER_4
+
+#if USE_TIMER_5
+#ifndef TIMER5_INSTANTIATED
+// To force pre-instatiate only once
+#define TIMER5_INSTANTIATED
+TimerInterrupt ITimer5(HW_TIMER_5);
+
+ISR(TIMER5_COMPA_vect)
+{
+  long countLocal = ITimer5.getCount();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+  Serial.println("T5 count = " + String(countLocal) + ", _OCRValueRemaining = " + String(ITimer5.get_OCRValueRemaining()) );
+#endif
+
+  if (ITimer5.getTimer() == 5)
+  {
+    if (countLocal != 0)
+    {
+      if (ITimer5.checkTimerDone())
+      {
+#if (TIMER_INTERRUPT_DEBUG > 1)
+        Serial.println("T5 callback, _OCRValueRemaining = " + String(ITimer5.get_OCRValueRemaining()) + ", millis = " + String(millis()) );
+#endif
+        ITimer5.callback();
+
+        // To reload _OCRValueRemaining as well as _OCR register to MAX_COUNT_16BIT
+        ITimer5.reload_OCRValue();
+
+        if (countLocal > 0)
+          ITimer5.setCount(countLocal - 1);
+      }
+      else
+      {
+        //Deduct _OCRValue by min(MAX_COUNT_16BIT, _OCRValue)
+        // If _OCRValue == 0, flag _timerDone for next cycle
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T5 before _OCRValueRemaining = " + String(ITimer5.get_OCRValueRemaining()) );
+#endif
+
+        // If last one (_OCRValueRemaining < MAX_COUNT_16BIT) => load _OCR register _OCRValueRemaining
+        ITimer5.adjust_OCRValue();
+
+#if (TIMER_INTERRUPT_DEBUG > 2)
+        Serial.println("T5 after _OCRValueRemaining = " + String(ITimer5.get_OCRValueRemaining()) );
+#endif
+      }
+    }
+    else
+    {
+#if (TIMER_INTERRUPT_DEBUG > 0)
+      Serial.println("T5 done");
+#endif
+      ITimer5.detachInterrupt();
+    }
+  }
+}
+
+#endif  //#ifndef TIMER5_INSTANTIATED
+#endif    //#if USE_TIMER_5
+#endif      //#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega128__)
+
+#endif      //#ifndef TimerInterrupt_h
+
+#endif


### PR DESCRIPTION
- Ported some bug fix code from the LCD branch (e.g. track on boot)
- Potentially some DEC guide issues were fixed.
- Inadvertently removed some default #defines. Put them back.
- Allow new stepper lib to be enabled by via #define
- Added ability to detect new firmware flashed
- Removed/disabled parking offset variable and commands, use home offset instead
- Fixed Park command to slew home and then to the parking position (home offset)
- Re-integrated old stepper library
- Sped up ESP32 stepper code.
