### PR TITLE
Peg AVR platform to 4.2.0 as 5.0.0 is broken and can't upload

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.13.1 - Updates**
+- Fix for uploading on AVR platform. Apparently atmelavr@5.0.0 (current stable) is broken and can't upload, so we peg it at atmelavr@4.2.0 for now.
+
 **V1.13.0 - Updates**
 NOTE: Make sure to do a Factory Reset when using this version.
 - Sped up ESP32 stepper code.

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.0"
+#define VERSION "V1.13.1"

--- a/platformio.ini
+++ b/platformio.ini
@@ -74,7 +74,10 @@ debug_load_mode = always
 
 [env:ramps]
 extends = common_embedded
-platform = atmelavr
+; atmelavr@5.0.0 is currently broken (can't upload, gets stk500v2_recv errors)
+; but https://github.com/platformio/platform-atmelavr.git @ d9d2738b
+; works, even though there are no commits since the 5.0.0 release?!?!?!?!?!?!
+platform = atmelavr@4.2.0
 board = ATmega2560
 upload_protocol = wiring
 build_flags =


### PR DESCRIPTION
`atmelavr@5.0.0` is currently broken (can't upload, gets `stk500v2_recv` errors) but https://github.com/platformio/platform-atmelavr.git @ d9d2738b works, even though there are no commits since the 5.0.0 release?!?!?!?!?!?! Very strange.