### PR TITLE
V1.13.6 - Autohoming Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+**V1.13.6 - Updates**
+- Added ability to query homing status during autohoming (:XGAH#)
+- Fixed a bug in autohoming that would make it fail if it did not pass over the sensor during the initial 30 degree search
+- Added debounce function to detection of sensor state changes. There were single false sensor trigger spikes that incorrectly detected sensor transitions.
+
 **V1.13.5 - Updates**
 - Updated ThingPulse OLED library to 4.6.1
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.5"
+#define VERSION "V1.13.6"

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -714,7 +714,7 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //      Description:
 //        Get auto homing state
 //      Information:
-//        Get the current state of RA and DEC Autohoming status. Only valid when at least 
+//        Get the current state of RA and DEC Autohoming status. Only valid when at least
 //        one Hall sensor based autohoming axis is enabled.
 //      Returns:
 //        "rastate|decstate#" if either axis is enabled

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -710,6 +710,16 @@ bool gpsAqcuisitionComplete(int &indicator);  // defined in c72_menuHA_GPS.hpp
 //        "1#" if succsessful
 //        "0#" if there is no Digital Level
 //
+// :XGAH#
+//      Description:
+//        Get auto homing state
+//      Information:
+//        Get the current state of RA and DEC Autohoming status. Only valid when at least 
+//        one Hall sensor based autohoming axis is enabled.
+//      Returns:
+//        "rastate|decstate#" if either axis is enabled
+//        "|" if no autohoming is enabled
+//
 // :XGB#
 //      Description:
 //        Get Backlash correction steps
@@ -1579,7 +1589,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         int distance = RA_HOMING_SENSOR_SEARCH_DEGREES;
         if (inCmd.length() > 3)
         {
-            distance = clamp((int) inCmd.substring(3).toInt(), 15, 75);
+            distance = clamp((int) inCmd.substring(3).toInt(), 5, 75);
             LOG(DEBUG_MEADE, "[MEADE]: RA AutoHome by %dh", distance);
         }
 
@@ -1600,7 +1610,7 @@ String MeadeCommandProcessor::handleMeadeMovement(String inCmd)
         int decDistance = DEC_HOMING_SENSOR_SEARCH_DEGREES;
         if (inCmd.length() > 3)
         {
-            decDistance = clamp((int) inCmd.substring(3).toInt(), 15, 75);
+            decDistance = clamp((int) inCmd.substring(3).toInt(), 5, 75);
             LOG(DEBUG_MEADE, "[MEADE]: DEC AutoHome by %dh", decDistance);
         }
 
@@ -1746,6 +1756,10 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
         else if (inCmd[1] == 'B')  // :XGB#
         {
             return String(_mount->getBacklashCorrection()) + "#";
+        }
+        else if ((inCmd[1] == 'A') && (inCmd.length() > 2) && (inCmd[2] == 'H'))  // :XGAH#
+        {
+            return _mount->getAutoHomingStates() + "#";
         }
         else if (inCmd[1] == 'C')  // :XGCn.nn*m.mm#
         {

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -339,7 +339,7 @@ void Mount::configureAZStepper(byte pin1, byte pin2, int maxSpeed, int maxAccele
     #ifdef NEW_STEPPER_LIB
     _stepperAZ = new StepperAzSlew(AccelStepper::DRIVER, pin1, pin2);
     #else
-    _stepperAZ = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    _stepperAZ    = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
     #endif
     _stepperAZ->setMaxSpeed(maxSpeed);
     _stepperAZ->setAcceleration(maxAcceleration);
@@ -357,7 +357,7 @@ void Mount::configureALTStepper(byte pin1, byte pin2, int maxSpeed, int maxAccel
     #ifdef NEW_STEPPER_LIB
     _stepperALT = new StepperAltSlew(AccelStepper::DRIVER, pin1, pin2);
     #else
-    _stepperALT = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    _stepperALT   = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
     #endif
     _stepperALT->setMaxSpeed(maxSpeed);
     _stepperALT->setAcceleration(maxAcceleration);
@@ -715,7 +715,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
     _driverALT->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected      = connectToDriver(_driverALT, "ALT");
+    UART_Rx_connected = connectToDriver(_driverALT, "ALT");
     if (!UART_Rx_connected)
     {
         digitalWrite(ALT_EN_PIN,
@@ -806,7 +806,7 @@ void Mount::configureFocusDriver(
     _driverFocus->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected      = connectToDriver(_driverFocus, "Focus");
+    UART_Rx_connected = connectToDriver(_driverFocus, "Focus");
     if (!UART_Rx_connected)
     {
         digitalWrite(FOCUS_EN_PIN,

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -339,7 +339,7 @@ void Mount::configureAZStepper(byte pin1, byte pin2, int maxSpeed, int maxAccele
     #ifdef NEW_STEPPER_LIB
     _stepperAZ = new StepperAzSlew(AccelStepper::DRIVER, pin1, pin2);
     #else
-    _stepperAZ    = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    _stepperAZ = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
     #endif
     _stepperAZ->setMaxSpeed(maxSpeed);
     _stepperAZ->setAcceleration(maxAcceleration);
@@ -357,7 +357,7 @@ void Mount::configureALTStepper(byte pin1, byte pin2, int maxSpeed, int maxAccel
     #ifdef NEW_STEPPER_LIB
     _stepperALT = new StepperAltSlew(AccelStepper::DRIVER, pin1, pin2);
     #else
-    _stepperALT   = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    _stepperALT = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
     #endif
     _stepperALT->setMaxSpeed(maxSpeed);
     _stepperALT->setAcceleration(maxAcceleration);
@@ -715,7 +715,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
     _driverALT->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected = connectToDriver(_driverALT, "ALT");
+    UART_Rx_connected      = connectToDriver(_driverALT, "ALT");
     if (!UART_Rx_connected)
     {
         digitalWrite(ALT_EN_PIN,
@@ -806,7 +806,7 @@ void Mount::configureFocusDriver(
     _driverFocus->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected = connectToDriver(_driverFocus, "Focus");
+    UART_Rx_connected      = connectToDriver(_driverFocus, "Focus");
     if (!UART_Rx_connected)
     {
         digitalWrite(FOCUS_EN_PIN,
@@ -2631,6 +2631,33 @@ void Mount::processHomingProgress()
     #endif
 }
 #endif
+
+String Mount::getAutoHomingStates() const
+{
+    String state;
+#if USE_HALL_SENSOR_RA_AUTOHOME == 1
+    if ((_raHoming != nullptr) && (!_raHoming->isIdleOrComplete()))
+    {
+        state += _raHoming->getHomingState(_raHoming->getHomingState());
+    }
+    else
+    {
+        state += _raHoming->getLastResult();
+    }
+#endif
+    state += "|";
+#if USE_HALL_SENSOR_DEC_AUTOHOME == 1
+    if ((_decHoming != nullptr) && (!_decHoming->isIdleOrComplete()))
+    {
+        state += _decHoming->getHomingState(_decHoming->getHomingState());
+    }
+    else
+    {
+        state += _decHoming->getLastResult();
+    }
+#endif
+    return state;
+}
 
 #if (USE_RA_END_SWITCH == 1 || USE_DEC_END_SWITCH == 1)
 /////////////////////////////////

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -447,6 +447,7 @@ class Mount
     bool findHomeByHallSensor(StepperAxis axis, int initialDirection, int searchDistance);
     void processHomingProgress();
 #endif
+    String getAutoHomingStates() const;
 
     void setHomingOffset(StepperAxis axis, long offset);
     long getHomingOffset(StepperAxis axis);


### PR DESCRIPTION
- Added ability to query homing status during autohoming (:XGAH#)
- Fixed a bug in autohoming that would make it fail if it did not pass over the sensor during the initial 30 degree search
- Added debounce function to detection of sensor state changes. There were single false sensor trigger spikes that incorrectly detected sensor transitions.