### PR TITLE
Az Alt homing support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.13.7 - Updates**
+- Added ability to keep track of AZ and ALT positions across sessions, set their home positions and slew back to their home positions.
+
 **V1.13.6 - Updates**
 - Added ability to query homing status during autohoming (:XGAH#)
 - Fixed a bug in autohoming that would make it fail if it did not pass over the sensor during the initial 30 degree search

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.6"
+#define VERSION "V1.13.7"

--- a/src/EPROMStore.cpp
+++ b/src/EPROMStore.cpp
@@ -139,6 +139,8 @@ void EEPROMStore::displayContents()
     LOG(DEBUG_INFO, "[EEPROM]: Stored Pitch Calibration Angle: %f", getPitchCalibrationAngle());
     LOG(DEBUG_INFO, "[EEPROM]: Stored Roll Calibration Angle: %f", getRollCalibrationAngle());
     LOG(DEBUG_INFO, "[EEPROM]: Stored RA Homing Offset: %l", getRAHomingOffset());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored AZ Position: %l", getAZPosition());
+    LOG(DEBUG_INFO, "[EEPROM]: Stored ALT Position: %l", getALTPosition());
     LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Homing Offset : %l", getDECHomingOffset());
     LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Lower Limit: %l", getDECLowerLimit());
     LOG(DEBUG_INFO, "[EEPROM]: Stored DEC Upper Limit: %l", getDECUpperLimit());
@@ -792,5 +794,61 @@ void EEPROMStore::storeDECHomingOffset(int32_t decHomingOffset)
 
     updateInt32(DEC_HOMING_OFFSET_ADDR, decHomingOffset);
     updateFlagsExtended(DEC_HOMING_MARKER_FLAG);
+    commit();  // Complete the transaction
+}
+
+// Get the current AZ position from home (in steps)
+int32_t EEPROMStore::getAZPosition()
+{
+    int32_t azPosition(0);  // microsteps (slew)
+
+    if (isPresentExtended(AZ_POSITION_MARKER_FLAG))
+    {
+        azPosition = readInt32(AZ_POSITION_ADDR);
+        LOG(DEBUG_EEPROM, "[EEPROM]: AZ position read as %l", azPosition);
+    }
+    else
+    {
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored values for AZ position");
+    }
+
+    return azPosition;  // microsteps (slew)
+}
+
+// Store the current AZ position (in steps)
+void EEPROMStore::storeAZPosition(int32_t azPosition)
+{
+    LOG(DEBUG_EEPROM, "[EEPROM]: Write: Updating AZ Position to %l", azPosition);
+
+    updateInt32(AZ_POSITION_ADDR, azPosition);
+    updateFlagsExtended(AZ_POSITION_MARKER_FLAG);
+    commit();  // Complete the transaction
+}
+
+// Get the current ALT position from home (in steps)
+int32_t EEPROMStore::getALTPosition()
+{
+    int32_t altPosition(0);  // microsteps (slew)
+
+    if (isPresentExtended(ALT_POSITION_MARKER_FLAG))
+    {
+        altPosition = readInt32(ALT_POSITION_ADDR);
+        LOG(DEBUG_EEPROM, "[EEPROM]: ALT position read as %l", altPosition);
+    }
+    else
+    {
+        LOG(DEBUG_EEPROM, "[EEPROM]: No stored values for ALT position");
+    }
+
+    return altPosition;  // microsteps (slew)
+}
+
+// Store the current ALT position in steps
+void EEPROMStore::storeALTPosition(int32_t altPosition)
+{
+    LOG(DEBUG_EEPROM, "[EEPROM]: Write: Updating ALT Position to %l", altPosition);
+
+    updateInt32(ALT_POSITION_ADDR, altPosition);
+    updateFlagsExtended(ALT_POSITION_MARKER_FLAG);
     commit();  // Complete the transaction
 }

--- a/src/EPROMStore.hpp
+++ b/src/EPROMStore.hpp
@@ -205,7 +205,7 @@ class EEPROMStore
         _AZ_POSITION_ADDR_1,
         _AZ_POSITION_ADDR_2,
         _AZ_POSITION_ADDR_3,
-         ALT_POSITION_ADDR = 62,
+        ALT_POSITION_ADDR = 62,
         _ALT_POSITION_ADDR_1,
         _ALT_POSITION_ADDR_2,
         _ALT_POSITION_ADDR_3,

--- a/src/EPROMStore.hpp
+++ b/src/EPROMStore.hpp
@@ -62,6 +62,12 @@ class EEPROMStore
     static int16_t getLastFlashedVersion();
     static void storeLastFlashedVersion(int16_t lastVersion);
 
+    static int32_t getAZPosition();
+    static void storeAZPosition(int32_t azPosition);
+
+    static int32_t getALTPosition();
+    static void storeALTPosition(int32_t altPosition);
+
   private:
     /////////////////////////////////
     //
@@ -85,7 +91,9 @@ class EEPROMStore
     // If Location 5 is 0xCF, then an extended 16-bit flag is stored in 21/22 and
     // indicates the additional fields that have been stored: 0000 0000 0000 0000
     //                                                        ^^^^ ^^^^ ^^^^ ^^^^
-    //                                                                  |||| ||||
+    //                                                               || |||| ||||
+    //                           ALT position (62-65) ---------------+| |||| ||||
+    //                            AZ Position (58-61) ----------------+ |||| ||||
     //                   Last flashed version (56-57) ------------------+||| ||||
     //                       DEC Homing Offet (52-55) -------------------+|| ||||
     //      DEC Steps/deg, normalized to 256MS (48-51) -------------------+| ||||
@@ -127,6 +135,8 @@ class EEPROMStore
         DEC_NORM_STEPS_MARKER_FLAG = 0x0020,
         DEC_HOMING_MARKER_FLAG     = 0x0040,
         LAST_FLASHED_MARKER_FLAG   = 0x0080,
+        AZ_POSITION_MARKER_FLAG    = 0x0100,
+        ALT_POSITION_MARKER_FLAG   = 0x0200,
     };
 
     // These are the offsets to each item stored in the EEPROM
@@ -191,7 +201,15 @@ class EEPROMStore
         _DEC_HOMING_OFFSET_ADDR_3,  // Int32
         LAST_FLASHED_VERSION = 56,
         _LAST_FLASHED_VERSION_1,
-        STORE_SIZE = 64
+        AZ_POSITION_ADDR = 58,
+        _AZ_POSITION_ADDR_1,
+        _AZ_POSITION_ADDR_2,
+        _AZ_POSITION_ADDR_3,
+         ALT_POSITION_ADDR = 62,
+        _ALT_POSITION_ADDR_1,
+        _ALT_POSITION_ADDR_2,
+        _ALT_POSITION_ADDR_3,
+        STORE_SIZE = 66
     };
 
     // Helper functions

--- a/src/MeadeCommandProcessor.cpp
+++ b/src/MeadeCommandProcessor.cpp
@@ -1819,7 +1819,7 @@ String MeadeCommandProcessor::handleMeadeExtraCommands(String inCmd)
         }
         else if ((inCmd[1] == 'A') && (inCmd.length() > 2) && (inCmd[2] == 'A'))  // :XGAA#
         {
-            int32_t azPos, altPos;
+            long azPos, altPos;
             _mount->getAZALTPositions(azPos, altPos);
             char scratchBuffer[20];
             sprintf(scratchBuffer, "%ld|%ld#", azPos, altPos);

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1819,11 +1819,11 @@ void Mount::setAZALTHome()
 {
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
     _stepperAZ->setCurrentPosition(0);
-    EEPROMStore::setAZPosition(0);
+    EEPROMStore::storeAZPosition(0);
 #endif
 #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
     _stepperALT->setCurrentPosition(0);
-    EEPROMStore::setALTPosition(0);
+    EEPROMStore::storeALTPosition(0);
 #endif
 }
 
@@ -2869,8 +2869,8 @@ void Mount::loop()
         // One of the motors was running last time through the loop, but not anymore, so shutdown the outputs.
         disableAzAltMotors();
         _azAltWasRunning = false;
-        EEPROMStore::setAZPosition(_stepperAZ->currentPosition());
-        EEPROMStore::setALTPosition(_stepperALT->currentPosition());
+        EEPROMStore::storeAZPosition(_stepperAZ->currentPosition());
+        EEPROMStore::storeALTPosition(_stepperALT->currentPosition());
     }
 
     oneIsRunning = false;

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -238,12 +238,12 @@ void Mount::readPersistentData()
     LOG(DEBUG_INFO, "[MOUNT]: EEPROM: DEC limits read as %l -> %l", _decLowerLimit, _decUpperLimit);
 
 #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    int32_t altPos = EEPROMStore::getALTPosition();
+    long altPos = EEPROMStore::getALTPosition();
     _stepperALT->setCurrentPosition(altPos);
 #endif
 
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
-    int32_t azPos = EEPROMStore::getAZPosition();
+    long azPos = EEPROMStore::getAZPosition();
     _stepperAZ->setCurrentPosition(azPos);
 #endif
 

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -1789,7 +1789,7 @@ void Mount::setSpeed(StepperAxis which, float speedDegsPerSec)
 #endif
 }
 
-void Mount::getAZALTPositions(int32_t &azPos, int32_t &altPos)
+void Mount::getAZALTPositions(long &azPos, long &altPos)
 {
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
     azPos = _stepperAZ->currentPosition();

--- a/src/Mount.cpp
+++ b/src/Mount.cpp
@@ -356,7 +356,7 @@ void Mount::configureAZStepper(byte pin1, byte pin2, int maxSpeed, int maxAccele
     #ifdef NEW_STEPPER_LIB
     _stepperAZ = new StepperAzSlew(AccelStepper::DRIVER, pin1, pin2);
     #else
-    _stepperAZ = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    _stepperAZ    = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
     #endif
     _stepperAZ->setMaxSpeed(maxSpeed);
     _stepperAZ->setAcceleration(maxAcceleration);
@@ -374,7 +374,7 @@ void Mount::configureALTStepper(byte pin1, byte pin2, int maxSpeed, int maxAccel
     #ifdef NEW_STEPPER_LIB
     _stepperALT = new StepperAltSlew(AccelStepper::DRIVER, pin1, pin2);
     #else
-    _stepperALT = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    _stepperALT   = new AccelStepper(AccelStepper::DRIVER, pin1, pin2);
     #endif
     _stepperALT->setMaxSpeed(maxSpeed);
     _stepperALT->setAcceleration(maxAcceleration);
@@ -732,7 +732,7 @@ void Mount::configureALTdriver(uint16_t ALT_SW_RX, uint16_t ALT_SW_TX, float rse
     _driverALT->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected      = connectToDriver(_driverALT, "ALT");
+    UART_Rx_connected = connectToDriver(_driverALT, "ALT");
     if (!UART_Rx_connected)
     {
         digitalWrite(ALT_EN_PIN,
@@ -823,7 +823,7 @@ void Mount::configureFocusDriver(
     _driverFocus->pdn_disable(true);
         #if UART_CONNECTION_TEST_TXRX == 1
     bool UART_Rx_connected = false;
-    UART_Rx_connected      = connectToDriver(_driverFocus, "Focus");
+    UART_Rx_connected = connectToDriver(_driverFocus, "Focus");
     if (!UART_Rx_connected)
     {
         digitalWrite(FOCUS_EN_PIN,
@@ -1794,7 +1794,7 @@ void Mount::getAZALTPositions(int32_t &azPos, int32_t &altPos)
 #if (AZ_STEPPER_TYPE != STEPPER_TYPE_NONE)
     azPos = _stepperAZ->currentPosition();
 #else
-    azPos = 0;
+    azPos  = 0;
 #endif
 #if (ALT_STEPPER_TYPE != STEPPER_TYPE_NONE)
     altPos = _stepperALT->currentPosition();

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -303,7 +303,7 @@ class Mount
 
     // Move AZ and ALT motors to their zero position
     void moveAZALTToHome();
-    void getAZALTPositions(int32_t &azPos, int32_t &altPos);
+    void getAZALTPositions(long &azPos, long &altPos);
     void setAZALTHome();
 
     // Various status query functions

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -301,6 +301,11 @@ class Mount
     // Sends the mount to the home position
     void startSlewingToHome();
 
+    // Move AZ and ALT motors to their zero position
+    void moveAZALTToHome();
+    void getAZALTPositions(int32_t & azPos, int32_t &altPos);
+    void setAZALTHome();
+
     // Various status query functions
     bool isSlewingRAorDEC() const;
     bool isSlewingIdle() const;

--- a/src/Mount.hpp
+++ b/src/Mount.hpp
@@ -303,7 +303,7 @@ class Mount
 
     // Move AZ and ALT motors to their zero position
     void moveAZALTToHome();
-    void getAZALTPositions(int32_t & azPos, int32_t &altPos);
+    void getAZALTPositions(int32_t &azPos, int32_t &altPos);
     void setAZALTHome();
 
     // Various status query functions


### PR DESCRIPTION
Added ability set home position of  AZ and ALT axes and to keep track of their positions across sessions and home them at any time.