### PR TITLE
Update avr-interrupt-stepper library to version 0.0.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-**V1.14.7 - Updates**
+**V1.13.8 - Updates**
 - Fixed DEC runaway issue by updating avr-interrupt-stepper library to version 0.0.3
 
 **V1.13.7 - Updates**

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.14.7 - Updates**
+- Fixed DEC runaway issue by updating avr-interrupt-stepper library to version 0.0.3
+
 **V1.13.7 - Updates**
 - Added ability to keep track of AZ and ALT positions across sessions, set their home positions and slew back to their home positions.
 

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.7"
+#define VERSION "V1.13.8"

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,7 +95,7 @@ debug_build_flags =
 lib_deps = 
 	${common.lib_deps}
 	jdolinay/avr-debugger @ 1.2
-	https://github.com/andre-stefanov/avr-interrupt-stepper@0.0.2
+	https://github.com/andre-stefanov/avr-interrupt-stepper@0.0.3
 
 [env:mksgenlv21]
 extends = env:ramps


### PR DESCRIPTION
this version fixes the moveTo integer overflow which resulted in DEC runaway