### PR TITLE
Fix git tag specification in pio lib dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**V1.13.10 - Updates**
+- Fixed dependency specification for git tags
+
 **V1.13.9 - Updates**
 - Added guide logging support.
 - Fixed some Meade documentation errors.

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.9"
+#define VERSION "V1.13.10"

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ lib_deps =
 	arduino-libraries/LiquidCrystal @ ^1.0.7
 	lincomatic/LiquidTWI2@^1.2.7
 	olikraus/U8g2@^2.28.8
-	https://github.com/ClutchplateDude/esp8266-oled-ssd1306@4.6.0
+	https://github.com/ClutchplateDude/esp8266-oled-ssd1306#4.6.0
 
 [env]
 extra_scripts =
@@ -95,7 +95,7 @@ debug_build_flags =
 lib_deps = 
 	${common.lib_deps}
 	jdolinay/avr-debugger @ 1.2
-	https://github.com/andre-stefanov/avr-interrupt-stepper@0.0.4
+	https://github.com/andre-stefanov/avr-interrupt-stepper#0.0.4
 
 [env:mksgenlv21]
 extends = env:ramps


### PR DESCRIPTION
`@` specifiers are not valid for git dependencies (only PlatformIO dependencies). Example 5 here: https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html#repository-git-hg-svn