### PR TITLE
Fix SSD1306 build

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+**V1.13.15 - Updates**
+- Check `INFO_DISPLAY_TYPE` builds in CI
+- Fix `INFO_DISPLAY_TYPE_I2C_SSD1306_128x64` for esp32 builds
+
 **V1.13.14 - Updates**
 - Improved Serial command handling (made it less 'blocking'), which should improve general performance
 - Guide pulses are ignored when tracking is disabled (for example, when at the limits)

--- a/Version.h
+++ b/Version.h
@@ -3,4 +3,4 @@
 // Also, numbers are interpreted as simple numbers.                        _   __   _
 // So 1.8 is actually 1.08, meaning that 1.12 is a later version than 1.8.  \_(..)_/
 
-#define VERSION "V1.13.14"
+#define VERSION "V1.13.15"

--- a/matrix_build.py
+++ b/matrix_build.py
@@ -17,12 +17,16 @@ from matrix_build_parallel import Executor, execute, get_available_executor_idx,
 
 CONTINUE_ON_ERROR = False
 
-BOARDS = [
+MKS_GENL_BOARDS = [
     "mksgenlv21",
     "mksgenlv2",
     "mksgenlv1",
-    "esp32",
+]
+AVR_BOARDS = MKS_GENL_BOARDS + [
     "ramps",
+]
+BOARDS = AVR_BOARDS + [
+    "esp32",
 ]
 
 STEPPER_TYPES = [
@@ -47,6 +51,11 @@ DISPLAY_TYPES = [
     "DISPLAY_TYPE_LCD_JOY_I2C_SSD1306",
 ]
 
+INFO_DISPLAY_TYPES = [
+    "INFO_DISPLAY_TYPE_NONE",
+    "INFO_DISPLAY_TYPE_I2C_SSD1306_128x64",
+]
+
 BUILD_FLAGS = {
     "CONFIG_VERSION": "1",
     "RA_STEPPER_TYPE": [x for x in STEPPER_TYPES if x != "STEPPER_TYPE_NONE"],
@@ -62,6 +71,7 @@ BUILD_FLAGS = {
     "FOCUS_STEPPER_TYPE": STEPPER_TYPES,
     "FOCUS_DRIVER_TYPE": DRIVER_TYPES,
     "DISPLAY_TYPE": DISPLAY_TYPES,
+    "INFO_DISPLAY_TYPE": INFO_DISPLAY_TYPES,
     "TEST_VERIFY_MODE": BOOLEAN_VALUES,
     "DEBUG_LEVEL": ["DEBUG_NONE", "DEBUG_ANY"],
     "RA_MOTOR_CURRENT_RATING": "1",
@@ -236,6 +246,25 @@ def set_support_constraints(problem):
     problem.addConstraint(driver_supports_stepper, ["AZ_DRIVER_TYPE", "AZ_STEPPER_TYPE"])
     problem.addConstraint(driver_supports_stepper, ["FOCUS_DRIVER_TYPE", "FOCUS_STEPPER_TYPE"])
 
+    # AVR boards can't have both DISPLAY_TYPE and INFO_DISPLAY_TYPE enabled
+    def avr_display_exclusivity(board, display, info_display):
+        if board not in AVR_BOARDS:
+            return True
+        return (
+                display == "DISPLAY_TYPE_NONE" or
+                info_display == "INFO_DISPLAY_TYPE_NONE"
+        )
+    problem.addConstraint(avr_display_exclusivity, ["BOARD", "DISPLAY_TYPE", "INFO_DISPLAY_TYPE"])
+
+    # MKS GenL boards must not have a focus stepper when info display is enabled
+    def mksgenl_focus_exclusivity(board, info_display, focus_stepper):
+        if board not in MKS_GENL_BOARDS:
+            return True
+        if info_display != "INFO_DISPLAY_TYPE_NONE":
+            return focus_stepper == "STEPPER_TYPE_NONE"
+        return True
+    problem.addConstraint(mksgenl_focus_exclusivity, ["BOARD", "INFO_DISPLAY_TYPE", "FOCUS_STEPPER_TYPE"])
+
 
 # Define constraints for excluded tests
 def set_test_constraints(problem):
@@ -266,6 +295,14 @@ def set_test_constraints(problem):
 def set_ci_constraints(problem):
     problem.addConstraint(InSetConstraint({"DISPLAY_TYPE_NONE", "DISPLAY_TYPE_LCD_KEYPAD"}), ["DISPLAY_TYPE"])
     # problem.addConstraint(InSetConstraint({"DRIVER_TYPE_ULN2003"}), ["ALT_DRIVER_TYPE"])
+
+    # Restrict INFO_DISPLAY_TYPE_I2C_SSD1306_128x64 to mksgenlv21 and esp32 only
+    # (just to reduce compile times)
+    def info_display_constraint(board, info_display):
+        if info_display == "INFO_DISPLAY_TYPE_I2C_SSD1306_128x64":
+            return board in ["mksgenlv21", "esp32"]
+        return True
+    problem.addConstraint(info_display_constraint, ["BOARD", "INFO_DISPLAY_TYPE"])
 
 
 def print_solutions_matrix(solutions, short_strings=False):

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ lib_deps =
 	arduino-libraries/LiquidCrystal @ ^1.0.7
 	lincomatic/LiquidTWI2@^1.2.7
 	olikraus/U8g2@^2.28.8
-	https://github.com/ClutchplateDude/esp8266-oled-ssd1306#4.6.0
+	https://github.com/ClutchplateDude/esp8266-oled-ssd1306#4.6.2
 
 [env]
 extra_scripts =

--- a/src/SSD1306_128x64_Display.hpp
+++ b/src/SSD1306_128x64_Display.hpp
@@ -6,6 +6,17 @@
 #include "Mount.hpp"
 #include "InfoDisplayRender.hpp"
 
+#if defined(ESP32)
+    /*
+     * ESP32 PROGMEM is fake, and its pgm_read_byte macro makes a useless cast
+     * which errors out with Werror=useless-cast, which can't be suppressed by
+     * our PUSH/POP_NO_WARNINGS because the macro expands in OUR code, not their
+     * header :/
+     */
+    #undef pgm_read_byte
+    #define pgm_read_byte(addr) (*(addr))
+#endif
+
 const float sineSize              = 18.0;
 const uint8_t sineTable[] PROGMEM = {0, 22, 44, 66, 87, 108, 128, 146, 164, 180, 195, 209, 221, 231, 240, 246, 251, 254, 255, 255};
 


### PR DESCRIPTION
Fixes #262 

- Updated CI to build with `INFO_DISPLAY_TYPE`, but only for `mksgenlv21` and `esp32`
  - Needed to add in some more constraints based on the firmware:
  - AVR-based boards can only have `DISPLAY_TYPE` OR `INFO_DISPLAY_TYPE`, not both
  - MKS Gen L-based boards can't have `INFO_DISPLAY_TYPE` and a focus motor (from their pin configuration)
- Fix the `https://github.com/ClutchplateDude/esp8266-oled-ssd1306#4.6.0` tag specifier, because the `4.6.0` tag is before @ClutchplateDude fixed the library. `4.6.2` tag is now correct.
- Apparently the `esp32` build with `INFO_DISPLAY_TYPE_I2C_SSD1306_128x64` was just broken? `pgm_read_byte()` on `esp32` (which is just a pointer cast because `esp32` doesn't actually have `PROGMEM`) does a useless cast which fails with our warning flags