### PR TITLE
Add conditional definition for SW_SERIAL_UART

### DIFF
--- a/boards/RAMPS/pins_RAMPS.hpp
+++ b/boards/RAMPS/pins_RAMPS.hpp
@@ -51,7 +51,9 @@
     #define DEC_DRIVER_ADDRESS 0b00
 #endif
 
-#define SW_SERIAL_UART 1
+#ifndef SW_SERIAL_UART
+    #define SW_SERIAL_UART 1
+#endif
 
 // DRIVER_TYPE_TMC2209_UART requires 4 digital pins in Arduino pin numbering
 #ifndef AZ_STEP_PIN


### PR DESCRIPTION
Define SW_SERIAL_UART if not already defined.
Avoid warnings when configuring ramps board to use Serial3 for TMC2209 drivers in UART mode in Configuration_local.hpp
```c++
#define SW_SERIAL_UART 0
#define RA_SERIAL_PORT Serial3
#define RA_DRIVER_ADDRESS 0b00
#define DEC_SERIAL_PORT Serial3
#define DEC_DRIVER_ADDRESS 0b01
```