### PR TITLE
build: Update avr-interrupt-stepper library version to 0.0.5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -97,7 +97,7 @@ debug_build_flags =
 lib_deps = 
 	${common.lib_deps}
 	jdolinay/avr-debugger @ 1.2
-	https://github.com/andre-stefanov/avr-interrupt-stepper#0.0.4
+	https://github.com/andre-stefanov/avr-interrupt-stepper#0.0.5
 
 [env:mksgenlv21]
 extends = env:ramps


### PR DESCRIPTION
This pull request updates a library dependency version in the `platformio.ini` configuration file. The change ensures that the project uses the latest features and fixes from the `avr-interrupt-stepper` library.

Dependency update:

* Updated the `avr-interrupt-stepper` library from version `0.0.4` to `0.0.5` in the `debug_build_flags` section of `platformio.ini`.