### PR TITLE
ci: remove PR title lint job from CI workflow and create separate workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,6 @@ on:
       - '*'
 
 jobs:
-  pr-title-lint:
-    name: PR Title (Conventional Commits)
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - reopened
+    branches:
+      - 'develop'
 
 jobs:
   pr-title-lint:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,19 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  pr-title-lint:
+    name: PR Title (Conventional Commits)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow for pull request title linting. The job responsible for checking PR titles against the Conventional Commits standard has been moved from the main CI workflow to its own dedicated workflow file.

Workflow restructuring:

* Removed the `pr-title-lint` job from `.github/workflows/ci.yml` to keep the main CI workflow focused on testing and simplify maintenance.
* Created a new workflow file `.github/workflows/pr-title-lint.yml` that triggers on pull request events (opened, edited, reopened) and runs the PR title linting job using the `amannn/action-semantic-pull-request` action.