### PR TITLE
Fixes and improvements for ESP32 in AP mode:

### DIFF
--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -109,13 +109,21 @@ String WifiControl::getStatus()
         result += "Infra-Fail-To-AP,";
     }
 
-    result += wifiStatus(WiFi.status()) + ",";
+    if(WIFI_MODE != WIFI_MODE_AP_ONLY)
+    {
+        result += wifiStatus(WiFi.status()) + ",";
+    }
     #if defined(ESP32)
     result += WiFi.getHostname();
+    result += ",";
     #endif
 
-    result += "," + getIP() + ":" + WIFI_PORT;
-    result += "," + String(WIFI_INFRASTRUCTURE_MODE_SSID) + "," + String(WIFI_HOSTNAME);
+    result += getIP() + ":" + WIFI_PORT + ",";
+    if (WIFI_MODE != WIFI_MODE_AP_ONLY)
+    {
+        result += String(WIFI_INFRASTRUCTURE_MODE_SSID) + ",";
+    }
+    result += String(WIFI_HOSTNAME);
 
     return result;
 }
@@ -129,7 +137,7 @@ void WifiControl::establishServers()
 
     delete _udp;
     _udp = new WiFiUDP();
-    _udp->begin(4031);
+    _udp->begin(WIFI_UDP_DISCOVERY_PORT);
 }
 
 String WifiControl::getIP()
@@ -161,12 +169,11 @@ void WifiControl::loop()
                     WiFi.localIP().toString().c_str(),
                     WIFI_PORT);
             }
-
-            if (_status != WL_CONNECTED)
-            {
-                infraToAPFailover();
-                return;
-            }
+        }
+        if (_status != WL_CONNECTED)
+        {
+            infraToAPFailover();
+            return;
         }
     }
 
@@ -263,7 +270,7 @@ void WifiControl::udpLoop()
         incomingPacket[lookingFor.length()] = 0;
         if (lookingFor.equalsIgnoreCase(incomingPacket))
         {
-            _udp->beginPacket(_udp->remoteIP(), 4031);
+            _udp->beginPacket(_udp->remoteIP(), WIFI_UDP_DISCOVERY_PORT);
             /*unsigned char bytes[255];
             reply.getBytes(bytes, 255);
             _udp->write(bytes, reply.length());*/

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -61,8 +61,11 @@ void WifiControl::startAccessPointMode()
     WiFi.setHostname(WIFI_HOSTNAME);
     #endif
 
-    WiFi.softAP(WIFI_HOSTNAME, WIFI_AP_MODE_WPAKEY);
+    WiFi.mode(WIFI_AP);
     WiFi.softAPConfig(local_ip, gateway, subnet);
+    WiFi.softAP(WIFI_HOSTNAME, WIFI_AP_MODE_WPAKEY);
+
+    establishServers();
 }
 
 String wifiStatus(int status)
@@ -111,10 +114,29 @@ String WifiControl::getStatus()
     result += WiFi.getHostname();
     #endif
 
-    result += "," + WiFi.localIP().toString() + ":" + WIFI_PORT;
+    result += "," + getIP() + ":" + WIFI_PORT;
     result += "," + String(WIFI_INFRASTRUCTURE_MODE_SSID) + "," + String(WIFI_HOSTNAME);
 
     return result;
+}
+
+void WifiControl::establishServers()
+{
+    delete _tcpServer;
+    _tcpServer = new WiFiServer(WIFI_PORT);
+    _tcpServer->begin();
+    _tcpServer->setNoDelay(true);
+
+    delete _udp;
+    _udp = new WiFiUDP();
+    _udp->begin(4031);
+}
+
+String WifiControl::getIP()
+{
+    return WIFI_MODE == WIFI_MODE_DISABLED  ? "NONE"
+           : WIFI_MODE == WIFI_MODE_AP_ONLY ? WiFi.softAPIP().toString()
+                                            : WiFi.localIP().toString();
 }
 
 void WifiControl::loop()
@@ -123,36 +145,32 @@ void WifiControl::loop()
     {
         return;
     }
-    if (_status != WiFi.status())
+
+    if (WIFI_MODE != WIFI_MODE_AP_ONLY)
     {
-        _status = WiFi.status();
-        LOG(DEBUG_WIFI, "[WIFI]: Connected status changed to %s", wifiStatus(_status).c_str());
-        if (_status == WL_CONNECTED)
+        if (_status != WiFi.status())
         {
-            delete _tcpServer;
-            _tcpServer = new WiFiServer(WIFI_PORT);
-            _tcpServer->begin();
-            _tcpServer->setNoDelay(true);
+            _status = WiFi.status();
+            LOG(DEBUG_WIFI, "[WIFI]: Connected status changed to %s", wifiStatus(_status).c_str());
+            if (_status == WL_CONNECTED)
+            {
+                establishServers();
+                LOG(DEBUG_WIFI,
+                    "[WIFI]: Connecting to SSID %s at %s:%d",
+                    WIFI_INFRASTRUCTURE_MODE_SSID,
+                    WiFi.localIP().toString().c_str(),
+                    WIFI_PORT);
+            }
 
-            delete _udp;
-            _udp = new WiFiUDP();
-            _udp->begin(4031);
-
-            LOG(DEBUG_WIFI,
-                "[WIFI]: Connecting to SSID %s at %s:%d",
-                WIFI_INFRASTRUCTURE_MODE_SSID,
-                WiFi.localIP().toString().c_str(),
-                WIFI_PORT);
+            if (_status != WL_CONNECTED)
+            {
+                infraToAPFailover();
+                return;
+            }
         }
     }
 
     _mount->loop();
-
-    if (_status != WL_CONNECTED)
-    {
-        infraToAPFailover();
-        return;
-    }
 
     tcpLoop();
     udpLoop();
@@ -172,49 +190,58 @@ void WifiControl::infraToAPFailover()
 
 void WifiControl::tcpLoop()
 {
-    if (client && client.connected())
-    {
-        while (client.available())
-        {
-            LOG(DEBUG_WIFI, "[WIFITCP]: Available bytes %d. Peeking.", client.available());
+    if (!_tcpServer)
+        return;
 
-            // Peek first byte and check for ACK (0x06) handshake
-            LOG(DEBUG_WIFI, "[WIFITCP]: First byte is %x", client.peek());
-            if (client.peek() == 0x06)
+    if (!client.connected())
+    {
+        client = _tcpServer->accept();
+        if (!client.connected())
+            return;
+    }
+
+    int peek;
+    int avail;
+    while ((avail = client.available()) != 0)
+    {
+        LOG(DEBUG_WIFI, "[WIFITCP]: Available bytes %d. Peeking.", avail);
+
+        // Peek first byte and check for ACK (0x06) handshake
+        peek = client.peek();
+        LOG(DEBUG_WIFI, "[WIFITCP]: First byte is %x", peek);
+        if (peek == 0x06)
+        {
+            client.read();
+            LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
+            client.write("P");
+            LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> P (polar mode)");
+        }
+        else
+        {
+            String cmd = client.readStringUntil('#');
+            LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- %s#", cmd.c_str());
+            const char *retVal = _cmdProcessor->processCommand(cmd);
+
+            if (retVal[0] != '\0')
             {
-                client.read();
-                LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
-                client.write("P");
-                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> P (polar mode)");
+                client.write(retVal);
+                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> %s", retVal);
             }
             else
             {
-                String cmd = client.readStringUntil('#');
-                LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- %s#", cmd.c_str());
-                const char *retVal = _cmdProcessor->processCommand(cmd);
-
-                if (retVal[0] != '\0')
-                {
-                    client.write(retVal);
-                    LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> %s", retVal);
-                }
-                else
-                {
-                    LOG(DEBUG_WIFI, "[WIFITCP]: No Reply");
-                }
+                LOG(DEBUG_WIFI, "[WIFITCP]: No Reply");
             }
-
-            _mount->loop();
         }
-    }
-    else
-    {
-        client = _tcpServer->available();
+
+        _mount->loop();
     }
 }
 
 void WifiControl::udpLoop()
 {
+    if (!_udp)
+        return;
+
     int packetSize = _udp->parsePacket();
     if (packetSize)
     {
@@ -222,7 +249,7 @@ void WifiControl::udpLoop()
         String reply      = "skyfi:";
         reply += WIFI_HOSTNAME;
         reply += "@";
-        reply += WiFi.localIP().toString();
+        reply += getIP();
         LOG(DEBUG_WIFI,
             "[WIFIUDP]: Received %d bytes from %s, port %d",
             packetSize,

--- a/src/WifiControl.cpp
+++ b/src/WifiControl.cpp
@@ -10,6 +10,7 @@ WifiControl::WifiControl(Mount *mount, LcdMenu *lcdMenu)
 {
     _mount   = mount;
     _lcdMenu = lcdMenu;
+    clearCmd();
 }
 
 void WifiControl::setup()
@@ -63,7 +64,11 @@ void WifiControl::startAccessPointMode()
 
     WiFi.mode(WIFI_AP);
     WiFi.softAPConfig(local_ip, gateway, subnet);
-    WiFi.softAP(WIFI_HOSTNAME, WIFI_AP_MODE_WPAKEY);
+    if (!WiFi.softAP(WIFI_HOSTNAME, WIFI_AP_MODE_WPAKEY))
+    {
+        LOG(DEBUG_WIFI, "[WIFI]: AP mode could not be started!");
+        return;
+    }
 
     establishServers();
 }
@@ -109,7 +114,7 @@ String WifiControl::getStatus()
         result += "Infra-Fail-To-AP,";
     }
 
-    if(WIFI_MODE != WIFI_MODE_AP_ONLY)
+    if (WIFI_MODE != WIFI_MODE_AP_ONLY)
     {
         result += wifiStatus(WiFi.status()) + ",";
     }
@@ -145,6 +150,12 @@ String WifiControl::getIP()
     return WIFI_MODE == WIFI_MODE_DISABLED  ? "NONE"
            : WIFI_MODE == WIFI_MODE_AP_ONLY ? WiFi.softAPIP().toString()
                                             : WiFi.localIP().toString();
+}
+
+void WifiControl::clearCmd()
+{
+    _currCmd = "";
+    _currCmd.reserve(_defaultCapacity);
 }
 
 void WifiControl::loop()
@@ -202,45 +213,71 @@ void WifiControl::tcpLoop()
 
     if (!client.connected())
     {
+        if (_currCmd.length() != 0)
+        {
+            clearCmd();
+        }
         client = _tcpServer->accept();
         if (!client.connected())
             return;
     }
 
-    int peek;
     int avail;
     while ((avail = client.available()) != 0)
     {
         LOG(DEBUG_WIFI, "[WIFITCP]: Available bytes %d. Peeking.", avail);
 
         // Peek first byte and check for ACK (0x06) handshake
-        peek = client.peek();
-        LOG(DEBUG_WIFI, "[WIFITCP]: First byte is %x", peek);
-        if (peek == 0x06)
+        if (_currCmd.length() == 0)
         {
-            client.read();
-            LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
-            client.write("P");
-            LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> P (polar mode)");
-        }
-        else
-        {
-            String cmd = client.readStringUntil('#');
-            LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- %s#", cmd.c_str());
-            const char *retVal = _cmdProcessor->processCommand(cmd);
-
-            if (retVal[0] != '\0')
+            int peek = client.peek();
+            LOG(DEBUG_WIFI, "[WIFITCP]: First byte is %x", peek);
+            if (peek == 0x06)
             {
-                client.write(retVal);
-                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> %s", retVal);
-            }
-            else
-            {
-                LOG(DEBUG_WIFI, "[WIFITCP]: No Reply");
+                client.read();
+                LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- Handshake request");
+                client.write("P");
+                LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> P (polar mode)");
+                _mount->loop();
             }
         }
 
-        _mount->loop();
+        int recv;
+        while ((recv = client.read()) != -1)
+        {
+            // Prevent newlines from polluting the command string
+            if (recv == '\n' || recv == '\r')
+            {
+                _mount->loop();
+                continue;
+            }
+
+            _currCmd += (char) recv;
+            if (recv == '#')
+            {
+                LOG(DEBUG_WIFI, "[WIFITCP]: Query <-- %s", _currCmd.c_str());
+                const char *retVal = _cmdProcessor->processCommand(_currCmd);
+
+                if (retVal[0] != '\0')
+                {
+                    client.write(retVal);
+                    LOG(DEBUG_WIFI, "[WIFITCP]: Reply --> %s", retVal);
+                }
+                else
+                {
+                    LOG(DEBUG_WIFI, "[WIFITCP]: No Reply");
+                }
+                clearCmd();
+            }
+
+            // Prevent memory overconsumption
+            if (_currCmd.length() == _maxCapacity)
+            {
+                LOG(DEBUG_WIFI, "[WIFITCP]: Command string reached maximum capacity --> clear");
+                clearCmd();
+            }
+            _mount->loop();
+        }
     }
 }
 

--- a/src/WifiControl.hpp
+++ b/src/WifiControl.hpp
@@ -29,7 +29,9 @@ class WifiControl
     void infraToAPFailover();
     void tcpLoop();
     void udpLoop();
-    wl_status_t _status;
+    void establishServers();
+    String getIP();
+    wl_status_t _status = WL_DISCONNECTED;
     Mount *_mount;
     LcdMenu *_lcdMenu;
     MeadeCommandProcessor *_cmdProcessor;

--- a/src/WifiControl.hpp
+++ b/src/WifiControl.hpp
@@ -32,6 +32,7 @@ class WifiControl
     void tcpLoop();
     void udpLoop();
     void establishServers();
+    void clearCmd();
     String getIP();
     wl_status_t _status = WL_DISCONNECTED;
     Mount *_mount;
@@ -41,9 +42,12 @@ class WifiControl
     WiFiServer *_tcpServer = nullptr;
     WiFiUDP *_udp          = nullptr;
     WiFiClient client;
+    String _currCmd;
 
     unsigned long _infraStart = 0;
     unsigned long _infraWait  = 30000;  // 30 second timeout for
+    static constexpr size_t _defaultCapacity = 32;
+    static constexpr size_t _maxCapacity = 128;
 };
 
 extern WifiControl wifiControl;

--- a/src/WifiControl.hpp
+++ b/src/WifiControl.hpp
@@ -10,6 +10,8 @@
         #include <WiFiSTA.h>
     #endif
 
+#define WIFI_UDP_DISCOVERY_PORT 4031
+
 // Forward declarations
 class Mount;
 class LcdMenu;


### PR DESCRIPTION
- Now correctly reports the device's IP in AP mode for UDP discovery requests. Previously reported as 0.0.0.0.
- Split logic between AP mode and Infra modes since WiFi.status() returns a meaningless value in AP mode. AP mode now immediately establishes TCP/UDP servers. Server establishment moved to own function.
- Also adds null-pointer guards to tcp/udp loop while servers are not established yet. Not relevant for AP mode, but included here due to simplicity.

Tested on ESP32 in WIFI_MODE_AP_ONLY. This PR does NOT address the infrastructure modes or the WIFI_MODE_ATTEMPT_INFRASTRUCTURE_FAIL_TO_AP mode in particular, which has some issues in the failover trigger. Local changes are ready and can be included in future PRs if desired.