### PR TITLE
fix: Increase MeadeResponse capacity from 64 to 128

### DIFF
--- a/src/core/meade/MeadeParser.hpp
+++ b/src/core/meade/MeadeParser.hpp
@@ -39,7 +39,7 @@ namespace meade
 class MeadeResponse
 {
   public:
-    static constexpr size_t Capacity = 64;
+    static constexpr size_t Capacity = 128;
 
     MeadeResponse() : _length(0)
     {


### PR DESCRIPTION
double character length to enable connection to OAT Control using MKS board, original response to short causing failure to conect.